### PR TITLE
Refactor code to only use a `triton_kernel_call` primitive

### DIFF
--- a/jax_triton/__init__.py
+++ b/jax_triton/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from jax_triton.triton_call import triton_call
+from jax_triton.triton_call import triton_call, triton_kernel_call

--- a/jax_triton/triton_call.py
+++ b/jax_triton/triton_call.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import os
+import functools
 import pickle
 
-from typing import Any, Callable, Optional, Tuple, Union
-from types import SimpleNamespace
+from typing import Any, Optional
 
 import jax
 import jax.dlpack
@@ -24,23 +24,31 @@ from jax import core
 import jax.numpy as jnp
 from jax.lib import xla_client as xc
 from jax.interpreters import mlir
+from jax.interpreters import xla
 from jax import tree_util
 from jax._src import util
 from jax._src.lib import xla_bridge as xb
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import mhlo
 import numpy as np
-import torch
-import triton
-import triton.language as tl
 
-from jax_triton import triton_kernel_call
+CAN_USE_TRITON = False
+try:
+  import triton
+  import triton.language as tl
+  del triton
+  CAN_USE_TRITON = True
+except ModuleNotFoundError:
+  pass
+
+from jax_triton import triton_kernel_call as triton_kernel_call_lib
 
 os.environ["TRITON_CACHE_DIR"] = ""
 map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip
 
-xc.register_custom_call_target("triton_kernel_call", triton_kernel_call.get_custom_call(), platform="CUDA")
+xc.register_custom_call_target(
+    "triton_kernel_call",triton_kernel_call_lib.get_custom_call(), platform="CUDA")
 
 def get_triton_type(obj: Any) -> str:
     type_map = {
@@ -51,92 +59,59 @@ def get_triton_type(obj: Any) -> str:
         jnp.dtype("int64"): "i64",
     }
     if isinstance(obj, jax.core.ShapedArray):
-        return type_map[obj.dtype]
+      return type_map[obj.dtype]
     if isinstance(obj, tl.constexpr):
-        obj = obj.value
+      obj = obj.value
     if isinstance(obj, int):
-        if -2**31 <= obj < 2**31:
-            return 'i32'
-        elif 2**31 <= obj < 2**32:
-            return 'u32'
-        elif -2**63 <= obj < 2**63:
-            return 'i64'
-        elif 2**63 <= obj < 2**64:
-            return 'u64'
-        else:
-            raise ValueError(f'integer overflow representing {obj}')
+      if -2**31 <= obj < 2**31:
+        return 'i32'
+      elif 2**31 <= obj < 2**32:
+        return 'u32'
+      elif -2**63 <= obj < 2**63:
+        return 'i64'
+      elif 2**63 <= obj < 2**64:
+        return 'u64'
+      else:
+        raise ValueError(f'integer overflow representing {obj}')
     if isinstance(obj, float):
-        return 'f'
+      return 'f'
     if isinstance(obj, bool):
-        return 'B'
+      return 'B'
     if isinstance(obj, str):
-        return 'str'
+      return 'str'
     raise NotImplementedError(f'could not compute type name for {obj}')
     
 def get_triton_python_ir(aval):
-    if aval.shape == ():
-        return "scalar", get_triton_type(aval)
-    return "ptr", get_triton_type(aval)
-
-def compile(triton_function, constants, *, key, device=0, num_warps=4, num_stages=2):
-    def lower(*args):
-        triton_function._warmup(arg_types=arg_types, device=device,
-            attributes=attributes, constants=constants, num_warps=num_warps,
-            num_stages=num_stages, key=key, is_manual_warmup=True,
-            extern_libs={})
-    return lower
-
-def j2t(x_jax):
-  x_torch = torch.utils.dlpack.from_dlpack(jax.dlpack.to_dlpack(x_jax))
-  return x_torch
-
-def t2j(x_torch):
-  x_torch = x_torch.contiguous()  # https://github.com/google/jax/issues/8082
-  x_jax = jax.dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(x_torch))
-  return x_jax
+  if aval.shape == ():
+    return "scalar", get_triton_type(aval)
+  return "ptr", get_triton_type(aval)
 
 Metaparameters = Any
 ShapeDtypeDuck = Any
 
-triton_call_p = jax.core.Primitive('triton_call')
-triton_call_p.multiple_results = True
+triton_kernel_call_p = jax.core.Primitive('triton_kernel_call')
+triton_kernel_call_p.multiple_results =True
 
-def triton_call(*args, kernel, out_shape, grid, num_warps=4, num_stages=2, 
-                dump_binary_path: Optional[str] = None, **metaparams):
-  flat_out_shapes, out_tree = tree_util.tree_flatten(out_shape)
-  out_flat = triton_call_p.bind(*args, kernel=kernel, out_shapes=flat_out_shapes,
-      grid=grid, num_warps=num_warps, num_stages=num_stages, 
-      dump_binary_path=dump_binary_path, **metaparams)
-  return tree_util.tree_unflatten(out_tree, out_flat)
+triton_kernel_call_p.def_impl(
+    functools.partial(xla.apply_primitive, triton_kernel_call_p))
 
-table = {'float32': torch.float32, 'int32': torch.int32, 'float16': torch.float16,
-         'float64': torch.float64, 'int64': torch.int64 }
-
-@triton_call_p.def_impl
-def triton_call_impl(*args, kernel, out_shapes, grid, dump_binary_path, **metaparams):
-  del dump_binary_path
-  args_torch = [j2t(x) for x in args]
-  outputs_torch = [torch.empty(out_shape.shape, dtype=table[out_shape.dtype.name],
-                   device=torch.device('cuda:0')) for out_shape in out_shapes]
-  kernel[grid](*args_torch, *outputs_torch, **metaparams)
-  return map(t2j, outputs_torch)
-
-@triton_call_p.def_abstract_eval
-def triton_call_abstract_eval(*_, out_shapes, **__):
+@triton_kernel_call_p.def_abstract_eval
+def triton_kernel_call_abstract_eval(*_, out_shapes, **__):
   return [core.ShapedArray(out_shape.shape, out_shape.dtype) for out_shape in out_shapes]
-
-def avals_to_layouts(avals):
-  return ir.ArrayAttr.get([aval_to_layout(a) for a in avals])
 
 def aval_to_layout(aval):
   arange = np.arange(aval.ndim, dtype='int64')[::-1].copy()
   return ir.DenseIntElementsAttr.get(arange, type=ir.IndexType.get())
 
-def emit_triton_call(ctx, triton_func, grid, num_warps, num_stages,
-                     dump_binary_path: Optional[str], **metaparams):
+def avals_to_layouts(avals):
+  return ir.ArrayAttr.get([aval_to_layout(a) for a in avals])
+
+def compile_triton_func(
+    avals_in, avals_out, triton_func, num_warps, num_stages, metaparams):
   metadata = {triton_func.arg_names.index(k) : v for k, v in metaparams.items()}
-  all_args = [*ctx.avals_in, *ctx.avals_out]
+  all_args = [*avals_in, *avals_out]
   arg_types = [get_triton_python_ir(a) for a in all_args]
+  # Assume every input is a pointer (no dynamic shape info)
   attributes = {i: 16 for i in range(len(all_args))}
   # TODO(sharadmv): handle multiple devices, right now we assume device 0 which
   # is fine when we have multiple of the same GPU but this won't work in
@@ -145,6 +120,10 @@ def emit_triton_call(ctx, triton_func, grid, num_warps, num_stages,
       attributes=attributes, constants=metadata, num_warps=num_warps,
       num_stages=num_stages, extern_libs={})
   name, asm, shared_mem = binary.name, binary.asm, binary.shared_mem
+  return name, asm, shared_mem
+
+def emit_triton_kernel_call(ctx, name, asm, shared_mem, *, dump_binary_path:
+    Optional[str], grid, metaparams, num_warps):
   if dump_binary_path is not None:
     binary = dict(
         asm=asm,
@@ -164,19 +143,20 @@ def emit_triton_call(ctx, triton_func, grid, num_warps, num_stages,
   else:
     assert False
   arity = len(ctx.avals_in) + len(ctx.avals_out)
-  descriptor, keepalive = triton_kernel_call.make_triton_call_descriptor(
+  descriptor, keepalive = triton_kernel_call_lib.make_triton_call_descriptor(
       name, asm, shared_mem, grid_0, grid_1, grid_2, num_warps, arity)
   return descriptor, keepalive
 
-def triton_call_lowering(ctx, *args, kernel, out_shapes, grid, num_warps=4, num_stages=2,
-                         dump_binary_path: Optional[str], **metaparams):
+def triton_kernel_call_lowering(ctx, *args, name, asm, shared_mem,
+                                out_shapes, grid, num_warps, num_stages,
+                                dump_binary_path: Optional[str], **metaparams):
   out_type = ir.TupleType.get_tuple([
       ir.RankedTensorType.get(out_shape.shape, mlir.dtype_to_ir_type(out_shape.dtype))
       for out_shape in out_shapes])
   i32_type = ir.IntegerType.get_signless(32)
-  descriptor, keepalive = emit_triton_call(ctx, kernel, grid,
-                                           num_warps, num_stages, dump_binary_path,
-                                           **metaparams)
+  descriptor, keepalive = emit_triton_kernel_call(
+      ctx, name, asm.asm_map, shared_mem, dump_binary_path=dump_binary_path,
+      num_warps=num_warps, grid=grid, metaparams=metaparams)
   ctx.module_context.add_keepalive(keepalive)
   out = mhlo.CustomCallOp(
             [out_type], args,
@@ -190,4 +170,44 @@ def triton_call_lowering(ctx, *args, kernel, out_shapes, grid, num_warps=4, num_
   results = [mhlo.GetTupleElementOp(out, mlir.i32_attr(i)).result
              for i in range(len(out_shapes))]
   return results
-mlir.register_lowering(triton_call_p, triton_call_lowering)
+mlir.register_lowering(triton_kernel_call_p, triton_kernel_call_lowering)
+
+class Asm:
+  """Hides the huge ASM dict from showing up in Jaxprs."""
+  def __init__(self, asm_map):
+    self.asm_map = asm_map
+
+def triton_call(*args, kernel, out_shape, grid, num_warps=4, num_stages=2,
+                dump_binary_path: Optional[str] = None, **metaparams):
+  if not CAN_USE_TRITON:
+    raise ValueError("`triton_call` is only available when `triton` is installed.")
+  out_shape = tree_util.tree_map(
+      lambda a: jax.ShapeDtypeStruct(a.shape, a.dtype), out_shape)
+  flat_args, in_tree = tree_util.tree_flatten(args)
+  del in_tree
+  # TODO(sharadmv): check that in_tree is flat (no Pytrees allowed in triton_call)
+  flat_out_shapes, out_tree = tree_util.tree_flatten(out_shape)
+  avals_in = [core.raise_to_shaped(core.get_aval(a)) for a in flat_args]
+  avals_out = [core.ShapedArray(a.shape, a.dtype) for a in flat_out_shapes]
+  name, asm_map, shared_mem = compile_triton_func(
+    avals_in, avals_out, kernel, num_warps, num_stages, metaparams)
+  asm = Asm(asm_map)
+  out_flat = triton_kernel_call_p.bind(*flat_args, name=name, asm=asm,
+      shared_mem=shared_mem, out_shapes=tuple(flat_out_shapes),
+      grid=grid, num_warps=num_warps, num_stages=num_stages,
+      dump_binary_path=dump_binary_path, **metaparams)
+  return tree_util.tree_unflatten(out_tree, out_flat)
+
+def triton_kernel_call(*args, name, asm, shared_mem, out_shape,
+                       grid, num_warps=4, num_stages=2, **metaparams):
+  out_shape = tree_util.tree_map(
+      lambda a: jax.ShapeDtypeStruct(a.shape, a.dtype), out_shape)
+  flat_args, in_tree = tree_util.tree_flatten(args)
+  del in_tree
+  # TODO(sharadmv): check that in_tree is flat (no Pytrees allowed in triton_call)
+  flat_out_shapes, out_tree = tree_util.tree_flatten(out_shape)
+  out_flat = triton_kernel_call_p.bind(*flat_args, name=name, asm=Asm(asm),
+      shared_mem=shared_mem, out_shapes=tuple(flat_out_shapes),
+      grid=grid, num_warps=num_warps, num_stages=num_stages,
+      dump_binary_path=None, **metaparams)
+  return tree_util.tree_unflatten(out_tree, out_flat)


### PR DESCRIPTION
This makes it easier to use w/o actually having `triton` and `torch`. We can dump compiled kernels when we have `triton` installed and then load them when we don't.