### PR TITLE
Upgrade triton dependency to dev20230822 nightly

### DIFF
--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -157,7 +157,7 @@ def compile_ttir_to_ptx_inplace(
   if num_stages is None:
     num_stages = 3 if compute_capability >= 75 else 2
   # TODO (jon-chuang): handle the Hopper case of num_ctas > 1 
-  # (CTAs are Thread Block Clusters in NVIDIA speak)
+  # (CTAs > 1 in Triton involve Thread Block Clusters only available on Hopper)
   num_ctas = 1 
 
   extra = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.9,<3.11"
 dependencies = [
   "absl-py>=1.4.0",
   "jax @ git+https://github.com/google/jax@a0c1265bbae2c3ec644d6181f23264b4794e9eac",
-  "triton-nightly @ https://aiinfra.pkgs.visualstudio.com/2692857e-05ef-43b4-ba9c-ccf1c22c437c/_packaging/07c94329-d4c3-4ad4-9e6b-f904a60032ec/pypi/download/triton-nightly/2.1.dev20230714011643/triton_nightly-2.1.0.dev20230714011643-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+  "triton-nightly @ https://aiinfra.pkgs.visualstudio.com/2692857e-05ef-43b4-ba9c-ccf1c22c437c/_packaging/07c94329-d4c3-4ad4-9e6b-f904a60032ec/pypi/download/triton-nightly/2.1.dev20230822000928/triton_nightly-2.1.0.dev20230822000928-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=39f23718220984746c7fc5831d65c2c990eaf2d755a1c16bcba24946515ef0f6"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Currently, Triton dep is 1.5 months old. 

While one should not attempt to update regularly, I think its about time to upgrade due to breaking API changes as well as benefit from Triton improvements (see for instance in https://github.com/google/jax/pull/17328#issuecomment-1705010065 - about 25% speedup in flash attention for the given tile size due to fixes on Triton side)