### PR TITLE
Add templating example

### DIFF
--- a/examples/pallas/templating.py
+++ b/examples/pallas/templating.py
@@ -1,0 +1,31 @@
+# Copyright 2022 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jax_triton import pallas as pl
+import jax.numpy as jnp
+
+def make_kernel(eltwise_kernel):
+  def add(x_ref, y_ref, o_ref):
+    x = pl.load(x_ref, ())
+    y = pl.load(y_ref, ())
+    pl.store(o_ref, (), eltwise_kernel(x + y))
+  return add
+
+kernel1 = make_kernel(lambda x: x * 2)
+kernel2 = make_kernel(jnp.exp)
+
+if __name__ == "__main__":
+  x = jnp.array(1.)
+  print(pl.pallas_call(kernel1, out_shape=x, grid=1)(x, x))
+  print(pl.pallas_call(kernel2, out_shape=x, grid=1)(x, x))

--- a/jax_triton/pallas/pallas_call.py
+++ b/jax_triton/pallas/pallas_call.py
@@ -15,6 +15,7 @@
 """Module for calling pallas functions from JAX."""
 from functools import partial
 
+import jax
 from jax import api_util
 from jax import core as jax_core
 from jax import linear_util as lu
@@ -123,6 +124,8 @@ def pallas_call(f, out_shape, grid, *, debug=False, num_warps=4, num_stages=3,
     grid = (grid,)
   name = f.__name__ if hasattr(f, "__name__") and f.__name__ else"func"
   flat_out_shapes, out_tree = tree_util.tree_flatten(out_shape)
+  flat_out_shapes = [jax.ShapeDtypeStruct(x.shape, x.dtype) for x in
+                     flat_out_shapes]
   def wrapped(*args, **kwargs):
     flat_args, _ = tree_util.tree_flatten((args, kwargs))
     in_tree = tree_util.tree_structure((*args, *flat_out_shapes))


### PR DESCRIPTION
Templating is hard in `triton` proper because it uses an AST-munger to convert Python into Triton IR. It can miss things like closed-over functions.

For example:
```python
import triton
import triton.language as tl
import jax_triton as jt
import jax.numpy as jnp

def make_triton_kernel(eltwise_kernel):
  @triton.jit
  def add(x_ptr, y_ptr, o_ptr):
    x = tl.load(x_ptr) 
    y = tl.load(y_ptr) 
    tl.store(o_ptr, eltwise_kernel(x + y))
  return add


@triton.jit  # Need to decorate this to be callable from another Triton kernel at all!
def mul2(x):
  return 2 * x

kernel = make_triton_kernel(mul2)

x = jnp.array(1.)
print(jt.triton_call(x, x, kernel=kernel, out_shape=x, grid=1))
```
We get the following error:
```
Traceback (most recent call last):
  File "/home/sharadmv/triton/python/triton/compiler.py", line 838, in make_triton_ir
    generator.visit(fn.parse())
  ...
  File "/home/sharadmv/triton/python/triton/compiler.py", line 131, in get_value
    raise ValueError(f'{name} is not defined')
ValueError: eltwise_kernel is not defined

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/sharadmv/jax-triton/examples/pallas/templating.py", line 22, in <module>
    print(jt.triton_call(x, x, kernel=kernel, out_shape=x, grid=1))
  File "/home/sharadmv/jax-triton/jax_triton/triton_call.py", line 225, in triton_call
    name, asm_map, shared_mem = compile_triton_func(
  File "/home/sharadmv/jax-triton/jax_triton/triton_call.py", line 131, in compile_triton_func
    asm, shared_mem, name = tc._compile(
  File "/home/sharadmv/triton/python/triton/compiler.py", line 892, in _compile
    module, _ = make_triton_ir(fn, signature, specialization, constants)
  File "/home/sharadmv/triton/python/triton/compiler.py", line 843, in make_triton_ir
    raise CompilationError(fn.src, node) from e
triton.compiler.CompilationError: at 4:18:
def add(x_ptr, y_ptr, o_ptr):
  x = tl.load(x_ptr) 
  y = tl.load(y_ptr) 
  tl.store(o_ptr, eltwise_kernel(x + y))
```

`pallas` on the other hand uses JAX's tracing machinery, which handles things like closures nicely. We can therefore use things like closures to template `pallas` functions. See the following working example:
```python
from jax_triton import pallas as pl
import jax.numpy as jnp

def make_kernel(eltwise_kernel):
  def add(x_ref, y_ref, o_ref):
    x = pl.load(x_ref, ()) 
    y = pl.load(y_ref, ()) 
    pl.store(o_ref, (), eltwise_kernel(x + y))
  return add

kernel1 = make_kernel(lambda x: x * 2)
kernel2 = make_kernel(jnp.exp)

x = jnp.array(1.)
print(pl.pallas_call(kernel1, out_shape=x, grid=1)(x, x))
print(pl.pallas_call(kernel2, out_shape=x, grid=1)(x, x))
```