### PR TITLE
Replace Deprecated `abc` Decorators (#1)

### DIFF
--- a/jax_triton/experimental/fusion/jaxpr_rewriter.py
+++ b/jax_triton/experimental/fusion/jaxpr_rewriter.py
@@ -35,7 +35,8 @@ Success = matcher.Success
 
 class Node(matcher.Pattern, metaclass=abc.ABCMeta):
 
-  @abc.abstractproperty
+  @property
+  @abc.abstractmethod
   def parents(self) -> list[Node]:
     ...
 


### PR DESCRIPTION
The `@abstractproperty`, `@abstractclassmethod`, and `@abstractstaticmethod` decorators from `abc` has been [deprecated](https://docs.python.org/3/library/abc.html) since Python 3.3. This is because it's possible to use `@property`, `@classmethod`, and `@staticmethod`  in combination with `@abstractmethod`. 

Our changes look like the following:
```diff
 import abc

 class Foo:
-   @abc.abstractproperty
+   @property
+   @abc.abstractmethod
    def bar():
        ...
```

and similarly for `@abstractclassmethod` and `@abstractstaticmethod`.

<details>
  <summary>More reading</summary>

  * [https://docs.python.org/3/library/abc.html#abc.abstractproperty](https://docs.python.org/3/library/abc.html#abc.abstractproperty)
  * [https://docs.python.org/3/library/abc.html#abc.abstractclassmethod](https://docs.python.org/3/library/abc.html#abc.abstractclassmethod)
  * [https://docs.python.org/3/library/abc.html#abc.abstractstaticmethod](https://docs.python.org/3/library/abc.html#abc.abstractstaticmethod)
</details>
<!--{"type":"DRIP","codemod":"pixee:python/fix-deprecated-abstractproperty"}-->