### PR TITLE
Add basic documentation site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: ci
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install -r docs/requirements.txt
+      - run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # jax-triton
 
+![PyPI version](https://img.shields.io/pypi/v/jax-triton)
+
 The `jax-triton` repository contains integrations between [JAX](https://github.com/google/jax) and [Triton](https://github.com/openai/triton).
+
+Documentation can be found [here](https://jax-ml.github.io/jax-triton).
 
 *This is not an officially supported Google product.*
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,83 @@
+# JAX-Triton documentation
+
+JAX-Triton is a repository containing containing integrations between [JAX](https://github.com/google/jax)
+and [Triton](https://github.com/openai/triton).
+
+JAX is a Python library for accelerated numerical computing and Triton is a Python library and compiler for writing custom GPU kernels.
+When we put the two together, we get JAX-Triton, which enables writing custom GPU kernels using Triton that can be embedded inside of JAX programs.
+
+## Getting started
+
+### Installing JAX-Triton
+
+You can install JAX-Triton with `pip`. This will also install a compatible JAX and Triton.
+```bash
+$ pip install jax-triton
+```
+JAX-Triton only works with JAX on GPU, so you'll need to make sure you have a CUDA-compatible `jaxlib` installed.
+For example you could run:
+```bash
+$ pip install "jax[cuda11_cudnn82]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+```
+
+Check out the [JAX installation guide](https://github.com/google/jax#pip-installation-gpu-cuda) for details.
+
+### Quickstart
+
+The main function of interest is `jax_triton.triton_call` for applying Triton
+functions to JAX arrays, including inside `jax.jit`-compiled functions. For
+example, we can define [a kernel from the Triton
+tutorial](https://triton-lang.org/master/getting-started/tutorials/01-vector-add.html#sphx-glr-getting-started-tutorials-01-vector-add-py):
+
+```python
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def add_kernel(
+    x_ptr,
+    y_ptr,
+    output_ptr,
+    block_size: tl.constexpr,
+):
+  """Adds two vectors."""
+  pid = tl.program_id(axis=0)
+  block_start = pid * block_size
+  offsets = block_start + tl.arange(0, block_size)
+  mask = offsets < 8
+  x = tl.load(x_ptr + offsets, mask=mask)
+  y = tl.load(y_ptr + offsets, mask=mask)
+  output = x + y
+  tl.store(output_ptr + offsets, output, mask=mask)
+```
+
+Then we can apply it to JAX arrays using `jax_triton.triton_call`:
+
+```python
+import jax
+import jax.numpy as jnp
+import jax_triton as jt
+
+def add(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
+  out_shape = jax.ShapeDtypeStruct(shape=x.shape, dtype=x.dtype)
+  block_size = 8
+  return jt.triton_call(
+      x,
+      y,
+      kernel=add_kernel,
+      out_shape=out_shape,
+      grid=(x.size // block_size,),
+      block_size=block_size)
+
+x_val = jnp.arange(8)
+y_val = jnp.arange(8, 16)
+print(add(x_val, y_val))
+print(jax.jit(add)(x_val, y_val))
+```
+
+See [the examples
+directory](https://github.com/jax-ml/jax-triton/tree/main/examples), especially
+[fused_attention.py](https://github.com/jax-ml/jax-triton/blob/main/examples/fused_attention.py)
+and [the fused attention
+ipynb](https://github.com/jax-ml/jax-triton/blob/main/examples/JAX_%2B_Triton_Flash_Attention.ipynb).

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs==1.4.2
+mkdocstrings==0.19.1
+mkdocstrings-python==0.8.3
+
+jax[cpu]

--- a/docs/triton_call.md
+++ b/docs/triton_call.md
@@ -1,0 +1,10 @@
+# Calling Triton kernels from JAX
+
+The primary way of using JAX Triton is using `jax_triton.triton_call` to call handwritten Triton kernels
+from inside JIT-ted JAX programs.
+
+::: jax_triton.triton_call
+    options:
+      show_root_heading: true
+      show_source: false
+      show_signature: false

--- a/jax_triton/__init__.py
+++ b/jax_triton/__init__.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 """Library for JAX-Triton integrations."""
-from jax_triton.triton_call import triton_call
-from jax_triton.triton_call import triton_kernel_call_lib
-from jax_triton.triton_call import cdiv
-from jax_triton.triton_call import strides_from_shape
-from jax_triton.triton_call import next_power_of_2
+from jax_triton.triton_lib import triton_call
+from jax_triton.triton_lib import triton_kernel_call_lib
+from jax_triton.triton_lib import cdiv
+from jax_triton.triton_lib import strides_from_shape
+from jax_triton.triton_lib import next_power_of_2
 from jax_triton import pallas

--- a/jax_triton/pallas/lowering.py
+++ b/jax_triton/pallas/lowering.py
@@ -33,7 +33,7 @@ from jax._src import state
 from jax._src.state import primitives as sp
 from jax._src.state import discharge
 from jax._src.state import ShapedArrayRef
-from jax_triton.triton_call import get_triton_python_ir
+from jax_triton.triton_lib import get_triton_python_ir
 import jax.numpy as jnp
 import triton
 import triton.language as tl

--- a/jax_triton/pallas/pallas_call.py
+++ b/jax_triton/pallas/pallas_call.py
@@ -44,7 +44,7 @@ import numpy as np
 from triton._C.libtriton import triton as tc
 
 from jax_triton import triton_kernel_call_lib
-from jax_triton.triton_call import emit_triton_kernel_call, avals_to_layouts
+from jax_triton.triton_lib import emit_triton_kernel_call, avals_to_layouts
 from jax_triton.pallas import lowering
 from jax_triton.pallas import core as pallas_core
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,49 @@
+site_name: JAX-Triton
+site_description: The documentation for JAX-Triton
+site_author: Google
+
+repo_url: https://github.com/jax-ml/jax-triton
+repo_name: jax-ml/jax-triton
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+    logo: "material/vector-link"
+  palette:
+    # Palette toggle for light mode
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+  features:
+    - navigation.sections
+    - toc.integrate
+    - header.autohide
+
+markdown_extensions:
+- pymdownx.highlight:
+    anchor_linenums: true
+- pymdownx.inlinehilite
+- pymdownx.snippets
+- pymdownx.superfences
+
+plugins:
+- mkdocstrings:
+    handlers:
+      python:
+        import:
+        - https://installer.readthedocs.io/en/stable/objects.inv
+
+nav:
+  - "index.md"
+  - "triton_call.md"
+
+strict: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = "JAX + OpenAI Triton integration"
 readme = "README.md"
 requires-python = ">=3.7<3.10"
 dependencies = [
-  "jax>=0.3.15",
-  "triton>=2.0.0.dev20220720",
+  "jax>=0.4.1",
+  "triton==2.0.0.dev20221202",
 ]
 
 [build-system]


### PR DESCRIPTION
Adds a basic documentation site using `mkdocs` and [Material for Mkdocs](https://squidfunk.github.io/mkdocs-material/).