### PR TITLE
Add pallas, a jaxpr "dialect" that lowers directly to Triton IR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__
+build/
+*.egg-info
+*.so

--- a/examples/add.py
+++ b/examples/add.py
@@ -37,7 +37,6 @@ def add_kernel(
   output = x + y
   tl.store(output_ptr + offsets, output, mask=mask)
 
-
 def add(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
   out_shape = jax.ShapeDtypeStruct(shape=x.shape, dtype=x.dtype)
   block_size = 8

--- a/examples/fusion/benchmark_matmul.py
+++ b/examples/fusion/benchmark_matmul.py
@@ -1,0 +1,74 @@
+# Copyright 2022 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import rich.console
+import rich.table
+import timeit
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+from jax import random
+
+from jax_triton.experimental import fusion as ji
+
+leaky_relu = lambda x: jnp.where(x >= 0., x, 0.01 * x)
+
+def dense_activation(act, x, w, b):
+  return act(jnp.matmul(x, w) + b)
+
+dense = functools.partial(dense_activation, lambda x: x)
+dense_leaky_relu = functools.partial(dense_activation, leaky_relu)
+dense_gelu = functools.partial(dense_activation, jax.nn.gelu)
+
+FUNCTIONS = [
+    ("jax-inductor", "none", ji.jit(dense)),
+    ("jax-inductor", "leaky_relu", ji.jit(dense_leaky_relu)),
+    ("jax-inductor", "gelu", ji.jit(dense_gelu)),
+    ("XLA", "none", jax.jit(dense)),
+    ("XLA", "leaky_relu", jax.jit(dense_leaky_relu)),
+    ("XLA", "gelu", jax.jit(dense_gelu)),
+    ]
+
+SIZES = [
+    (256, 128),
+    (512, 256),
+    (1024, 512),
+    (2048, 1024),
+    ]
+
+n_trials = 20000
+
+if __name__ == "__main__":
+  console = rich.console.Console()
+  for b, d in SIZES:
+    table = rich.table.Table(title=f"({b}, {d}) x ({d}, {d})", )
+    table.add_column("Codegen")
+    table.add_column("Activation")
+    table.add_column("Average time (ms)")
+
+    k1, k2, k3 = random.split(random.PRNGKey(0), 3)
+    x = random.normal(k1, (b, d), dtype=jnp.float16).block_until_ready()
+    w = random.normal(k2, (d, d), dtype=jnp.float16).block_until_ready()
+    b = random.normal(k3, (d,), dtype=jnp.float16).block_until_ready()
+
+    for func_name, act_name, func in FUNCTIONS:
+      for _ in range(10):
+        func(x, w, b).block_until_ready()
+      times = timeit.Timer(
+          lambda: func(x, w, b).block_until_ready()).repeat(
+              number=n_trials, repeat=5)
+      table.add_row(func_name, act_name, f"{np.min(times) / n_trials * 1000:.4}")
+    console.print(table)

--- a/examples/fusion/nn.py
+++ b/examples/fusion/nn.py
@@ -1,0 +1,71 @@
+# Copyright 2022 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax import random
+import timeit
+
+from jax_triton.experimental import fusion as ji
+
+dtype = jnp.float16
+
+def dense(features, weights, activation=jax.nn.gelu):
+  kernel, bias = weights
+  return activation(features.dot(kernel) + bias[None])
+
+def init_layer(key, in_size, out_size):
+  k1, k2 = random.split(key)
+  return (random.normal(k1, [in_size, out_size], dtype),
+          random.normal(k2, [out_size], dtype))
+
+batch_size = 4096
+hidden_size = 512
+input_size = 512
+
+n_layers = 4
+
+def apply(weights, x):
+  for weight in weights[:-1]:
+    x = dense(x, weight)
+  return dense(x, weights[-1], activation=lambda x: x)
+
+if __name__ == "__main__":
+  keys = random.split(random.PRNGKey(0), n_layers)
+  keys_iter = iter(keys)
+
+  weights = [
+      init_layer(next(keys_iter), input_size, hidden_size),
+      ] + [
+          init_layer(next(keys_iter), hidden_size, hidden_size)
+          for _ in range(n_layers - 1)
+      ]
+
+  mlp = functools.partial(apply, weights)
+
+  x = jnp.ones((batch_size, input_size), dtype=dtype)
+
+  xla_jit_net = jax.jit(mlp)
+  ji_jit_net = jax.jit(ji.jit(mlp, debug=True))
+
+  ji_jit_net(x).block_until_ready()
+  xla_jit_net(x).block_until_ready()
+
+  t = timeit.timeit(lambda: ji_jit_net(x).block_until_ready(), number=5000)
+  print(f"jax-inductor: {t:.4}ms")
+
+  t = timeit.timeit(lambda: xla_jit_net(x).block_until_ready(), number=5000)
+  print(f"XLA: {t:.4}ms")

--- a/examples/pallas/fused_attention.py
+++ b/examples/pallas/fused_attention.py
@@ -1,0 +1,160 @@
+import functools
+
+from typing import Optional
+
+import jax
+from jax import lax
+import jax.numpy as jnp
+from jax._src.lax.control_flow.for_loop import for_loop
+import jax_triton as jt
+
+from jax_triton import pallas as pl
+
+
+def mha_kernel(
+    q_ref, k_ref, v_ref,  # Input arrays
+    o_ref, tmp_ref, # Output arrays
+    *, sm_scale, block_q, block_d, block_k):
+  start_q = pl.program_id(0)
+  off_h = pl.program_id(1)  # int in [0, num_heads)
+  off_b = pl.program_id(2)  # int in [0, batch_size)
+
+   # Each thread block processes a block of block_q queries.
+  span_q = start_q * block_q + jnp.arange(block_q)
+  # Model dimension is read in one op. Model dimension must be power of 2.
+  span_d = jnp.arange(0, block_d)  # block_d == head_dim.
+
+  tmp_idxs = (
+      lax.broadcast_in_dim(off_b, (block_q,), ()),
+      lax.broadcast_in_dim(off_h, (block_q,), ()),
+      span_q)
+
+  # acc is the buffer where we accumulate the output on sram.
+  # m_i and l_i (see FlashAttention paper) are updated during the k,v loop.
+  m_i = jnp.zeros([block_q], dtype=jnp.float32) - float('inf')
+  l_i = jnp.zeros([block_q], dtype=jnp.float32)
+  # acc is the buffer where we accumulate the output on sram.
+  acc = jnp.zeros([block_q, block_d], dtype=jnp.float32)
+
+  # Load q: it will stay in L1 throughout. Indices form a matrix because we
+  # read, compute, and write all in 2d chunks. 1 element ~= 1 CUDA thread index.
+  # q tile has shape [block_q, block_d], block_d == head_dim.
+  q_idxs = (
+      lax.broadcast_in_dim(off_b, (block_q, block_d), ()),
+      lax.broadcast_in_dim(span_q, (block_q, block_d), (0,)),
+      lax.broadcast_in_dim(off_h, (block_q, block_d), ()),
+      lax.broadcast_in_dim(span_d, (block_q, block_d), (1,)))
+  q = q_ref[q_idxs]
+  # In FlashAttention algorithm 1 there are 2 loops: slow over tiles of kv (size
+  # (Bc == block_k here), and fast over blocks of q (size Br == block_q here).
+  # Here we only loop over blocks of kv to process entire seq_len, the loop over
+  # blocks of q is carried out by the grid.
+  def body(i, refs):
+    acc_ref, m_i_ref, l_i_ref = refs
+    acc, m_i, l_i = acc_ref[:], m_i_ref[:], l_i_ref[:]
+    start_k = pl.multiple_of(i * block_k, block_k)
+    span_k = start_k + jnp.arange(0, block_k)
+    k_idxs = (
+        lax.broadcast_in_dim(off_b, (block_k, block_d), ()),
+        lax.broadcast_in_dim(span_k, (block_k, block_d), (0,)),
+        lax.broadcast_in_dim(off_h, (block_k, block_d), ()),
+        lax.broadcast_in_dim(span_d, (block_k, block_d), (1,)))
+    k = k_ref[k_idxs]
+    p_ij = jnp.zeros([block_q, block_k], dtype=jnp.float32)
+    if sm_scale == 1.0:
+      p_ij += pl.dot(q, k, trans_b=True)   # [block_q, block_k]
+    else:
+      p_ij += sm_scale * pl.dot(q, k, trans_b=True)  # [block_q, block_k]
+    # Bring closer to XLA:GPU numerics.
+    p_ij = p_ij.astype(q_ref.dtype)
+    p_ij = p_ij.astype(jnp.float32)
+    # -- compute m_ij, p, l_ij
+    m_ij = jnp.max(p_ij, axis=1)  # Row max, shape [block_q].
+    p_ij = jnp.exp(p_ij - m_ij[:, None])  # Shape [block_q, block_k].
+    l_ij = jnp.sum(p_ij, axis=1)  # Shape [block_q].
+
+    # NOTE: Flash attention begins.
+    # -- update m_i and l_i
+    m_i_new = jnp.maximum(m_i, m_ij)  # Shape [block_q].
+    alpha = jnp.exp(m_i - m_i_new)  # Shape [block_q].
+    beta = jnp.exp(m_ij - m_i_new)  # Shape [block_q].
+    l_i_new = alpha * l_i + beta * l_ij  # Shape [block_q].
+    # -- update output accumulator --
+    # The two terms in the accumulation of o are processed separately.
+    p_scale = beta / l_i_new  # Shape [block_q].
+    p_ij = p_ij * p_scale[:, None]  # Shape [block_q].
+    # Update the scaling of the output buffer acc.
+    acc_scale = l_i / l_i_new * alpha  # Shape [block_q].
+    # Compiler bug! Use tmp real quck
+    tmp_ref[tmp_idxs] =  acc_scale
+    acc_scale = tmp_ref[tmp_idxs]
+
+    acc = acc * acc_scale[:, None]
+    l_i_ref[:] = l_i_new  # Update m_i and l_i for the next block_k.
+    m_i_ref[:] = m_i_new
+    # # NOTE: Flash attention ends.
+
+    # Add the new block of attention weights.
+    v = v_ref[k_idxs]
+    acc_ref[()] = acc + jnp.dot(p_ij.astype(q_ref.dtype), v)
+
+  acc, m_i, l_i = for_loop(seq_len // block_k, body, (acc, m_i, l_i))
+  start_q = pl.program_id(0)
+  span_q = start_q * block_q + jnp.arange(block_q)
+  # Write output to dram.
+  span_d = jnp.arange(block_d)
+  acc = acc.astype(o_ref.dtype)
+  o_idxs = (
+      lax.broadcast_in_dim(off_b, (block_q, block_d), ()),
+      lax.broadcast_in_dim(span_q, (block_q, block_d), (0,)),
+      lax.broadcast_in_dim(off_h, (block_q, block_d), ()),
+      lax.broadcast_in_dim(span_d, (block_q, block_d), (1,)))
+  o_ref[o_idxs] = acc
+
+def mha(q, k, v, *,
+        sm_scale: float = 1.0,
+        block_q: int = 128,
+        block_k: int = 128,
+        num_warps: Optional[int] = None,
+        num_stages: int = 1,
+        grid=None,
+        ):
+  batch_size, seq_len, num_heads, head_dim = q.shape
+  # Heuristics.
+  if grid is None:
+    grid = (jt.cdiv(seq_len, block_q), num_heads, batch_size)
+
+  if num_warps is None:
+    num_warps = 4 if head_dim <= 64 else 8
+  kernel = functools.partial(mha_kernel, sm_scale=sm_scale,
+                             block_q=block_q, block_k=block_k,
+                             block_d=head_dim)
+  out_shape = [
+      jax.ShapeDtypeStruct(shape=q.shape, dtype=q.dtype),
+      jax.ShapeDtypeStruct(shape=(batch_size, num_heads, seq_len),
+                           dtype=jnp.float32)
+  ]
+  out, _ = pl.pallas_call(kernel, num_warps=num_warps, num_stages=num_stages,
+                          grid=grid, out_shapes=out_shape, debug=True)(q, k, v)
+  return out
+
+@functools.partial(jax.jit, static_argnames=['sm_scale'])
+def mha_reference(q, k, v, sm_scale=1.0):
+  logits = jnp.einsum('bqhc,bkhc->bhqk', q, k).astype(jnp.float32)
+  weights = jax.nn.softmax(logits * sm_scale).astype(q.dtype)
+  return jnp.einsum('bhqk,bkhc->bqhc', weights, v)
+
+if __name__ == "__main__":
+  dtype = jnp.float16
+  batch, seq_len, n_heads, head_dim = 384, 384, 4, 32
+  shape = (batch, seq_len, n_heads, head_dim)
+
+  q_key, k_key, v_key = jax.random.split(jax.random.PRNGKey(0), 3)
+  q = jax.random.normal(q_key, shape, dtype=dtype)
+  k = jax.random.normal(k_key, shape, dtype=dtype)
+  v = jax.random.normal(v_key, shape, dtype=dtype)
+
+  o = mha(q, k, v)
+  o.block_until_ready()
+  o_ref = mha_reference(q, k, v)
+  print(o.block_until_ready())

--- a/jax_triton/__init__.py
+++ b/jax_triton/__init__.py
@@ -13,4 +13,8 @@
 # limitations under the License.
 
 """Library for JAX-Triton integrations."""
-from jax_triton.triton_call import triton_call, triton_kernel_call
+from jax_triton.triton_call import triton_call
+from jax_triton.triton_call import triton_kernel_call
+from jax_triton.triton_call import cdiv
+from jax_triton.triton_call import strides_from_shape
+from jax_triton import pallas

--- a/jax_triton/experimental/fusion/__init__.py
+++ b/jax_triton/experimental/fusion/__init__.py
@@ -12,23 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""setup.py for jax-triton."""
-import pybind11
-from setuptools import Extension
-from setuptools import find_packages
-from setuptools import setup
+"""Module for an experimental fusion library."""
+import jax
+sigmoid = jax.nn.sigmoid
+import oryx
+jax.nn.sigmoid = sigmoid
+del sigmoid, oryx, jax
 
-setup(
-    packages=find_packages(),
-    ext_modules=[
-        Extension(
-            name="jax_triton.triton_kernel_call",
-            sources=["lib/triton_kernel_call.cc"],
-            include_dirs=["/usr/local/cuda/include",
-                          pybind11.get_include()],
-            libraries=["cuda"],
-            library_dirs=[
-                "/usr/local/cuda/lib64", "/usr/local/cuda/lib64/stubs"
-            ],
-        )
-    ])
+from jax_triton.experimental.fusion.lowering import jit

--- a/jax_triton/experimental/fusion/fusion.py
+++ b/jax_triton/experimental/fusion/fusion.py
@@ -1,0 +1,347 @@
+# Copyright 2022 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contains fusion primitives and their lowering."""
+import dataclasses
+import functools
+import os
+
+from typing import Any, Tuple
+
+import jax
+from jax import core
+from jax import lax
+from jax import linear_util as lu
+from jax.interpreters import partial_eval as pe
+from jax.interpreters import xla
+from jax._src import util
+from jax._src.lax.control_flow import for_loop
+import jax.numpy as jnp
+# import jax_triton as jt
+from jax_triton import pallas as pl
+
+from jax_triton.experimental.fusion import jaxpr_rewriter
+from oryx.experimental.matching import jax_rewrite
+from oryx.experimental.matching import matcher
+
+
+Eqn = jaxpr_rewriter.Eqn
+Part = jaxpr_rewriter.Part
+
+map, unsafe_map = util.safe_map, map
+zip, unsafe_zip = util.safe_zip, zip
+
+def lower_fused_jaxpr(jaxpr: core.Jaxpr, consts) -> core.Jaxpr:
+  def _traceable(*args):
+    return _eval_fused_jaxpr(jaxpr, consts, *args)
+  in_avals = [v.aval for v in jaxpr.invars]
+  lowered_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(lu.wrap_init(_traceable), in_avals)
+  return lowered_jaxpr, consts
+
+lowering_rules = {}
+def _eval_fused_jaxpr(jaxpr, consts, *args):
+  env = {}
+
+  def read_env(atom: core.Atom) -> Any:
+    if isinstance(atom, core.Literal):
+      return atom.val
+    return env[atom]
+
+  def write_env(var: core.Var, val: Any):
+    env[var] = val
+
+  map(write_env, jaxpr.invars, args)
+  map(write_env, jaxpr.constvars, consts)
+
+  for eqn in jaxpr.eqns:
+    if eqn.primitive not in lowering_rules:
+      raise NotImplementedError(eqn.primitive)
+    rule = lowering_rules[eqn.primitive]
+    invals = map(read_env, eqn.invars)
+    outvals = rule(*invals, **eqn.params)
+    if eqn.primitive.multiple_results:
+      map(write_env, eqn.outvars, outvals)
+    else:
+      write_env(eqn.outvars[0], outvals)
+  return map(read_env, jaxpr.outvars)
+
+
+def _mul_lowering_rule(x, y):
+  block_size = 512
+  def _mul_scalar_kernel(x_ref, o_ref):
+    pid = pl.program_id(0)
+    idx = pid * block_size + jnp.arange(block_size)
+    x = x_ref[idx]
+    o_ref[idx] = x * y
+  def _mul_kernel(x_ref, y_ref, o_ref):
+    pid = pl.program_id(0)
+    idx = pid * block_size + jnp.arange(block_size)
+    x = x_ref[idx]
+    y = y_ref[idx]
+    o_ref[idx] = x + y
+  num_blocks, remainder = divmod(x.size, block_size)
+  num_blocks += bool(remainder)
+  grid = lambda _: (num_blocks,)
+  if y.shape == ():
+    return pl.pallas_call(_mul_scalar_kernel, out_shape=jax.ShapeDtypeStruct(x.shape,
+      x.dtype), grid=grid, num_warps=8,
+        num_stages=3)(x)
+  return pl.pallas_call(_mul_kernel, out_shape=jax.ShapeDtypeStruct(x.shape,
+    x.dtype), grid=grid, num_warps=8,
+      num_stages=3)(x, y)
+lowering_rules[lax.mul_p] = _mul_lowering_rule
+
+def _add_lowering_rule(x, y):
+  block_size = 512
+  def _add_scalar_kernel(x_ref, o_ref):
+    pid = pl.program_id(0)
+    idx = pid * block_size + jnp.arange(block_size)
+    x = x_ref[idx]
+    o_ref[idx] = x + y
+  def _add_kernel(x_ref, y_ref, o_ref):
+    pid = pl.program_id(0)
+    idx = pid * block_size + jnp.arange(block_size)
+    x = x_ref[idx]
+    y = y_ref[idx]
+    o_ref[idx] = x + y
+  num_blocks, remainder = divmod(x.size, block_size)
+  num_blocks += bool(remainder)
+  grid = lambda _: (num_blocks,)
+  if y.shape == ():
+    return pl.pallas_call(_add_scalar_kernel, out_shape=jax.ShapeDtypeStruct(x.shape,
+      x.dtype), grid=grid, num_warps=8,
+        num_stages=3)(x)
+  return pl.pallas_call(_add_kernel, out_shape=jax.ShapeDtypeStruct(x.shape,
+    x.dtype), grid=grid, num_warps=8,
+      num_stages=3)(x, y)
+lowering_rules[lax.add_p] = _add_lowering_rule
+
+def _sub_lowering_rule(x, y):
+  return x - y
+lowering_rules[lax.sub_p] = _sub_lowering_rule
+
+def _div_lowering_rule(x, y):
+  return x / y
+lowering_rules[lax.div_p] = _div_lowering_rule
+
+def _reduce_sum_lowering_rule(x, **params):
+  return lax.reduce_sum_p.bind(x, **params)
+lowering_rules[lax.reduce_sum_p] = _reduce_sum_lowering_rule
+
+def _tanh_lowering_rule(x):
+  block_size = 512
+  def _tanh_kernel(x_ref, o_ref):
+    pid = pl.program_id(0)
+    idx = pid * block_size + jnp.arange(block_size)
+    x = x_ref[idx]
+    o_ref[idx] = jnp.tanh(x)
+  num_blocks, remainder = divmod(x.size, block_size)
+  num_blocks += bool(remainder)
+  grid = lambda _: (num_blocks,)
+  return pl.pallas_call(_tanh_kernel,
+      out_shape=jax.ShapeDtypeStruct(x.shape,
+    x.dtype), grid=grid,
+      num_warps=4, num_stages=3)(x)
+lowering_rules[lax.tanh_p] = _tanh_lowering_rule
+
+def _logistic_lowering_rule(x):
+  block_size = 512
+  def _logistic_kernel(x_ref, o_ref):
+    pid = pl.program_id(0)
+    idx = pid * block_size + jnp.arange(block_size)
+    x = x_ref[idx]
+    o_ref[idx] = jax.nn.sigmoid(x)
+  num_blocks, remainder = divmod(x.size, block_size)
+  num_blocks += bool(remainder)
+  grid = lambda _: (num_blocks,)
+  return pl.pallas_call(_logistic_kernel,
+      out_shape=jax.ShapeDtypeStruct(x.shape,
+    x.dtype), grid=grid,
+      num_warps=4, num_stages=3)(x)
+lowering_rules[lax.logistic_p] = _logistic_lowering_rule
+
+def _xla_call_lowering_rule(*args, call_jaxpr, **_):
+  return _eval_fused_jaxpr(call_jaxpr, (), *args)
+lowering_rules[xla.xla_call_p] = _xla_call_lowering_rule
+
+elementwise_p = core.Primitive('elementwise')
+elementwise_p.multiple_results = True
+
+elementwise_p.def_abstract_eval(lambda *avals, **_: [avals[0]])
+
+def _elementwise_lowering_rule(x, *, ops):
+  block_size = 256
+  def _elementwise_kernel(x_ref, o_ref):
+    pid = pl.program_id(0)
+    idx = pid * block_size + jnp.arange(block_size)
+    x = x_ref[idx]
+    args = (x,)
+    for op in ops:
+      args = op(*args)
+    x, = args
+    o_ref[idx] = x
+  num_blocks, remainder = divmod(x.size, block_size)
+  num_blocks += bool(remainder)
+  grid = lambda _: (num_blocks,)
+  return pl.pallas_call(_elementwise_kernel, out_shape=[jax.ShapeDtypeStruct(x.shape,
+    x.dtype)], grid=grid, num_warps=8,
+      num_stages=3)(x)
+lowering_rules[elementwise_p] = _elementwise_lowering_rule
+
+
+def make_elementwise(shape, dtype, *args):
+  *args, ops = args
+  return Part(0, shape, dtype, Eqn(elementwise_p, jax_rewrite.Params(ops=ops), list(args),
+             [shape], [dtype]))
+
+@dataclasses.dataclass(frozen=True)
+class MatmulElementwise(jax_rewrite.JaxExpression):
+  x: jax_rewrite.JaxExpression
+  y: jax_rewrite.JaxExpression
+  elem_ops: Tuple[core.Primitive]
+
+  def match(self, expr, bindings, succeed):
+    if not isinstance(expr, MatmulElementwise):
+      return
+    yield from matcher.matcher((self.elem_ops, self.x, self.y))((expr.elem_ops,
+      expr.x, expr.y), bindings, succeed)
+
+  def dtype(self):
+    return self.x.dtype
+
+  def shape(self):
+    return (self.x.shape[0], self.y.shape[1])
+
+  def evaluate(self, env):
+    x = jax_rewrite.evaluate(self.x, env)
+    y = jax_rewrite.evaluate(self.y, env)
+    return matmul_elementwise_fusion_p.bind(
+        x, y, eltwise_ops=self.elem_ops)
+
+  def tree_map(self, fn):
+    return MatmulElementwise(fn(self.x), fn(self.y), self.elem_ops)
+
+  def tree_children(self):
+    yield self.x
+    yield self.y
+
+  def __str__(self):
+    return f"(fusion matmul_eltwise ({self.x}, {self.y}) {self.elem_ops})"
+
+matmul_elementwise_fusion_p = core.Primitive("matmul_eltwise_fusion")
+
+def _matmul_elementwise_fusion_impl(x, y, *args, **_):
+  raise NotImplementedError
+matmul_elementwise_fusion_p.def_impl(_matmul_elementwise_fusion_impl)
+
+def _matmul_elementwise_fusion_abstract_eval(x, y, *args, **_):
+  return core.ShapedArray((x.shape[0], y.shape[1]), x.dtype)
+matmul_elementwise_fusion_p.def_abstract_eval(_matmul_elementwise_fusion_abstract_eval)
+
+def _matmul_elementwise_lowering_rule(x, y, *args, left_ops, right_ops, out_ops,
+                                      contract_dims):
+  if len(args) == 1:
+    bias, = args
+  else:
+    bias = None
+  lhs_dim, rhs_dim = contract_dims
+  M, N, K = x.shape[1 - lhs_dim], y.shape[1 - rhs_dim], x.shape[lhs_dim]
+  assert x.shape[lhs_dim] == y.shape[rhs_dim]
+
+  BLOCK_SIZE_M = min(256, M)
+  BLOCK_SIZE_N = min(128, N)
+  BLOCK_SIZE_K = min(32, K)
+  GROUP_SIZE_M = 8
+
+
+  BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, num_stages, num_warps = (
+      32, 64, 64, 4, 6)
+  if "TRITON_CONFIG" in os.environ:
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, num_stages, num_warps = map(
+        int, os.environ["TRITON_CONFIG"].split(","))
+
+  @functools.partial(pl.pallas_call,
+      out_shape=jax.ShapeDtypeStruct((M, N), x.dtype),
+      grid=jt.cdiv(M, BLOCK_SIZE_M) * jt.cdiv(N, BLOCK_SIZE_N),
+      num_warps=num_warps, num_stages=num_stages)
+  def fused_matmul(x_ref, y_ref, *args):
+    if len(args) == 2:
+      bias_ref, o_ref = args
+    else:
+      bias_ref = None
+      o_ref, = args
+    pid = pl.program_id(axis=0)
+    num_pid_m = M // BLOCK_SIZE_M
+    num_pid_n = N // BLOCK_SIZE_N
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = lax.div(pid, num_pid_in_group)
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = jnp.minimum(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + lax.rem(pid, group_size_m)
+    pid_n = lax.div(lax.rem(pid, num_pid_in_group), group_size_m)
+    idx_m = pid_m * BLOCK_SIZE_M + jnp.arange(BLOCK_SIZE_M)
+    idx_n = pid_n * BLOCK_SIZE_N + jnp.arange(BLOCK_SIZE_N)
+    idx_m = pl.max_contiguous(pl.multiple_of(idx_m, BLOCK_SIZE_M), BLOCK_SIZE_M)
+    idx_n = pl.max_contiguous(pl.multiple_of(idx_n, BLOCK_SIZE_N), BLOCK_SIZE_N)
+    def body(i, acc_ref):
+      idx_k = i * BLOCK_SIZE_K + jnp.arange(BLOCK_SIZE_K)
+      if lhs_dim == 1:
+        x_idx = (
+            jax.lax.broadcast_in_dim(idx_m, (BLOCK_SIZE_M, BLOCK_SIZE_K), (0,)),
+            jax.lax.broadcast_in_dim(idx_k, (BLOCK_SIZE_M, BLOCK_SIZE_K), (1,)))
+      else:
+        x_idx = (
+            jax.lax.broadcast_in_dim(idx_k, (BLOCK_SIZE_K, BLOCK_SIZE_M), (0,)),
+            jax.lax.broadcast_in_dim(idx_m, (BLOCK_SIZE_K, BLOCK_SIZE_M), (1,)))
+      if rhs_dim == 0:
+        y_idx = (
+            jax.lax.broadcast_in_dim(idx_k, (BLOCK_SIZE_K, BLOCK_SIZE_N), (0,)),
+            jax.lax.broadcast_in_dim(idx_n, (BLOCK_SIZE_K, BLOCK_SIZE_N), (1,)))
+      else:
+        y_idx = (
+            jax.lax.broadcast_in_dim(idx_n, (BLOCK_SIZE_N, BLOCK_SIZE_K), (0,)),
+            jax.lax.broadcast_in_dim(idx_k, (BLOCK_SIZE_N, BLOCK_SIZE_K), (1,)))
+      x_block, y_block = x_ref[x_idx], y_ref[y_idx]
+      for eltwise_op in left_ops:
+        x_block, = eltwise_op(x_block)
+      for eltwise_op in right_ops:
+        y_block, = eltwise_op(y_block)
+      out = pl.dot(x_block, y_block, trans_a=lhs_dim == 0, trans_b=rhs_dim == 1,
+                   allow_tf32=True)
+      acc_ref[:, :] += out
+    acc = jnp.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=jnp.float32)
+    acc = for_loop.for_loop(K // BLOCK_SIZE_K, body, acc)
+    if bias_ref is not None:
+      b = bias_ref[idx_n]
+      acc = acc + jax.lax.broadcast_in_dim(b, (BLOCK_SIZE_M, BLOCK_SIZE_N), (1,))
+    for eltwise_op in out_ops:
+      acc, = eltwise_op(acc)
+    acc = acc.astype(x_ref.dtype)
+    o_idx = (
+        jax.lax.broadcast_in_dim(idx_m, (BLOCK_SIZE_M, BLOCK_SIZE_N), (0,)),
+        jax.lax.broadcast_in_dim(idx_n, (BLOCK_SIZE_M, BLOCK_SIZE_N), (1,)),
+        )
+    o_ref[o_idx] = acc
+  return fused_matmul(x, y, *args)
+lowering_rules[matmul_elementwise_fusion_p] = _matmul_elementwise_lowering_rule
+
+def _dot_general_lowering_rule(x, y, dimension_numbers, **_):
+  contract_dims, batch_dims = dimension_numbers
+  del batch_dims
+  lhs_dim, rhs_dim = contract_dims[0][0], contract_dims[1][0]
+  return _matmul_elementwise_lowering_rule(x, y, left_ops=[], right_ops=[],
+                                           out_ops=[], contract_dims=(lhs_dim,
+                                                                      rhs_dim))
+lowering_rules[lax.dot_general_p] = _dot_general_lowering_rule
+

--- a/jax_triton/experimental/fusion/jaxpr_rewriter.py
+++ b/jax_triton/experimental/fusion/jaxpr_rewriter.py
@@ -1,0 +1,299 @@
+# Copyright 2022 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contains utilities for rewriting jaxprs."""
+from __future__ import annotations
+
+import abc
+import dataclasses
+import itertools as it
+
+from typing import Any, Callable, Dict, List, Set, Tuple, Union
+
+from jax import core as jax_core
+import jax.numpy as jnp
+
+from oryx.experimental.matching import matcher
+from oryx.experimental.matching import jax_rewrite as jr
+
+Expr = matcher.Expr
+Bindings = matcher.Bindings
+Continuation = matcher.Continuation
+Success = matcher.Success
+
+class Node(matcher.Pattern, metaclass=abc.ABCMeta):
+
+  @abc.abstractproperty
+  def parents(self) -> List[Node]:
+    ...
+
+
+  @abc.abstractmethod
+  def set_parent(self, node, new_node):
+    ...
+
+  @abc.abstractmethod
+  def map_parents(self, fn: Callable[[Node], Node]) -> Node:
+    ...
+
+@dataclasses.dataclass(eq=False)
+class Eqn(Node):
+  primitive: jax_core.Primitive
+  params: jr.Params
+  invars: List[Node]
+  shape: Union[Tuple[int, ...], List[Tuple[int, ...]]]
+  dtype: Union[jnp.dtype, List[jnp.dtype]]
+
+  @property
+  def parents(self):
+    return self.invars
+
+  def set_parent(self, node, new_node):
+    invar_idx = self.invars.index(node)
+    self.invars[invar_idx] = new_node
+
+  def map_parents(self, fn):
+    return Eqn(self.primitive, self.params, list(map(fn, self.invars)),
+               self.shape, self.dtype)
+
+  def match(self, expr, bindings, succeed):
+    if not isinstance(expr, Eqn):
+      return
+    yield from matcher.matcher((self.primitive, self.params, self.invars,
+      self.shape, self.dtype))(
+        (expr.primitive, expr.params, expr.invars, expr.shape, expr.dtype),
+        bindings, succeed)
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class JaxprVar(Node):
+  shape: Tuple[int, ...]
+  dtype: jnp.dtype
+
+  def match(self, expr, bindings, succeed):
+    if expr is self:
+      yield from succeed(bindings)
+
+  @property
+  def parents(self):
+    return []
+
+  def set_parent(self, node, new_node):
+    raise NotImplementedError
+
+  def map_parents(self, fn):
+    return self
+
+  @classmethod
+  def from_var(cls, var: jax_core.Var) -> JaxprVar:
+    return JaxprVar(var.aval.shape, var.aval.dtype)
+
+@dataclasses.dataclass(eq=False, frozen=True)
+class Literal(Node):
+  value: Any
+  dtype: jnp.dtype
+
+  @property
+  def parents(self):
+    return []
+
+  def map_parents(self, fn, visited):
+    return self
+
+  def set_parent(self, node, new_node):
+    raise NotImplementedError
+
+  @property
+  def shape(self):
+    return ()
+
+  def match(self, expr, bindings, succeed):
+    if not isinstance(expr, Literal):
+      return []
+    yield from matcher.matcher((self.value, self.dtype))((expr.value,
+      expr.dtype), bindings, succeed)
+
+  @classmethod
+  def from_literal(cls, var: jax_core.Literal) -> Literal:
+    return Literal(var.val, var.aval.dtype)
+
+
+@dataclasses.dataclass(eq=False)
+class Part(Node):
+  index: int
+  shape: Tuple[int, ...]
+  dtype: jnp.dtype
+  parent: Node
+
+  def match(self, expr, bindings, succeed):
+    if not isinstance(expr, Part):
+      return []
+    yield from matcher.matcher((self.index, self.shape, self.dtype, self.parent))((
+      expr.index, expr.shape, expr.dtype, expr.parent), bindings, succeed)
+
+  def set_parent(self, _, new_node):
+    self.parent = new_node
+
+  @property
+  def parents(self):
+    return [self.parent]
+
+  def map_parents(self, fn):
+    return Part(self.index, self.shape, self.dtype, fn(self.parent))
+
+@dataclasses.dataclass(eq=True)
+class JaxprGraph(matcher.Pattern):
+  constvars: List[Node]
+  invars: List[Node]
+  outvars: List[Node]
+
+  def get_nodes(self):
+    nodes = set(self.outvars)
+    queue = list(self.outvars)
+    while queue:
+      node = queue.pop(0)
+      nodes.add(node)
+      for p in node.parents:
+        queue.append(p)
+    return nodes
+
+  def get_children(self, node) -> List[Node]:
+    nodes = self.get_nodes()
+    return [n for n in nodes if node in n.parents]
+
+  def rewrite_subgraph(self, pattern, handler) -> bool:
+    queue = list(self.outvars)
+    while queue:
+      node = queue.pop(0)
+      assert isinstance(node, Node)
+      try:
+        match = matcher.match(pattern, node)
+        new_node = handler(**match)
+        if node in self.outvars:
+          i = self.outvars.index(node)
+          self.outvars[i] = new_node
+        elif isinstance(node, Eqn):
+          children = self.get_children(node)
+          assert children
+          for c in children:
+            c.set_parent(node, new_node)
+        else:
+          raise NotImplementedError
+        return True
+      except matcher.MatchError:
+        queue.extend(node.parents)
+        for p in node.parents:
+          if isinstance(p, Eqn):
+            assert self.get_children(p)
+    return False
+
+  @classmethod
+  def from_jaxpr(cls, jaxpr: jax_core.Jaxpr) -> JaxprGraph:
+    var_mapping = {}
+    for var in it.chain(jaxpr.constvars, jaxpr.invars):
+      node = JaxprVar.from_var(var)
+      var_mapping[var] = node
+    for eqn in jaxpr.eqns:
+      invars = []
+      for invar in eqn.invars:
+        if isinstance(invar, jax_core.Literal):
+          node = Literal.from_literal(invar)
+        else:
+          node = var_mapping[invar]
+        invars.append(node)
+      if eqn.primitive.multiple_results:
+        node = Eqn(eqn.primitive, jr.Params(eqn.params), invars,
+                   [o.aval.shape for o in eqn.outvars],
+                   [o.aval.dtype for o in eqn.outvars])
+        for i, outvar in enumerate(eqn.outvars):
+          part = Part(i, outvar.aval.shape, outvar.aval.dtype, node)
+          var_mapping[outvar] = part
+      else:
+        node = Eqn(eqn.primitive, jr.Params(eqn.params), invars,
+                   eqn.outvars[0].aval.shape, eqn.outvars[0].aval.dtype)
+        var_mapping[eqn.outvars[0]] = node
+    constvars = [var_mapping[constvar] for constvar in jaxpr.constvars]
+    invars = [var_mapping[invar] for invar in jaxpr.invars]
+    outvars = [var_mapping[outvar] for outvar in jaxpr.outvars]
+    return JaxprGraph(constvars, invars, outvars)
+
+  def to_jaxpr(self) -> jax_core.Jaxpr:
+    gen = jax_core.gensym()
+    eqns = []
+    sorted_nodes = self.toposort()
+    env = {}
+    for var in it.chain(self.invars, self.constvars):
+      env[var] = gen(jax_core.ShapedArray(var.shape, var.dtype))
+    incomplete_eqns = {}
+    for node in sorted_nodes:
+      if isinstance(node, Literal):
+        continue
+      elif isinstance(node, JaxprVar):
+        assert node in env
+        continue
+      elif isinstance(node, Eqn):
+        invars = []
+        for n in node.invars:
+          if isinstance(n, Literal):
+            invars.append(jax_core.Literal(n.value, jax_core.ShapedArray((),
+              n.dtype)))
+          else:
+            invars.append(env[n])
+        jaxpr_eqn = jax_core.JaxprEqn(invars, [], node.primitive,
+            dict(node.params), jax_core.no_effects, None)
+        if node.primitive.multiple_results:
+          incomplete_eqns[node] = jaxpr_eqn
+        else:
+          outvar = gen(jax_core.ShapedArray(node.shape, node.dtype))
+          env[node] = outvar
+          jaxpr_eqn = jaxpr_eqn.replace(outvars=[outvar])
+          incomplete_eqns[node] = jaxpr_eqn
+      elif isinstance(node, Part):
+        eqn = node.parent
+        incomplete_eqn = incomplete_eqns[eqn]
+        outvars = list(incomplete_eqn.outvars)
+        if len(outvars) <= node.index:
+          outvars = outvars + [None] * (node.index - len(outvars) + 1)
+        outvar = gen(jax_core.ShapedArray(node.shape, node.dtype))
+        outvars[node.index] = outvar
+        env[node] = outvar
+        incomplete_eqns[eqn] = incomplete_eqn.replace(outvars=outvars)
+    eqns = list(incomplete_eqns.values())
+    constvars = [env[n] for n in self.constvars]
+    invars = [env[n] for n in self.invars]
+    outvars = [env[n] for n in self.outvars]
+    return jax_core.Jaxpr(constvars, invars, outvars, eqns, jax_core.no_effects)
+
+  def toposort(self) -> List[Node]:
+    node_stack = list(self.outvars)
+    child_counts = {}
+    while node_stack:
+      node = node_stack.pop()
+      if node in child_counts:
+        child_counts[node] += 1
+      else:
+        child_counts[node] = 1
+        node_stack.extend(node.parents)
+    for node in self.outvars:
+      child_counts[node] -= 1
+    childless_nodes = [node for node in self.outvars if child_counts[node] == 0]
+    sorted_nodes = []
+    while childless_nodes:
+      node = childless_nodes.pop()
+      sorted_nodes.append(node)
+      for parent in node.parents:
+        if child_counts[parent] == 1:
+          childless_nodes.append(parent)
+        else:
+          child_counts[parent] -= 1
+    return list(reversed(sorted_nodes))

--- a/jax_triton/experimental/fusion/lowering.py
+++ b/jax_triton/experimental/fusion/lowering.py
@@ -1,0 +1,377 @@
+# Copyright 2022 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contains lowering passes for jaxprs to pallas."""
+import functools
+
+from typing import Any, Dict
+
+import jax
+from jax import api_util
+from jax import core
+from jax import lax
+from jax import linear_util as lu
+from jax import tree_util
+from jax._src import util
+from jax._src import source_info_util
+from jax.interpreters import partial_eval as pe
+
+from jax_triton.experimental.fusion import fusion
+from jax_triton.experimental.fusion import jaxpr_rewriter
+
+from oryx.experimental.matching import jax_rewrite as jr
+from oryx.experimental.matching import matcher
+
+
+map, unsafe_map = util.safe_map, map
+zip, unsafe_zip = util.safe_zip, zip
+
+Var = matcher.Var
+Dot = matcher.Dot
+Segment = matcher.Segment
+Eqn = jaxpr_rewriter.Eqn
+Part = jaxpr_rewriter.Part
+
+Sigmoid = lambda x: Eqn(lax.logistic_p, jr.Params(), [x], Dot, Dot)
+Exp = lambda x: Eqn(lax.exp_p, jr.Params(), [x], Dot, Dot)
+Add = lambda x, y: Eqn(lax.add_p, jr.Params(), [x, y], Dot, Dot)
+Mul = lambda x, y: Eqn(lax.mul_p, jr.Params(), [x, y], Dot, Dot)
+Sub = lambda x, y: Eqn(lax.sub_p, jr.Params(), [x, y], Dot, Dot)
+Max = lambda x, y: Eqn(lax.max_p, jr.Params(), [x, y], Dot, Dot)
+Ge = lambda x, y: Eqn(lax.ge_p, jr.Params(), [x, y], Dot, Dot)
+IntegerPow = lambda x, y: Eqn(lax.integer_pow_p, jr.Params(y=y), [x], Dot, Dot)
+Tanh = lambda x: Eqn(lax.tanh_p, jr.Params(), [x], Dot, Dot)
+
+def _apply_all(rules):
+  def rule(graph):
+    done = False
+    while not done:
+      done = True
+      rewritten = []
+      for pattern, handler in rules:
+        d = graph.rewrite_subgraph(pattern, handler)
+        rewritten.append(d)
+      done = not any(rewritten)
+  return rule
+
+Elementwise = lambda x, ops: Part(0, Eqn(fusion.elementwise_p,
+  jr.Params(ops=ops), [x], Dot, Dot), Dot, Dot)
+
+elementwise_of_elementwise = Eqn(
+    fusion.elementwise_p,
+    jr.Params(ops=Var('outer_ops')),
+    [Segment('left'), Part(Var('idx'), Dot, Dot, Eqn(fusion.elementwise_p, jr.Params(ops=Var('inner_ops')),
+      Var('inner_args'), Dot, Dot)), Segment('right')],
+    Var('shape'), Var('dtype'))
+def _elementwise_handler(idx, left, inner_args, right, inner_ops, outer_ops, shape,
+    dtype):
+  def wrapper_eltwise_op(*args):
+    left_, inner, right = util.split_list(args, [len(left), len(inner_args)])
+    for op in inner_ops:
+      inner = op(*inner)
+    args = [*left_, *inner, *right]
+    for op in outer_ops:
+      args = op(*args)
+    return args
+  return Eqn(
+      fusion.elementwise_p, jr.Params(ops=[wrapper_eltwise_op]),
+      [*left, *inner_args, *right], shape, dtype)
+
+add_elemwise_pattern = Eqn(lax.add_p, jr.Params(),
+    [Var('x'), Part(0, Dot, Dot, Eqn(fusion.elementwise_p,
+    jr.Params(ops=Var('ops')), [Var('x')], Dot, Dot))], Var('shape'), Var('dtype'))
+def _add_elemwise_handler(x, ops, shape, dtype):
+  def _wrapper_op(*args):
+    x_, = args
+    for op in ops:
+      args = op(*args)
+    y, = args
+    return [x_ + y]
+  return Part(0, shape, dtype, Eqn(fusion.elementwise_p, jr.Params(ops=[_wrapper_op]),
+             [x], [shape], [dtype]))
+
+mul_elemwise_pattern = Eqn(lax.mul_p, jr.Params(),
+    [Var('x'), Part(0, Dot, Dot, Eqn(fusion.elementwise_p,
+    jr.Params(ops=Var('ops')), [Var('x')], Dot, Dot))], Var('shape'), Var('dtype'))
+def _mul_elemwise_handler(x, ops, shape, dtype):
+  def _wrapper_op(*args):
+    x_, = args
+    for op in ops:
+      args = op(*args)
+    y, = args
+    return [x_ * y]
+  return Part(0, shape, dtype, Eqn(fusion.elementwise_p, jr.Params(ops=[_wrapper_op]),
+             [x], [shape], [dtype]))
+
+fuse_elementwise = _apply_all([
+  (elementwise_of_elementwise, _elementwise_handler),
+  (add_elemwise_pattern, _add_elemwise_handler),
+  (mul_elemwise_pattern, _mul_elemwise_handler),
+  ])
+
+dup_elementwise = Eqn(
+    fusion.elementwise_p,
+    jr.Params(ops=Var('ops')),
+    [Segment('left'), Var('x'), Segment('middle'), Var('x'), Segment('right')],
+    Var('shape'), Var('dtype'))
+def _dup_elementwise_handler(left, x, middle, right, shape, dtype, ops):
+  def wrapper_op(*args):
+    left_, x, middle_, right_ = util.split_list(args, [len(left), 1, len(middle)])
+    args = [*left_, *x, *middle_, *x, *right_]
+    for op in ops:
+      args = op(*args)
+    return args
+  return Eqn(
+      fusion.elementwise_p, jr.Params(ops=[wrapper_op]),
+      [*left, x, *middle, *right], shape, dtype)
+
+dedup_elementwise = _apply_all([
+  (dup_elementwise, _dup_elementwise_handler)
+  ])
+
+Matmul = lambda x, y, shape, dtype, ldim, rdim: Eqn(
+    lax.dot_general_p, jr.Params(dimension_numbers=(((ldim,),
+                                                     (rdim,)), ((), ())),
+                                 precision=None,
+                                 preferred_element_type=None), [x, y],
+    shape, dtype)
+
+transpose_matmul_pattern = Eqn(
+    lax.transpose_p, jr.Params(permutation=(1, 0)),
+    [Eqn(lax.dot_general_p, jr.Params(dimension_numbers=(((1,), (1,)), ((), ())),
+                                      precision=None,
+                                      preferred_element_type=None),
+         [Var('x'), Var('y')], Dot, Dot)], Var('shape'), Var('dtype'))
+def _transpose_matmul_handler(x, y, shape, dtype):
+  return Eqn(
+    lax.dot_general_p,
+    jr.Params(dimension_numbers=(((1,), (1,)), ((), ())),
+              precision=None,
+              preferred_element_type=None), [y, x],
+    shape, dtype)
+
+ElementwiseFusedMatmul = lambda x, y, params, shape, dtype: Eqn(
+    fusion.matmul_elementwise_fusion_p, params, [x, y], shape, dtype)
+
+matmul_add_bias_pattern = Eqn(
+    lax.add_p,
+    jr.Params(),
+    [
+      Matmul(Var('x'), Var('y'), Var('shape'), Var('dtype'),
+             Var('ldim'), Var('rdim')),
+      Eqn(lax.broadcast_in_dim_p, jr.Params(broadcast_dimensions=(1,),
+                                            shape=Dot),
+          [Var('z')], Dot, Dot)
+    ], Dot, Dot)
+def _matmul_add_bias_handler(x, y, z, shape, dtype, ldim, rdim):
+  return Eqn(fusion.matmul_elementwise_fusion_p,
+             jr.Params(contract_dims=(ldim, rdim), left_ops=[], right_ops=[], out_ops=[]),
+             [x, y, z], shape, dtype)
+
+matmul_elementwise = Eqn(
+    fusion.elementwise_p,
+    jr.Params(ops=Var('ops')),
+    [Matmul(Var('x'), Var('y'), Var('shape'), Var('dtype'), Var('ldim'),
+    Var('rdim'))], Dot, Dot)
+def _matmul_elementwise_handler(x, y, ops, shape, dtype, ldim, rdim):
+  return Eqn(fusion.matmul_elementwise_fusion_p,
+             jr.Params(left_ops=[], right_ops=[], out_ops=ops,
+                       contract_dims=(ldim, rdim)),
+             [x, y], shape, dtype)
+
+left_elementwise_matmul = Matmul(
+    Elementwise(Var('x'), Var('ops')), Var('y'), Var('shape'), Var('dtype'),
+    Var('ldim'), Var('rdim'))
+
+def _left_elementwise_matmul(x, y, ops, shape, dtype, ldim, rdim):
+  return Eqn(fusion.matmul_elementwise_fusion_p, jr.Params(left_ops=ops, out_ops=ops),
+             [x, y], shape, dtype)
+
+right_elementwise_matmul = Matmul(
+    Var('x'), Elementwise(Var('y'), Var('ops')), Var('shape'), Var('dtype'),
+    Var('ldim'), Var('rdim'))
+
+def _right_elementwise_matmul(x, y, ops, shape, dtype, ldim, rdim):
+  return Eqn(fusion.matmul_elementwise_fusion_p, jr.Params(
+    right_ops=ops, left_ops=[], out_ops=[]), [x, y], shape, dtype)
+
+left_elementwise_fused_matmul = ElementwiseFusedMatmul(
+    Elementwise(Var('x'), Var('ops')), Var('y'),
+      Var('params'), Var('shape'), Var('dtype'))
+
+def _left_elementwise_fused_matmul(x, y, ops, params, shape, dtype):
+  return Eqn(fusion.matmul_elementwise_fusion_p,
+             jr.Params(right_ops=params["right_ops"],
+                       left_ops=[*ops, *params["left_ops"]],
+                       out_ops=params["out_ops"]),
+             [x, y], shape, dtype)
+
+right_elementwise_fused_matmul = Eqn(
+    fusion.matmul_elementwise_fusion_p,
+    Var('params'),
+    [Var('x'), Part(0, Dot, Dot, Eqn(
+      fusion.elementwise_p,
+      jr.Params(ops=Var('ops')), [Var('y')], Dot, Dot))],
+    Var('shape'), Var('dtype'))
+
+def _right_elementwise_fused_matmul(x, y, ops, params, shape, dtype):
+  return Eqn(fusion.matmul_elementwise_fusion_p,
+             jr.Params(right_ops=[*ops, *params["right_ops"]],
+                       left_ops=params["left_ops"],
+                       out_ops=params["out_ops"]),
+             [x, y], shape, dtype)
+
+out_elementwise_fused_matmul = Eqn(
+    fusion.elementwise_p, jr.Params(ops=Var('ops')), [
+      Eqn(fusion.matmul_elementwise_fusion_p,
+          Var('params'), [Var('x'), Var('y'), Segment('bias')],
+          Var('shape'), Var('dtype'))
+      ], Dot, Dot)
+
+def _out_elementwise_fused_matmul(x, y, bias, ops, params, shape, dtype):
+  return Eqn(fusion.matmul_elementwise_fusion_p,
+             jr.Params(out_ops=[*ops, *params["out_ops"]],
+                       left_ops=params["left_ops"],
+                       right_ops=params["right_ops"],
+                       contract_dims=params["contract_dims"]),
+             [x, y, *bias], shape, dtype)
+
+fuse_matmul_elementwise = _apply_all([
+  # (left_elementwise_matmul, _left_elementwise_matmul),
+  # (right_elementwise_matmul, _right_elementwise_matmul),
+  # (left_elementwise_fused_matmul, _left_elementwise_fused_matmul),
+  # (right_elementwise_fused_matmul, _right_elementwise_fused_matmul),
+  (transpose_matmul_pattern, _transpose_matmul_handler),
+  (matmul_add_bias_pattern, _matmul_add_bias_handler),
+  (matmul_elementwise, _matmul_elementwise_handler),
+  (out_elementwise_fused_matmul, _out_elementwise_fused_matmul),
+  ])
+
+def _inline_calls(jaxpr: core.Jaxpr, consts) -> core.Jaxpr:
+  _traceable = functools.partial(_eval_jaxpr_inline_calls, jaxpr, consts)
+  in_avals = [v.aval for v in jaxpr.invars]
+  inlined_jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(lu.wrap_init(_traceable), in_avals)
+  return inlined_jaxpr, consts
+
+elementwise_rules = {}
+
+def _register_unary_elementwise_rule(prim):
+  def rule(x, **params):
+    def _op(*args):
+      x, = args
+      return [prim.bind(x, **params)]
+    return fusion.elementwise_p.bind(x, ops=[_op])[0]
+  elementwise_rules[prim] = rule
+
+def _register_binary_elementwise_rule(prim):
+  def rule(x, y, **params):
+    if y.shape == ():
+      def _op(*args):
+        x, = args
+        return [prim.bind(x, y.astype(x.dtype), **params)]
+      return fusion.elementwise_p.bind(x, ops=[_op])[0]
+    elif x.shape == ():
+      def _op(*args):
+        y, = args
+        return [prim.bind(x.astype(y.dtype), y, **params)]
+      return fusion.elementwise_p.bind(y, ops=[_op])[0]
+    return prim.bind(x, y, **params)
+  elementwise_rules[prim] = rule
+
+_register_unary_elementwise_rule(lax.sin_p)
+_register_unary_elementwise_rule(lax.cos_p)
+_register_unary_elementwise_rule(lax.exp_p)
+_register_unary_elementwise_rule(lax.logistic_p)
+_register_unary_elementwise_rule(lax.integer_pow_p)
+_register_unary_elementwise_rule(lax.tanh_p)
+_register_binary_elementwise_rule(lax.mul_p)
+_register_binary_elementwise_rule(lax.ge_p)
+_register_binary_elementwise_rule(lax.max_p)
+_register_binary_elementwise_rule(lax.min_p)
+_register_binary_elementwise_rule(lax.add_p)
+_register_binary_elementwise_rule(lax.sub_p)
+_register_binary_elementwise_rule(lax.div_p)
+
+def _select_n_elementwise_rule(pred, x, y):
+  def _op(pred, x, y):
+    return [lax.select_n_p.bind(pred, x, y)]
+  return fusion.elementwise_p.bind(pred, x, y, ops=[_op])[0]
+elementwise_rules[lax.select_n_p] = _select_n_elementwise_rule
+
+
+def _eval_jaxpr_inline_calls(jaxpr: core.Jaxpr, consts, *args):
+  def read(v: core.Atom) -> Any:
+    return v.val if isinstance(v, core.Literal) else env[v]
+
+  def write(v: Var, val: Any) -> None:
+    env[v] = val
+
+  env: Dict[Var, Any] = {}
+  map(write, jaxpr.constvars, consts)
+  map(write, jaxpr.invars, args)
+  for eqn in jaxpr.eqns:
+    subfuns, bind_params = eqn.primitive.get_bind_params(eqn.params)
+    name_stack = source_info_util.current_name_stack() + eqn.source_info.name_stack
+    with source_info_util.user_context(eqn.source_info.traceback, name_stack=name_stack):
+      if isinstance(eqn.primitive, core.CallPrimitive):
+        call_jaxpr = eqn.params["call_jaxpr"]
+        ans = _eval_jaxpr_inline_calls(call_jaxpr, [], *map(read, eqn.invars))
+      elif eqn.primitive in elementwise_rules:
+        ans = elementwise_rules[eqn.primitive](*map(read, eqn.invars),
+                                               **bind_params)
+      else:
+        ans = eqn.primitive.bind(*subfuns, *map(read, eqn.invars), **bind_params)
+    if eqn.primitive.multiple_results:
+      map(write, eqn.outvars, ans)
+    else:
+      write(eqn.outvars[0], ans)
+  return map(read, jaxpr.outvars)
+
+def lower_jaxpr(jaxpr: core.Jaxpr, consts, fuse: bool, debug: bool) -> core.Jaxpr:
+  if debug:
+    print("=========== Initial jaxpr ====================")
+    print(jaxpr)
+  jaxpr, consts = _inline_calls(jaxpr, consts)
+  if debug:
+    print("===== Inlining and detecting elementwise ops =========")
+    print(jaxpr)
+  graph = jaxpr_rewriter.JaxprGraph.from_jaxpr(jaxpr)
+  if fuse:
+    fuse_elementwise(graph)
+    dedup_elementwise(graph)
+    if debug:
+      print("=========== Elementwise fusion ========================")
+      print(graph.to_jaxpr())
+    fuse_matmul_elementwise(graph)
+    if debug:
+      print("=========== Matmul elementwise fusion ========================")
+      print(graph.to_jaxpr())
+  jaxpr = graph.to_jaxpr()
+  lowered_jaxpr, consts = fusion.lower_fused_jaxpr(jaxpr, consts)
+  if debug:
+    print("=========== Pallas lowering ========================")
+    print(lowered_jaxpr)
+  return lowered_jaxpr, consts
+
+def jit(f, *, fuse: bool = True, debug: bool = False):
+  @jax.jit
+  def wrapped(*args, **kwargs):
+    flat_args, in_tree = tree_util.tree_flatten((args, kwargs))
+    flat_fun, out_tree_thunk = api_util.flatten_fun(lu.wrap_init(f), in_tree)
+    in_avals = [core.raise_to_shaped(core.get_aval(a)) for a in flat_args]
+    jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(flat_fun, in_avals)
+    jaxpr, consts = lower_jaxpr(jaxpr, consts, fuse=fuse, debug=debug)
+    out_vals = core.eval_jaxpr(jaxpr, consts, *flat_args)
+    return tree_util.tree_unflatten(out_tree_thunk(), out_vals)
+  return wrapped

--- a/jax_triton/pallas/__init__.py
+++ b/jax_triton/pallas/__init__.py
@@ -12,23 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""setup.py for jax-triton."""
-import pybind11
-from setuptools import Extension
-from setuptools import find_packages
-from setuptools import setup
-
-setup(
-    packages=find_packages(),
-    ext_modules=[
-        Extension(
-            name="jax_triton.triton_kernel_call",
-            sources=["lib/triton_kernel_call.cc"],
-            include_dirs=["/usr/local/cuda/include",
-                          pybind11.get_include()],
-            libraries=["cuda"],
-            library_dirs=[
-                "/usr/local/cuda/lib64", "/usr/local/cuda/lib64/stubs"
-            ],
-        )
-    ])
+"""Module for pallas, a jaxpr "dialect" for Triton."""
+from jax_triton.pallas.pallas_call import pallas_call
+from jax_triton.pallas.primitives import dot
+from jax_triton.pallas.primitives import load
+from jax_triton.pallas.primitives import max_contiguous
+from jax_triton.pallas.primitives import multiple_of
+from jax_triton.pallas.primitives import program_id
+from jax_triton.pallas.primitives import store

--- a/jax_triton/pallas/lowering.py
+++ b/jax_triton/pallas/lowering.py
@@ -1,0 +1,458 @@
+# Copyright 2022 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for lowering JAX primitives to Triton IR."""
+import dataclasses
+
+from typing import Any, Set
+
+import jax
+from jax import api_util
+from jax import core as jax_core
+from jax import linear_util as lu
+from jax import tree_util
+from jax import lax
+from jax._src import ad_util
+from jax._src import util
+from jax._src.lax.control_flow import for_loop
+from jax.interpreters import partial_eval as pe
+from jax.interpreters import xla
+from jax._src.state import primitives as sp
+from jax._src.state import discharge
+from jax._src.state import ShapedArrayRef
+from jax_triton.triton_call import get_triton_python_ir
+import jax.numpy as jnp
+import triton
+import triton.language as tl
+import numpy as np
+from triton.language import ir as tl_ir
+import triton._C.libtriton.triton as _triton
+
+from jax_triton.pallas import primitives
+
+map, unsafe_map = util.safe_map, map
+zip, unsafe_zip = util.safe_zip, zip
+
+@dataclasses.dataclass
+class TritonModuleContext:
+  name: str
+  ir_context: tl_ir.context
+  builder: tl_ir.builder
+  module: tl_ir.module
+
+@dataclasses.dataclass
+class TritonLoweringRuleContext:
+  context: TritonModuleContext
+  avals_in: Any
+  avals_out: Any
+
+  def __post_init__(self):
+    self.builder = self.context.builder
+
+@dataclasses.dataclass
+class TritonLoweringResult:
+  """Keeps pybind11 objects alive."""
+  ir_context: tl_ir.context
+  module: tl_ir.module
+  builder: tl_ir.builder
+
+triton_lowering_rules = {}
+
+def lower_jaxpr_to_triton_module(jaxpr: jax_core.Jaxpr, name: str) -> tl_ir.module:
+  ir_context = tl_ir.context()
+  builder = tl_ir.builder(ir_context)
+  module = tl_ir.module("", builder)
+  ctx = TritonModuleContext(name, ir_context, builder, module)
+
+  in_avals = [var.aval for var in jaxpr.invars]
+  triton_types = [get_triton_python_ir(x) for x in in_avals]
+  arg_types = [triton.compiler.str_to_ty(arg) for arg in triton_types]
+  assert len(jaxpr.outvars) == 0
+  ret_type = tl.void
+  prototype = tl.function_type(ret_type, arg_types)
+  out = prototype.to_ir(ctx.builder)
+  fn = ctx.module.get_or_insert_function(name, out)
+  args = []
+  for i in range(len(in_avals)):
+    fn.add_attr(i + 1, tl_ir.attribute(tl_ir.attribute_kind.aligned, 16))
+    ptr = tl.tensor(fn.args[i], prototype.param_types[i])
+    args.append(ptr)
+  fn.set_is_kernel(True)
+  insert_pt = ctx.builder.get_insert_block()
+  entry = tl_ir.basic_block.create(ctx.builder.context, "entry", fn)
+  ctx.builder.set_insert_block(entry)
+  () = lower_jaxpr_to_triton_ir(ctx, jaxpr, *args)
+  ctx.builder.ret_void()
+  ctx.builder.set_insert_block(insert_pt)
+  return TritonLoweringResult(ir_context, module, builder)
+
+def lower_jaxpr_to_triton_ir(ctx: TritonModuleContext, jaxpr: jax_core.Jaxpr,
+                             *args) -> tl_ir.module:
+
+  env = {}
+  def read_env(var: jax_core.Atom):
+    if type(var) is jax_core.Literal:
+      return tl.core._to_tensor(np.array(var.val).tolist(), builder=ctx.builder)
+    return env[var]
+
+  def write_env(var: jax_core.Var, val):
+    env[var] = val
+
+  map(write_env, jaxpr.invars, args)
+  for eqn in jaxpr.eqns:
+    invals = map(read_env, eqn.invars)
+    if eqn.primitive not in triton_lowering_rules:
+      raise NotImplementedError(eqn.primitive)
+    rule = triton_lowering_rules[eqn.primitive]
+    avals_in = [v.aval for v in eqn.invars]
+    avals_out = [v.aval for v in eqn.outvars]
+    rule_ctx = TritonLoweringRuleContext(ctx, avals_in, avals_out)
+    outvals = rule(rule_ctx, *invals, **eqn.params)
+    if eqn.primitive.multiple_results:
+      map(write_env, eqn.outvars, outvals)
+    else:
+      write_env(eqn.outvars[0], outvals)
+  return map(read_env, jaxpr.outvars)
+
+def _program_id_lowering_rule(ctx: TritonLoweringRuleContext, *, axis):
+  return tl.program_id(axis, _builder=ctx.builder)
+triton_lowering_rules[primitives.program_id_p] = _program_id_lowering_rule
+
+def _max_contiguous_lowering_rule(ctx: TritonLoweringRuleContext, x, *, values):
+  values = [tl.constexpr(v) for v in values]
+  return tl.max_contiguous(x, values, _builder=ctx.builder)
+triton_lowering_rules[primitives.max_contiguous_p] = _max_contiguous_lowering_rule
+
+def _multiple_of_lowering_rule(ctx: TritonLoweringRuleContext, x, *, values):
+  values = [tl.constexpr(v) for v in values]
+  return tl.multiple_of(x, values, _builder=ctx.builder)
+triton_lowering_rules[primitives.multiple_of_p] = _multiple_of_lowering_rule
+
+def _exp_lowering_rule(ctx: TritonLoweringRuleContext, a):
+  return tl.exp(a, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.exp_p] = _exp_lowering_rule
+
+def _logistic_lowering_rule(ctx: TritonLoweringRuleContext, a):
+  one_= tl.core._to_tensor(1., ctx.builder)
+  x = tl.exp(a.__neg__(_builder=ctx.builder), _builder=ctx.builder)
+  x = x.__add__(one_, _builder=ctx.builder)
+  x = one_.__truediv__(x, _builder=ctx.builder)
+  return x
+triton_lowering_rules[jax.lax.logistic_p] = _logistic_lowering_rule
+
+def _sin_lowering_rule(ctx: TritonLoweringRuleContext, a):
+  return tl.sin(a, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.sin_p] = _sin_lowering_rule
+
+def _cos_lowering_rule(ctx: TritonLoweringRuleContext, a):
+  return tl.cos(a, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.cos_p] = _cos_lowering_rule
+
+def _mul_lowering_rule(ctx: TritonLoweringRuleContext, a, b):
+  return a.__mul__(b, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.mul_p] = _mul_lowering_rule
+
+def _div_lowering_rule(ctx: TritonLoweringRuleContext, a, b):
+  floating_dtypes = {tl.float16, tl.float32, tl.float64, tl.bfloat16}
+  if a.dtype in floating_dtypes and b.dtype in floating_dtypes:
+    return a.__truediv__(b, _builder=ctx.builder)
+  return a.__floordiv__(b, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.div_p] = _div_lowering_rule
+
+def _iota_lowering_rule(ctx: TritonLoweringRuleContext, *, dtype, shape, dimension):
+  if dimension != 0:
+    raise NotImplementedError()
+  return tl.arange(0, shape[0], _builder=ctx.builder)
+triton_lowering_rules[jax.lax.iota_p] = _iota_lowering_rule
+
+def _add_lowering_rule(ctx: TritonLoweringRuleContext, a, b):
+  return a.__add__(b, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.add_p] = _add_lowering_rule
+triton_lowering_rules[ad_util.add_any_p] = _add_lowering_rule
+
+def _integer_pow_lowering_rule(ctx: TritonLoweringRuleContext, a, *, y):
+  if y == 2:
+    return a.__mul__(a, _builder=ctx.builder)
+  if y == 3:
+    return a.__mul__(a.__mul__(a, _builder=ctx.builder), _builder=ctx.builder)
+  return tl.libdevice.pow(a, y, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.integer_pow_p] = _integer_pow_lowering_rule
+
+def _tanh_lowering_rule(ctx: TritonLoweringRuleContext, a):
+  return tl.libdevice.tanh(a, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.tanh_p] = _tanh_lowering_rule
+
+def _min_lowering_rule(ctx: TritonLoweringRuleContext, a, b):
+  pred = a.__lt__(b, _builder=ctx.builder)
+  return tl.semantic.where(pred, a, b, ctx.builder)
+triton_lowering_rules[jax.lax.min_p] = _min_lowering_rule
+
+def _convert_element_type_lowering_rule(ctx: TritonLoweringRuleContext, a, *,
+                                        new_dtype, weak_type):
+  if new_dtype == jnp.float32:
+    new_dtype = tl.float32
+  elif new_dtype == jnp.float16:
+    new_dtype = tl.float16
+  elif new_dtype == jnp.bfloat16:
+    new_dtype = tl.bfloat16
+  return tl.semantic.cast(a, new_dtype, ctx.builder)
+triton_lowering_rules[jax.lax.convert_element_type_p] = _convert_element_type_lowering_rule
+
+def max_lowering_rule(ctx: TritonLoweringRuleContext, a, b):
+  pred = a.__gt__(b, _builder=ctx.builder)
+  return tl.semantic.where(pred, a, b, ctx.builder)
+triton_lowering_rules[jax.lax.max_p] = max_lowering_rule
+
+def ge_lowering_rule(ctx: TritonLoweringRuleContext, a, b):
+  return a.__ge__(b, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.ge_p] = ge_lowering_rule
+
+def select_n_lowering_rule(ctx: TritonLoweringRuleContext, pred, a, b):
+  return tl.semantic.where(pred, a, b, ctx.builder)
+triton_lowering_rules[jax.lax.select_n_p] = select_n_lowering_rule
+
+def _rem_lowering_rule(ctx: TritonLoweringRuleContext, a, b):
+  return a.__mod__(b, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.rem_p] = _rem_lowering_rule
+
+def _sub_lowering_rule(ctx: TritonLoweringRuleContext, a, b):
+  return a.__sub__(b, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.sub_p] = _sub_lowering_rule
+
+def _lt_lowering_rule(ctx: TritonLoweringRuleContext, a, b):
+  return a.__lt__(b, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.lt_p] = _lt_lowering_rule
+
+def _broadcast_in_dim_lowering_rule(ctx: TritonLoweringRuleContext, a, *, broadcast_dimensions, shape):
+  # Add dummy dimensions
+  if len(a.shape) != 1 or a.shape[0].value != 1:
+    a_shape_iter = iter(a.shape)
+    new_shape = [next(a_shape_iter) if i in broadcast_dimensions else 1
+        for i in range(len(shape))]
+    new_shape = tuple(tl.constexpr(v) for v in new_shape)
+    a = tl.reshape(a, new_shape, _builder=ctx.builder)
+  return tl.broadcast_to(a, list(shape), _builder=ctx.builder)
+triton_lowering_rules[jax.lax.broadcast_in_dim_p] = _broadcast_in_dim_lowering_rule
+
+def _squeeze_lowering_rule(ctx: TritonLoweringRuleContext, a, *, dimensions):
+  shape = [tl.constexpr(s) for s in ctx.avals_out[0].shape]
+  return tl.reshape(a, shape, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.squeeze_p] = _squeeze_lowering_rule
+
+def _offset_ptr(ptr, indices, shape, out_shape, builder):
+  strides = np.cumprod([1, *shape[::-1]])[:-1][::-1]
+  offset = None
+  for i, (idx, s, dim) in enumerate(zip(indices, strides, shape)):
+    size = tl.core._to_tensor(int(s), builder)
+    if isinstance(idx, slice):
+      if idx != slice(None):
+        raise NotImplementedError
+      idx = tl.arange(0, dim, _builder=builder)
+      if i > 0 and offset.shape != [1]:
+        idx = tl.reshape(idx, (*([tl.constexpr(1)] *
+          len(ptr.shape)), tl.constexpr(dim)), _builder=builder)
+        dst_shape = [*offset.shape, tl.constexpr(1)]
+        ret_ty = tl.block_type(offset.type.scalar, dst_shape)
+        offset = tl.tensor(builder.create_reshape(offset.handle, dst_shape), ret_ty)
+    idx = idx.__mul__(size, _builder=builder)
+    if offset is None:
+      offset = idx
+    else:
+      offset = offset.__add__(idx, _builder=builder)
+  if offset is not None:
+    ptr = ptr.__add__(offset, _builder=builder)
+  if ptr.shape != [1] and ptr.shape == [1, *out_shape]:
+    ptr = tl.reshape(ptr, map(tl.constexpr, out_shape), _builder=builder)
+  return ptr
+
+def _pack_indices(non_slice_idx, indexed_dims):
+  non_slice_idx_iter = iter(non_slice_idx)
+  return tuple(next(non_slice_idx_iter) if indexed else slice(None) for indexed
+               in indexed_dims)
+
+def _get_lowering_rule(ctx: TritonLoweringRuleContext, ptr, *non_slice_idx, indexed_dims):
+  idx = _pack_indices(non_slice_idx, indexed_dims)
+  avals_in = ctx.avals_in
+  avals_out = ctx.avals_out
+  if not isinstance(ptr.type, tl.pointer_type):
+    assert len(avals_in) == 1
+    return ptr
+  ptr = _offset_ptr(ptr, idx, avals_in[0].shape, avals_out[0].shape, ctx.builder)
+  return tl.load(ptr, _builder=ctx.builder)
+triton_lowering_rules[sp.get_p] = _get_lowering_rule
+
+def _masked_load_lowering_rule(ctx: TritonLoweringRuleContext, ptr,
+                               *non_slice_idx, indexed_dims, masked,
+                               eviction_policy, cache_modifier, is_volatile):
+  non_slice_idx, mask_other = util.split_list(non_slice_idx, [sum(indexed_dims)])
+  idx = _pack_indices(non_slice_idx, indexed_dims)
+  avals_in = ctx.avals_in
+  avals_out = ctx.avals_out
+  if not isinstance(ptr.type, tl.pointer_type):
+    assert len(avals_in) == 1
+    return ptr
+  ptr = _offset_ptr(ptr, idx, avals_in[0].shape, avals_out[0].shape, ctx.builder)
+  mask, other = None, None
+  if masked:
+    assert 0 < len(mask_other) <= 2
+    if len(mask_other) == 2:
+      mask, other = mask_other
+    elif len(mask_other) == 1:
+      mask, = mask_other
+  return tl.load(ptr, mask=mask, other=other, cache_modifier=cache_modifier,
+                 volatile=is_volatile, eviction_policy=eviction_policy,
+                 _builder=ctx.builder)
+triton_lowering_rules[primitives.load_p] = _masked_load_lowering_rule
+
+def _swap_lowering_rule(ctx: TritonLoweringRuleContext, ptr, value, *non_slice_idx, indexed_dims):
+  avals_in = ctx.avals_in
+  avals_out = ctx.avals_out
+  idx = _pack_indices(non_slice_idx, indexed_dims)
+  ptr = _offset_ptr(ptr, idx, avals_in[0].shape, avals_out[0].shape, ctx.builder)
+  mask = None
+  old_value = tl.load(ptr, mask=mask, _builder=ctx.builder)
+  tl.store(ptr, value, mask=mask, _builder=ctx.builder)
+  return old_value
+triton_lowering_rules[sp.swap_p] = _swap_lowering_rule
+
+def _masked_swap_lowering_rule(ctx: TritonLoweringRuleContext, ptr, value,
+                               *non_slice_idx, indexed_dims, masked,
+                               eviction_policy):
+  non_slice_idx, mask_other = util.split_list(non_slice_idx, [sum(indexed_dims)])
+  idx = _pack_indices(non_slice_idx, indexed_dims)
+  avals_in = ctx.avals_in
+  avals_out = ctx.avals_out
+  ptr = _offset_ptr(ptr, idx, avals_in[0].shape, avals_out[0].shape, ctx.builder)
+  mask = None
+  if masked:
+    assert len(mask_other) == 1
+    mask, = mask_other
+  return tl.store(ptr, value, mask=mask, eviction_policy=eviction_policy,
+                  _builder=ctx.builder)
+triton_lowering_rules[primitives.swap_p] = _masked_swap_lowering_rule
+
+def _addupdate_lowering_rule(ctx: TritonLoweringRuleContext, ptr, value,
+    *non_slice_idx, indexed_dims):
+  idx = _pack_indices(non_slice_idx, indexed_dims)
+  avals_in = ctx.avals_in
+  avals_out = ctx.avals_out
+  mask = None
+  ptr = _offset_ptr(ptr, idx, avals_in[0].shape, avals_out[0].shape, ctx.builder)
+  old_value = tl.load(ptr, mask=mask, _builder=ctx.builder)
+  tl.store(ptr, old_value.__add__(value, _builder=ctx.builder),
+           mask=mask, _builder=ctx.builder)
+  return []
+triton_lowering_rules[sp.addupdate_p] = _addupdate_lowering_rule
+
+def _dot_general_lowering(ctx: TritonLoweringRuleContext, a, b, *,
+    dimension_numbers, precision, preferred_element_type):
+  contract_dims, batch_dims = dimension_numbers
+  assert batch_dims == ((), ())
+  a_contract_dim, = contract_dims[0]
+  b_contract_dim, = contract_dims[1]
+  trans_a = a_contract_dim == 0
+  trans_b = b_contract_dim == 1
+  allow_tf32 = precision == lax.Precision.HIGH or precision == lax.Precision.DEFAULT
+  return tl.dot(a, b, _builder=ctx.builder, trans_a=trans_a, trans_b=trans_b,
+                allow_tf32=allow_tf32)
+triton_lowering_rules[jax.lax.dot_general_p] = _dot_general_lowering
+
+def _reduce_max_lowering(ctx: TritonLoweringRuleContext, a, *, axes):
+  assert len(axes) == 1
+  axis, = axes
+  return tl.max(a, axis=axis, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.reduce_max_p] = _reduce_max_lowering
+
+def _reduce_sum_lowering(ctx: TritonLoweringRuleContext, a, *, axes):
+  assert len(axes) == 1
+  axis, = axes
+  return tl.sum(a, axis=axis, _builder=ctx.builder)
+triton_lowering_rules[jax.lax.reduce_sum_p] = _reduce_sum_lowering
+
+def _xla_call_lowering_rule(ctx: TritonLoweringRuleContext, *args, call_jaxpr, **_):
+  return lower_jaxpr_to_triton_ir(ctx.context, call_jaxpr, *args)
+triton_lowering_rules[xla.xla_call_p] = _xla_call_lowering_rule
+
+def _for_lowering_rule(ctx: TritonLoweringRuleContext, *args, jaxpr,
+    which_linear, nsteps, reverse, unroll):
+  current_bb = ctx.builder.get_insert_block()
+  loop_bb = _triton.ir.basic_block.create(ctx.builder.context, "loop", current_bb.parent)
+  postloop_bb = _triton.ir.basic_block.create(ctx.builder.context, "postloop", current_bb.parent)
+  orig_loop_counter = loop_counter = tl.core._to_tensor(0, ctx.builder)
+
+  nsteps = tl.core._to_tensor(nsteps, ctx.builder)
+  pred = loop_counter.__lt__(nsteps, _builder=ctx.builder)
+  # If pred, we loop otherwise postloop
+  ctx.builder.cond_br(pred.handle, loop_bb, postloop_bb)
+
+  # Start populating the loop block
+  ctx.builder.set_insert_block(loop_bb)
+
+  instr = loop_bb.get_first_non_phi()
+  ctx.builder.set_insert_point((loop_bb, instr))
+
+  # Populate phi args for loop block (loop counter and values)
+  should_discharge = [not isinstance(a, ShapedArrayRef) for a in ctx.avals_in]
+  loop_counter = ctx.builder.create_phi(tl.int32.to_ir(ctx.builder), 2)
+  read_only = [for_loop._is_read_only(eff) for eff in
+               for_loop._get_ref_state_effects(jaxpr)[1:]]
+  lowering_args = []
+  for arg, sd, ro in zip(args, should_discharge, read_only):
+    if not sd or ro:
+      lowering_args.append(arg)
+      continue
+    lowering_args.append(tl.tensor(ctx.builder.create_phi(arg.type.to_ir(ctx.builder),
+                                                          2), arg.type))
+
+  loop_counter = loop_counter_phi = triton.language.tensor(loop_counter, tl.int32)
+  # Partially discharge state from jaxpr for non-pointers
+  discharged_jaxpr, () = discharge.discharge_state(jaxpr, (), should_discharge=[True, *should_discharge])
+  # Inline discharged jaxpr into loop block
+  ptr_args, _ = util.partition_list(should_discharge, lowering_args)
+  new_args = lower_jaxpr_to_triton_ir(ctx.context, discharged_jaxpr,
+                                      loop_counter, *lowering_args)
+  new_args = util.merge_lists(should_discharge, ptr_args, new_args)
+  # Increment loop and check pred + branch
+  loop_counter = loop_counter.__add__(1, _builder=ctx.builder)
+  pred = loop_counter.__lt__(nsteps, _builder=ctx.builder)
+  ctx.builder.cond_br(pred.handle, loop_bb, postloop_bb)
+
+  # Update phi nodes to point to outputs of loop block
+  bb = loop_counter_phi.handle.get_parent()
+  prec_bb, next_bb = bb.get_predecessors()
+  loop_counter_phi.handle.add_incoming(orig_loop_counter.handle, prec_bb)
+  loop_counter_phi.handle.add_incoming(loop_counter.handle, next_bb)
+  for ro, d, old_arg, new_arg, phi_arg in zip(read_only, should_discharge, args,
+                                              new_args, lowering_args):
+    if not d or ro:
+      continue
+    phi_arg.handle.add_incoming(old_arg.handle, prec_bb)
+    phi_arg.handle.add_incoming(new_arg.handle, next_bb)
+
+  # Start populating post loop arrgs
+  ctx.builder.set_insert_block(postloop_bb)
+
+  # Set up phi nodes and populate
+  post_args = []
+  for ro, d, old_arg, new_arg in zip(read_only, should_discharge, args, new_args):
+    if not d or ro:
+      post_args.append(new_arg)
+      continue
+    phi_arg = tl.tensor(ctx.builder.create_phi(new_arg.type.to_ir(ctx.builder), 2),
+                        new_arg.type)
+    phi_arg.handle.add_incoming(old_arg.handle, prec_bb)
+    phi_arg.handle.add_incoming(new_arg.handle, next_bb)
+    post_args.append(phi_arg)
+  return post_args
+triton_lowering_rules[for_loop.for_p] = _for_lowering_rule

--- a/jax_triton/pallas/pallas_call.py
+++ b/jax_triton/pallas/pallas_call.py
@@ -1,0 +1,146 @@
+# Copyright 2022 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for calling pallas functions from JAX."""
+from functools import partial
+
+from jax import api_util
+from jax import core as jax_core
+from jax import linear_util as lu
+from jax import tree_util
+from jax.interpreters import ad
+from jax.interpreters import partial_eval as pe
+from jax.interpreters import mlir
+from jax.interpreters import xla
+from jax._src import ad_util
+from jax._src.lib.mlir import ir
+from jax._src.lib.mlir.dialects import mhlo
+from jax._src import state
+from jax._src.util import (
+    split_list, safe_map, safe_zip)
+from jax._src.lax.control_flow import for_loop
+
+from triton._C.libtriton import triton as tc
+
+from jax_triton.triton_call import emit_triton_kernel_call, avals_to_layouts
+from jax_triton.pallas import lowering
+
+map, unsafe_map = safe_map, map
+zip, unsafe_zip = safe_zip, zip
+
+pallas_call_p = jax_core.Primitive('pallas_call')
+pallas_call_p.multiple_results = True
+
+pallas_call_p.def_impl(partial(xla.apply_primitive, pallas_call_p))
+
+def _pallas_call_abstract_eval(*avals, out_shapes, **_):
+  return map(lambda x: jax_core.ShapedArray(x.shape, x.dtype), out_shapes)
+pallas_call_p.def_abstract_eval(_pallas_call_abstract_eval)
+
+def _pallas_call_jvp_rule(primals, tangents, *, jaxpr, name, which_linear,
+    out_shapes, grid, debug, **metaparams):
+  nonzero_tangents = [not isinstance(t, ad_util.Zero) for t in tangents]
+  tangents = [ad.instantiate_zeros(t) if inst else t
+              for t, inst in zip(tangents, nonzero_tangents)]
+  tangents = [t for t in tangents if type(t) is not ad_util.Zero]
+  nonzero_tangents_with_outputs = nonzero_tangents + [True] * len(out_shapes)
+  closed_jaxpr = jax_core.ClosedJaxpr(jaxpr, ())
+  jvp_jaxpr_, _ = ad.jvp_jaxpr(closed_jaxpr, nonzero_tangents_with_outputs, [])
+  jvp_jaxpr, () = jvp_jaxpr_.jaxpr, jvp_jaxpr_.consts  # TODO consts
+  jvp_which_linear = which_linear + (True,) * len(tangents)
+  jvp_outshapes = (*out_shapes, *out_shapes)
+  invars, outvars = [], []
+  inputs = []
+  for i in range(len(jvp_jaxpr.invars)):
+    if i % 2 == 0:
+      # Primal
+      invars.append(jvp_jaxpr.invars[i])
+    else:
+      # Tangent
+      outvars.append(jvp_jaxpr.invars[i])
+  for i in range(len(primals)):
+    inputs.append(primals[i])
+  jvp_jaxpr = jvp_jaxpr.replace(invars=[*invars, *outvars])
+  out_flat = pallas_call_p.bind(*primals, *tangents, jaxpr=jvp_jaxpr,
+                                name=f"{name}_jvp",
+                                out_shapes=jvp_outshapes,
+                                which_linear=jvp_which_linear,
+                                grid=grid, debug=debug, **metaparams)
+  # `out_flat` includes constant inputs into the `for_loop` which are converted
+  # into outputs as well. We don't care about these in AD so we throw them out.
+  out_primals, out_tangents = split_list(out_flat, [len(out_flat) // 2])
+  return out_primals, out_tangents
+ad.primitive_jvps[pallas_call_p] = _pallas_call_jvp_rule
+
+
+def pallas_call_lowering(ctx: mlir.LoweringRuleContext, *in_nodes, jaxpr, name,
+                         out_shapes, which_linear, grid, num_warps, num_stages,
+                         debug, **metaparams):
+  del which_linear
+  lowering_result = lowering.lower_jaxpr_to_triton_module(jaxpr, name)
+  if debug:
+    lowering_result.module.print()
+  backend = tc.runtime.backend.CUDA
+  device = 0
+  name, asm, shared_mem = tc.code_gen.compile_ttir(backend, lowering_result.module, device,
+      num_warps, num_stages, {}, 0)
+  out_type = ir.TupleType.get_tuple([
+      ir.RankedTensorType.get(out_shape.shape, mlir.dtype_to_ir_type(out_shape.dtype))
+      for out_shape in ctx.avals_out])
+  i32_type = ir.IntegerType.get_signless(32)
+  descriptor, keepalive = emit_triton_kernel_call(
+      ctx, name, asm, shared_mem, num_warps=num_warps, grid=grid,
+      metaparams=metaparams, dump_binary_path=None)
+  ctx.module_context.add_keepalive(keepalive)
+  out = mhlo.CustomCallOp(
+            [out_type], in_nodes,
+            call_target_name=ir.StringAttr.get("triton_kernel_call"),
+            has_side_effect=ir.BoolAttr.get(False),
+            backend_config=ir.StringAttr.get(descriptor),
+            api_version=ir.IntegerAttr.get(i32_type, 1),
+            called_computations=ir.ArrayAttr.get([]),
+            operand_layouts=avals_to_layouts(ctx.avals_in),
+            result_layouts=avals_to_layouts(ctx.avals_out))
+  results = [mhlo.GetTupleElementOp(out, mlir.i32_attr(i)).result
+             for i in range(len(out_shapes))]
+  return results
+mlir.register_lowering(pallas_call_p, pallas_call_lowering)
+
+def pallas_call(f, out_shape, grid, *, debug=False, num_warps=4, num_stages=3,
+                **metaparams):
+  if isinstance(grid, int):
+    grid = (grid,)
+  name = f.__name__ if hasattr(f, "__name__") and f.__name__ else"func"
+  flat_out_shapes, out_tree = tree_util.tree_flatten(out_shape)
+  def wrapped(*args, **kwargs):
+    flat_args, _ = tree_util.tree_flatten((args, kwargs))
+    in_tree = tree_util.tree_structure((*args, *flat_out_shapes))
+    flat_avals = map(
+        jax_core.raise_to_shaped, map(jax_core.get_aval, flat_args))
+    flat_output_avals = [jax_core.ShapedArray(out_shape.shape, out_shape.dtype)
+        for out_shape in flat_out_shapes]
+    ptr_avals = [state.ShapedArrayRef(aval.shape, aval.dtype) for aval in flat_avals]
+    out_ptr_avals = [state.ShapedArrayRef(aval.shape, aval.dtype) for aval in flat_output_avals]
+    flat_fun, _ = api_util.flatten_fun_nokwargs(lu.wrap_init(f), in_tree)
+    jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(flat_fun, [*ptr_avals, *out_ptr_avals])
+    jaxpr = for_loop._hoist_consts_to_refs(jaxpr)
+
+    which_linear = (False,) * len(flat_args)
+    out_flat = pallas_call_p.bind(*consts, *flat_args, jaxpr=jaxpr, name=name,
+                                  which_linear=which_linear,
+                                  out_shapes=tuple(flat_out_shapes),
+                                  grid=grid, debug=debug, num_warps=num_warps,
+                                  num_stages=num_stages, **metaparams)
+    return tree_util.tree_unflatten(out_tree, out_flat)
+  return wrapped

--- a/jax_triton/pallas/primitives.py
+++ b/jax_triton/pallas/primitives.py
@@ -1,0 +1,141 @@
+# Copyright 2022 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for pallas-specific JAX primitives and functions."""
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+import jax
+from jax import core as jax_core
+from jax import lax
+from jax._src import ad_util
+from jax._src.util import safe_map, safe_zip, split_list
+from jax._src.state import primitives as state_primitives
+from jax.interpreters import ad
+import jax.numpy as jnp
+
+map, unsafe_map = safe_map, map
+zip, unsafe_zip = safe_zip, zip
+
+program_id_p = jax_core.Primitive("program_id")
+
+def program_id(axis):
+  return program_id_p.bind(axis=axis)
+
+def _program_id_abstract_eval(**_):
+  return jax_core.ShapedArray((), jnp.int32)
+program_id_p.def_abstract_eval(_program_id_abstract_eval)
+
+max_contiguous_p = jax_core.Primitive("max_contiguous")
+
+def max_contiguous(x, values):
+  if not isinstance(values, list):
+    values = [values]
+  return max_contiguous_p.bind(x, values=values)
+
+def _max_contiguous_abstract_eval(aval, **_):
+  return aval
+max_contiguous_p.def_abstract_eval(_max_contiguous_abstract_eval)
+
+multiple_of_p = jax_core.Primitive("multiple_of")
+
+def multiple_of(x, values):
+  if not isinstance(values, list):
+    values = [values]
+  return multiple_of_p.bind(x, values=values)
+
+def _multiple_of_abstract_eval(aval, **_):
+  return aval
+multiple_of_p.def_abstract_eval(_multiple_of_abstract_eval)
+
+load_p = jax_core.Primitive('masked_load')
+
+def _load_abstract_eval(ref_aval, *all_avals, indexed_dims: Tuple[bool],
+                        **params: Any):
+  idx_avals, _ = split_list(all_avals, [sum(indexed_dims)])
+  return state_primitives._get_abstract_eval(
+      ref_aval, *idx_avals, indexed_dims=indexed_dims)
+load_p.def_effectful_abstract_eval(_load_abstract_eval)
+
+def _load_jvp(primals: List[Any], tangents: List[Any], *, indexed_dims, **params):
+  ref_primal, *idx_and_rest_primals = primals
+  ref_tangent, *idx_and_rest_tangents = tangents
+  idx_primals, _ = split_list(idx_and_rest_primals, [sum(indexed_dims)])
+  _, rest_tangents = split_list(idx_and_rest_tangents, [sum(indexed_dims)])
+  return (load_p.bind(ref_primal, *idx_and_rest_primals,
+                      indexed_dims=indexed_dims, **params),
+          load_p.bind(ref_tangent, *idx_primals, *rest_tangents,
+                      indexed_dims=indexed_dims, **params))
+ad.primitive_jvps[load_p] = _load_jvp
+
+def _load_transpose(g, ref, *idx_and_rest, **params):
+  raise NotImplementedError
+ad.primitive_transposes[load_p] = _load_transpose
+
+swap_p = jax_core.Primitive('masked_swap')
+
+def _swap_abstract_eval(ref_aval, val_aval, *all_avals, indexed_dims: Tuple[bool],
+                        **_: Any):
+  idx_avals, _ = split_list(all_avals, [sum(indexed_dims)])
+  return state_primitives._swap_abstract_eval(
+      ref_aval, val_aval, *idx_avals, indexed_dims=indexed_dims)
+swap_p.def_effectful_abstract_eval(_swap_abstract_eval)
+
+def _swap_jvp(primals: List[Any], tangents: List[Any], *, indexed_dims, **params):
+  ref_primal, val_primal, *idx_and_rest_primals = primals
+  ref_tangent, val_tangent, *idx_and_rest_tangents = tangents
+  idx_primals, _ = split_list(idx_and_rest_primals, [sum(indexed_dims)])
+  _, rest_tangents = split_list(idx_and_rest_tangents, [sum(indexed_dims)])
+  val_tangent = ad_util.instantiate(val_tangent)
+  return (swap_p.bind(ref_primal, val_primal, *idx_and_rest_primals,
+                      indexed_dims=indexed_dims, **params),
+          swap_p.bind(ref_tangent, val_tangent, *idx_primals, *rest_tangents,
+                      indexed_dims=indexed_dims, **params))
+ad.primitive_jvps[swap_p] = _swap_jvp
+
+def _swap_transpose(g, ref, *idx_and_rest, **params):
+  raise NotImplementedError
+ad.primitive_transposes[swap_p] = _swap_transpose
+
+def load(x_ref, idx, *, mask=None, other=None, cache_modifier="",
+         eviction_poicy="", volatile=False):
+  idx, indexed_dims = state_primitives._unpack_idx(idx, x_ref.ndim)
+  args = idx
+  if mask is not None:
+    args = (*args, mask)
+  if other is not None:
+    assert mask is not None
+    args = (*args, other)
+  return load_p.bind(x_ref, *args, masked=True, cache_modifier=cache_modifier,
+                     eviction_policy=eviction_poicy, is_volatile=volatile,
+                     indexed_dims=indexed_dims)
+
+
+def store(x_ref, idx, val, *, mask=None, eviction_policy="") -> None:
+  idx, indexed_dims = state_primitives._unpack_idx(idx, x_ref.ndim)
+  args = idx
+  if mask is not None:
+    args = (*args, mask)
+  _ = swap_p.bind(x_ref, val, *args, masked=True, eviction_policy=eviction_policy,
+                  indexed_dims=indexed_dims)
+  return
+
+def dot(a, b, trans_a=False, trans_b=False, allow_tf32=True):
+  rhs_contract_dim = int(trans_b)
+  lhs_contract_dim = int(not trans_a)
+  return jax.lax.dot_general(
+      a, b, dimension_numbers=(((lhs_contract_dim,), (rhs_contract_dim,)), ((), ())),
+      precision=lax.Precision.HIGH if allow_tf32 else lax.Precision.HIGHEST,
+      preferred_element_type=None)

--- a/tests/pallas_test.py
+++ b/tests/pallas_test.py
@@ -1,0 +1,219 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import os
+import unittest
+
+os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import jax
+from jax import lax
+from jax import random
+from jax.config import config
+from jax._src.lax.control_flow.for_loop import for_loop
+import jax.numpy as jnp
+import jax_triton as jt
+from jax_triton import pallas as pl
+import numpy as np
+try:
+  import torch
+except ModuleNotFoundError:
+  torch = None
+
+config.parse_flags_with_absl()
+
+class PallasCallTest(parameterized.TestCase):
+
+  def test_add_one(self):
+    @functools.partial(
+        pl.pallas_call, out_shape=jax.ShapeDtypeStruct((), jnp.float32),
+        grid=1)
+    def add_one(x_ref, o_ref):
+      o_ref[()] = x_ref[()] + 1.
+
+    x = 0.
+    self.assertEqual(add_one(x), 1.)
+
+  def test_vector_indexing(self):
+    @functools.partial(
+        pl.pallas_call, out_shape=jax.ShapeDtypeStruct((), jnp.float32),
+        grid=1)
+    def index(x_ref, i_ref, o_ref):
+      o_ref[()] = x_ref[i_ref[()]]
+
+    x = jnp.arange(5.)
+    for i in range(5):
+      np.testing.assert_allclose(index(x, i), x[i])
+
+  def test_vector_slicing(self):
+    @functools.partial(
+        pl.pallas_call, out_shape=jax.ShapeDtypeStruct((2,), jnp.float32),
+        grid=1)
+    def index(x_ref, idx_ref, o_ref):
+      idx = idx_ref[()]
+      o_ref[:] = x_ref[idx]
+
+    x = jnp.arange(5.)
+    for i in range(4):
+      idx = jnp.arange(i, i + 2)
+      np.testing.assert_allclose(index(x, idx), x[idx])
+
+
+  @parameterized.named_parameters(*[
+    (f"m_{m}_n_{n}_k_{k}_dtype_{dtype}_bm_{block_size_m}_"
+     f"bn_{block_size_n}_bk_{block_size_k}_gm_{group_size_m}", m, n, k, dtype,
+     block_size_m, block_size_n, block_size_k, group_size_m)
+      for m in [512, 1024]
+      for k in [512]
+      for n in [512, 1024]
+      for dtype in ["float32", "float16"]
+      for block_size_m in [64, 128]
+      for block_size_n in [128, 256]
+      for block_size_k in [32]
+      for group_size_m in [8]
+      if block_size_m < m and block_size_n < n and block_size_k < k
+    ])
+  def test_matmul(self, m, n, k, dtype, bm, bn, bk, gm):
+
+    # TODO(sharadmv): expose this information in `jaxlib`
+    if torch is not None and torch.cuda.get_device_capability() < (7, 0):
+      raise unittest.SkipTest(
+          "Matmul only works on GPUs with capability >= sm70")
+
+    @functools.partial(
+        pl.pallas_call, out_shape=jax.ShapeDtypeStruct((m, n), jnp.float32),
+        grid=jt.cdiv(m, bm) * jt.cdiv(n, bn))
+    def matmul(x_ref, y_ref, o_ref):
+      pid = pl.program_id(axis=0)
+      num_pid_m = m // bm
+      num_pid_n = n // bn
+      num_pid_in_group = gm * num_pid_n
+      group_id = lax.div(pid, num_pid_in_group)
+      first_pid_m = group_id * gm
+      group_size_m = jnp.minimum(num_pid_m - first_pid_m, gm)
+      pid_m = first_pid_m + lax.rem(pid, group_size_m)
+      pid_n = lax.div(lax.rem(pid, num_pid_in_group), group_size_m)
+      idx_m = pid_m * bm + jnp.arange(bm)
+      idx_n = pid_n * bn + jnp.arange(bn)
+      idx_m = pl.max_contiguous(pl.multiple_of(idx_m, bm), bm)
+      idx_n = pl.max_contiguous(pl.multiple_of(idx_n, bn), bn)
+      acc = jnp.zeros((bm, bn), dtype=jnp.float32)
+      def body(i, acc_ref):
+        idx_k = i * bk + jnp.arange(bk)
+        x_idx = (
+            jax.lax.broadcast_in_dim(idx_m, (bm, bk), (0,)),
+            jax.lax.broadcast_in_dim(idx_k, (bm, bk), (1,)))
+        y_idx = (
+            jax.lax.broadcast_in_dim(idx_k, (bk, bn), (0,)),
+            jax.lax.broadcast_in_dim(idx_n, (bk, bn), (1,)))
+        x_block, y_block = x_ref[x_idx], y_ref[y_idx]
+        out = jnp.dot(x_block, y_block)
+        acc_ref[:, :] += out
+      acc = for_loop(k // bk, body, acc).astype(o_ref.dtype)
+      o_idx = (
+          jax.lax.broadcast_in_dim(idx_m, (bm, bn), (0,)),
+          jax.lax.broadcast_in_dim(idx_n, (bm, bn), (1,)),
+          )
+      o_ref[o_idx] = acc
+
+    k1, k2 = random.split(random.PRNGKey(0))
+    x = random.normal(k1, (m, k), dtype=dtype)
+    y = random.normal(k2, (k, n), dtype=dtype)
+    out, expected = matmul(x, y), jnp.matmul(x, y)
+    np.testing.assert_allclose(out, expected, atol=0.05, rtol=0.05)
+
+  @parameterized.named_parameters(*(
+      dict(testcase_name=f"{size}_{dtype}", size=size, dtype=dtype)
+      for size in [16, 32, 64]
+      for dtype in ["float32", "float16"]
+  ))
+  def test_dot(self, size, dtype):
+    # TODO(sharadmv): expose this information in `jaxlib`
+    if torch is not None and torch.cuda.get_device_capability() < (7, 0):
+      raise unittest.SkipTest(
+          "Matmul only works on GPUs with capability >= sm70")
+
+    @functools.partial(
+        pl.pallas_call,
+        out_shape=jax.ShapeDtypeStruct((size, size), dtype),
+        grid=1)
+    def dot(x_ref, y_ref, o_ref):
+      x = x_ref[:, :]
+      y = y_ref[:, :]
+      o_ref[:, :] = pl.dot(x, y)
+
+    k1, k2 = random.split(random.PRNGKey(0))
+    x = random.normal(k1, (size, size), dtype=dtype)
+    y = random.normal(k2, (size, size), dtype=dtype)
+    out, expected = dot(x, y), jnp.dot(x, y)
+    np.testing.assert_allclose(out, expected, atol=0.05, rtol=0.05)
+
+  @parameterized.named_parameters(*(
+      dict(testcase_name=f"{batch_size}_{size}_{block_size}_{dtype}",
+           batch_size=batch_size, size=size, block_size=block_size, dtype=dtype)
+      for batch_size in [1, 2, 4, 23]
+      for size in [1, 2, 129, 255, 256]
+      for block_size in [1, 2, 32, 64, 128, 256]
+      for dtype in ["float32"]
+      if size < block_size
+  ))
+  def test_softmax(self, batch_size, size, block_size, dtype):
+    @functools.partial(pl.pallas_call,
+        out_shape=jax.ShapeDtypeStruct((batch_size, size), dtype),
+        grid=batch_size)
+    def softmax(x_ref, o_ref):
+      row_idx = pl.program_id(0)
+      x_idx = jnp.arange(block_size)
+      row_idxs = (
+          lax.broadcast_in_dim(row_idx, (block_size,), ()),
+          x_idx)
+      mask = x_idx < x_ref.shape[1]
+      row = pl.load(x_ref, row_idxs, mask=mask, other=-float("inf"))
+      row_minus_max = row - jnp.max(row, axis=0)
+      numerator = jnp.exp(row_minus_max)
+      denominator = jnp.sum(numerator, axis=0)
+      softmax_output = numerator / denominator
+      pl.store(o_ref, row_idxs, softmax_output, mask=mask)
+
+    key = random.PRNGKey(0)
+    x = random.normal(key, [batch_size, size], dtype=dtype)
+    np.testing.assert_allclose(softmax(x), jax.nn.softmax(x, axis=-1),
+        atol=1e-5, rtol=1e-5)
+
+  @parameterized.parameters(*(
+      (size, block_size)
+      for size in [1, 2, 64, 129, 1021]
+      for block_size in [1, 2, 32, 64, 128]
+  ))
+  def test_masked_load_store(self, size, block_size):
+    @functools.partial(pl.pallas_call,
+        out_shape=(
+          jax.ShapeDtypeStruct((size,), jnp.float32)
+          ),
+        grid=jt.cdiv(size, block_size))
+    def add_one(x_ref, o_ref):
+      idx = pl.program_id(0) * block_size + jnp.arange(block_size)
+      mask = idx < x_ref.shape[0]
+      x = pl.load(x_ref, (idx,), mask=mask)
+      pl.store(o_ref, (idx,), x + 1., mask=mask)
+
+    key = random.PRNGKey(0)
+    x = random.normal(key, (size,))
+    np.testing.assert_allclose(add_one(x), x + 1., atol=1e-5, rtol=1e-5)
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/triton_call_test.py
+++ b/tests/triton_call_test.py
@@ -32,7 +32,15 @@ except ModuleNotFoundError:
 import jax_triton as jt
 
 config.parse_flags_with_absl()
-config.update("jax_enable_x64", True)
+
+
+def setUpModule():
+  config.update("jax_enable_x64", True)
+
+
+def tearDownModule():
+  config.update("jax_enable_x64", False)
+
 
 @triton.jit
 def add_kernel(x_ptr, y_ptr, output_ptr,
@@ -50,8 +58,8 @@ def add_kernel(x_ptr, y_ptr, output_ptr,
 @triton.jit
 def matmul_kernel(
     a_ptr, b_ptr, c_ptr, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr,
-    BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr):
+    BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr, GROUP_SIZE_M: tl.constexpr):
     stride_am = K
     stride_ak = 1
     stride_bk = N


### PR DESCRIPTION
Add `pallas`, a jaxpr "dialect" that lowers directly to Triton IR.

Previously, in `jax-triton`, users would write Triton kernels directly via the `triton` library (i.e. using `triton.jit`). This PR adds the ability to write Triton kernels in JAX directly, using `jax.numpy` and `jax.lax`.

Specifically, we allow users to express kernels using a *stateful* subset of JAX, which we call "pallas".

Example:
```python
import jax
from jax_triton import pallas as pl

def add_one_tanh_kernel(x_ref, o_ref):
  # x_ref, o_ref are *mutable* references (like Triton pointers)
  o_ref[i] = jnp.tanh(x_ref[i] + 1)

def add_one_tanh(x):
  return pl.pallas_call(add_one_tanh_kernel, out_shape=x, num_warps=4, num_stages=3, grid=x.shape[0])(x)

add_one_tanh(2.) # Runs a Triton kernel!
```

The reason why we might want to do this is that Pallas kernels *don't* involve any pointer arithmetic, only index arithmetic (things like strides are handled automatically!). Also, we can transform Pallas with JAX transformations (though no concrete applications of this yet).

Checkout the example code in `tests/pallas_test.py` and `examples/pallas`.