### PR TITLE
Add CPU backend

### DIFF
--- a/jax_triton/__init__.py
+++ b/jax_triton/__init__.py
@@ -24,7 +24,6 @@ __all__ = [
     "__version_info__",
 ]
 
-from jax._src.lib import gpu_triton
 from jax_triton import utils
 from jax_triton.triton_lib import triton_call
 from jax.experimental.pallas import cdiv
@@ -32,18 +31,5 @@ from jax.experimental.pallas import next_power_of_2
 from jax.experimental.pallas import strides_from_shape
 from jax_triton.version import __version__
 from jax_triton.version import __version_info__
-
-try:
-  get_compute_capability = gpu_triton.get_compute_capability
-  get_serialized_metadata = gpu_triton.get_serialized_metadata
-except AttributeError:
-  raise ImportError(
-      "jax-triton requires JAX to be installed with GPU support. The "
-      "installation page on the JAX documentation website includes "
-      "instructions for installing a supported version:\n"
-      "https://jax.readthedocs.io/en/latest/installation.html"
-  )
-else:
-  del gpu_triton  # Not part of the API.
 
 # trailer

--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -52,17 +52,26 @@ try:
   import triton.language as tl
   from triton.runtime import autotuner
   import triton._C.libtriton as _triton
-  import triton.backends.nvidia.compiler as cb
 
   CAN_USE_TRITON = True
 except ModuleNotFoundError:
   pass
 
 try:
+  import triton.backends.nvidia.compiler as cb
+except ImportError:
+  cb = None
+
+try:
   import triton.backends.amd.compiler as hb
 except ImportError:
   hb = None
-  pass
+
+try:
+  import triton.backends.cpu.compiler as cpub
+
+except ImportError:
+  cpub = None
 
 
 os.environ["TRITON_CACHE_DIR"] = ""
@@ -170,6 +179,13 @@ def get_hip_backend(device, compute_capability):
   backend = hb.HIPBackend(target)
   return backend
 
+def get_cpu_backend(device, compute_capability):
+  arch = _triton.llvm.get_cpu_tripple()
+  arch = arch.split("-")[0]
+  target = cpub.GPUTarget('cpu', arch, 0)
+  backend = cpub.CPUBackend(target)
+  return backend
+
 @dataclasses.dataclass
 class CompilationResult:
   binary: str
@@ -181,8 +197,8 @@ class CompilationResult:
 
 def compile_ttir_inplace(
     ttir,
-    backend: [cb.CUDABackend | hb.HIPBackend],
-    options: [cb.CUDAOptions | hb.HIPOptions],
+    backend: cb.CUDABackend | hb.HIPBackend | cpub.CPUBackend,
+    options: cb.CUDAOptions | hb.HIPOptions | cpub.CPUOptions,
     compute_capability,
     platform
 ):
@@ -196,6 +212,13 @@ def compile_ttir_inplace(
 
   elif platform == 'rocm':
     return compile_ttir_to_hsaco_inplace(
+          ttir,
+          backend,
+          options,
+          compute_capability,
+    )
+  elif platform == 'cpu':
+    return compile_ttir_to_asm_inplace(
           ttir,
           backend,
           options,
@@ -319,6 +342,70 @@ def compile_ttir_to_hsaco_inplace(
       shared_mem_bytes=shared_mem_bytes,
       cluster_dims=cluster_dims,
       ttgir=ttgir,
+      llir=llir,
+  )
+
+def compile_ttir_to_asm_inplace(
+    ttir,
+    cpu_backend: cpub.CPUBackend,
+    cpu_options: cpub.CPUOptions,
+    compute_capability,
+) -> CompilationResult:
+  if cpu_options.debug:
+    print(ttir)
+  try:
+    metadata = {}
+    opt_ttir = cpu_backend.make_ttir(ttir, metadata, cpu_options)
+    ttcir = cpu_backend.make_ttcir(
+      opt_ttir,
+      metadata,
+      cpu_options
+    )
+  except RuntimeError as e:
+    ttir.dump()
+    raise ValueError("TTIR->TTCIR pass failed!") from e
+  if cpu_options.debug:
+    print(ttcir)
+  try:
+    tttcir = cpu_backend.make_tttcir(
+      ttcir,
+      metadata,
+      cpu_options
+    )
+  except RuntimeError as e:
+    ttcir.dump()
+    raise ValueError("TTCIR->TTTCIR pass failed!") from e
+  if cpu_options.debug:
+    print(tttcir)
+  try:
+    llir = cpu_backend.make_llir(
+      tttcir,
+      metadata,
+      cpu_options
+    )
+  except RuntimeError as e:
+    tttcir.dump()
+    raise ValueError("TTTCIR->LLIR pass failed!") from e
+  shared_mem_bytes = metadata["shared"]
+  if cpu_options.debug:
+    print(llir)
+  asm = cpu_backend.make_asm(
+    llir,
+    metadata,
+    cpu_options
+  )
+  if cpu_options.debug:
+    print(asm)
+  name = metadata["name"]
+  cluster_dims = metadata["cluster_dims"]
+  tttcir = str(tttcir) if _JAX_TRITON_DUMP_DIR else None
+  llir = str(llir) if _JAX_TRITON_DUMP_DIR else None
+  return CompilationResult(
+      binary=asm,
+      name=name,
+      shared_mem_bytes=shared_mem_bytes,
+      cluster_dims=cluster_dims,
+      ttgir=tttcir,
       llir=llir,
   )
 
@@ -690,6 +777,12 @@ mlir.register_lowering(
     platform="rocm",
 )
 
+mlir.register_lowering(
+    triton_kernel_call_p,
+    functools.partial(triton_kernel_call_lowering, get_cpu_backend),
+    platform="cpu",
+)
+
 class ShapeDtype(Protocol):
 
   @property
@@ -827,23 +920,84 @@ def triton_call(
   if input_output_aliases is None:
     input_output_aliases = {}
 
-  out_flat = triton_kernel_call_p.bind(
-      *array_args,
-      fn=kernel,
-      scalar_args=tuple(scalar_args),
-      name=name,
-      custom_call_target_name=custom_call_target_name,
-      out_shapes=tuple(flat_out_shapes),
-      grid=grid,
-      num_warps=num_warps,
-      num_stages=num_stages,
-      num_ctas=num_ctas,
-      compute_capability=compute_capability,
-      enable_fp_fusion=enable_fp_fusion,
-      input_output_aliases=tuple(input_output_aliases.items()),
-      zeroed_outputs=zeroed_outputs,
-      debug=debug,
-      serialized_metadata=serialized_metadata,
-      **metaparams,
-  )
+  if cb is not None or hb is not None:
+    out_flat = triton_kernel_call_p.bind(
+        *array_args,
+        fn=kernel,
+        scalar_args=tuple(scalar_args),
+        name=name,
+        custom_call_target_name=custom_call_target_name,
+        out_shapes=tuple(flat_out_shapes),
+        grid=grid,
+        num_warps=num_warps,
+        num_stages=num_stages,
+        num_ctas=num_ctas,
+        compute_capability=compute_capability,
+        enable_fp_fusion=enable_fp_fusion,
+        input_output_aliases=tuple(input_output_aliases.items()),
+        zeroed_outputs=zeroed_outputs,
+        debug=debug,
+        serialized_metadata=serialized_metadata,
+        **metaparams,
+    )
+  else:
+    if isinstance(kernel, autotuner.Autotuner):
+      for config in kernel.configs:
+        if config.pre_hook is not None:
+          raise NotImplementedError("`pre_hook` is not supported")
+
+    class Pointer:
+
+      def __init__(self, x):
+        self.x = x
+        self.dtype = x.dtype
+
+      def data_ptr(self):
+        return self.x.unsafe_buffer_pointer()
+
+    def to_triton_arg(arg):
+      if arg.ndim == 0:
+        dtypes = {
+          jnp.bool.dtype: bool,
+          jnp.int32.dtype: int,
+          jnp.int64.dtype: int,
+          jnp.float32.dtype: float,
+          jnp.float64.dtype: float,
+        }
+        if arg.dtype not in dtypes:
+          raise ValueError(f"Invalid argument {arg} with type {arg.dtype}.")
+        return dtypes[arg.dtype](arg)
+      else:
+        return Pointer(arg)
+
+    def callback(flat_args, outputs):
+      kernel[lambda meta: normalize_grid(grid, metaparams | meta)](
+          *map(to_triton_arg, flat_args),
+          *map(Pointer, outputs),
+          **metaparams,
+      )
+      return outputs
+
+    # FIXME(stephen-huan): doesn't take into account kernel's meta
+    config_zeroed_outputs = zeroed_outputs
+    if callable(zeroed_outputs):
+      config_zeroed_outputs = config_zeroed_outputs(metaparams)
+
+    output_input_aliases = {}
+    for input_idx, output_idx in input_output_aliases.items():
+      if output_idx in output_input_aliases:
+        # TODO(stephen-huan): not sure how to handle this properly
+        raise NotImplementedError(
+          "Multiple inputs aliased to the same output is not supported."
+        )
+      output_input_aliases[output_idx] = flat_args[input_idx]
+      if output_idx in config_zeroed_outputs:
+        flat_args[input_idx] = flat_args[input_idx].at[:].set(0)
+
+    out_shapes = tuple(flat_out_shapes)
+    outputs = [
+      output_input_aliases.get(i, jnp.zeros(shape.shape, shape.dtype))
+      for i, shape in enumerate(out_shapes)
+    ]
+    out_flat = jax.pure_callback(callback, out_shapes, flat_args, outputs)
   return tree_util.tree_unflatten(out_tree, out_flat)

--- a/tests/cluster_test.py
+++ b/tests/cluster_test.py
@@ -74,7 +74,7 @@ class ClusterTest(parameterized.TestCase):
         _dummy_fn(jnp.empty((16,)))
 
   def test_cluster_not_available(self):
-    if 'h100' in jax.devices()[0].device_kind.lower():
+    if 'h100' not in jax.devices()[0].device_kind.lower():
       self.skipTest('Clusters available only on H100s.')
 
     my_triton_call = functools.partial(jt.triton_call, num_ctas=2)

--- a/tests/triton_call_test.py
+++ b/tests/triton_call_test.py
@@ -29,6 +29,12 @@ import triton.language as tl
 
 config.parse_flags_with_absl()
 
+try:
+  jt.get_compute_capability(0)
+except AttributeError:
+  # TODO(stephen-huan): add in jaxlib
+  jt.get_compute_capability = lambda _: np.inf
+
 
 def setUpModule():
   config.update("jax_enable_x64", True)

--- a/tests/triton_call_test.py
+++ b/tests/triton_call_test.py
@@ -553,7 +553,7 @@ class TritonKernelCallTest(parameterized.TestCase):
             BLOCK_SIZE_M=32,
             BLOCK_SIZE_N=32,
             BLOCK_SIZE_K=32,
-            # K_EXACTLY_DIVISIBLE_BY_BLOCK=False,
+            K_EXACTLY_DIVISIBLE_BY_BLOCK=False,
         )
       except TypeError:
         pass  # Error thrown as the mocked method's return value is invalid.

--- a/tests/triton_test.py
+++ b/tests/triton_test.py
@@ -20,7 +20,10 @@ import jax_triton as jt
 import numpy as np
 import triton
 import triton.language as tl
-from triton.language.extra.cuda import libdevice
+try:
+  from triton.language.extra.cuda import libdevice
+except ImportError:
+  from triton.language.extra.cpu import libdevice
 
 
 @triton.jit


### PR DESCRIPTION
(_This is more of a issue/feature request than a PR, but since I have a working prototype I figured I'd share it_.)

Triton now has a CPU backend from [triton-cpu](https://github.com/triton-lang/triton-cpu), which compiles LLIR to assembly using LLVM. This PR adds support for this by using `jax.pure_callback` to wrap calling Triton kernels from Python (generating a XLA custom call). A proper implementation of this would add a openmp [cpu launcher](https://github.com/triton-lang/triton-cpu/blob/4e4e6b8d0a584d1ab26355c8c9b697c85472dbad/third_party/cpu/backend/driver.py#L115-L354) to jaxlib's [gpu_triton.py](https://github.com/jax-ml/jax/blob/c4d19ca83cdcfbf2d34e2affb86946da2f4773dc/jaxlib/gpu_triton.py) akin to [triton_kernels.cc](https://github.com/jax-ml/jax/blob/c4d19ca83cdcfbf2d34e2affb86946da2f4773dc/jaxlib/gpu/triton_kernels.cc) (unfortunately, the cpu backend doesn't seem to fit neatly into jaxlib's existing Triton abstractions, for example, it seems cuda/rocm are mutually exclusive since they overwrite the same names in `gpu_triton.py` while cpu can co-exist with gpu). I don't have enough familiarity with C++/jaxlib/xla to make this change myself, hence the feature request.

The motivation for adding a cpu backend is that it's faster than `TRITON_INTERPRET=1` and allows for `jax.jit`'ing Triton kernels like on gpu. In addition, it would possibly allow Pallas kernels to be ran on cpu without `interpret=True`, which is generally very slow. Pure JAX code can be ran on either cpu or gpu with no code modifications, and it'd be nice if this was also true for Triton/Pallas kernels (for debugging/prototyping, but also to run fast on cpu itself).

Known limitations of this PR:
- Since `jax.pure_callback` is used instead of a C++ XLA custom call, kernel launch overhead is relatively high
  - The codepath for the cpu backend is completely separate from gpu (doesn't use the custom call target `triton_kernel_call` or MLIR lowering `triton_kernel_call_lowering`) so the behavior is slightly different
- Although implemented, input-output aliases are probably not handled correctly
- `zeroed_outputs` doesn't receive meta parameters from Triton configurations
- The matmul tests are _extremely_ slow (which might be triton-cpu's fault as we're just dispatching to it)

Passes (and definitely completely overfit to) all tests except for those that count the number of compilations (as it doesn't use the MLIR lowering path) and `test_autotune_with_heuristics` since Triton evaluates the configuration multiple times.

```
========================================================================== short test summary info ===========================================================================
FAILED tests/triton_call_test.py::TritonKernelCallTest::test_autotune_with_heuristics - AssertionError: Lists differ: [True, True, True, True, True, True, True, True, True, True,[147 chars]True] != [True, True, True, False]
FAILED tests/triton_call_test.py::TritonKernelCallTest::test_kernel_cache_equivalent_kernels - AssertionError: 0 != 1
FAILED tests/triton_call_test.py::TritonKernelCallTest::test_kernel_cache_same_kernel_different_params - AssertionError: 0 != 1
FAILED tests/triton_call_test.py::TritonKernelCallTest::test_specialization - AssertionError: Expected 'ast_to_ttir' to have been called once. Called 0 times.
=========================================================== 4 failed, 155 passed, 6 skipped in 2965.08s (0:49:25) ============================================================
```

The first two commits are unrelated fixes to the tests which can be merged, and I've opened https://github.com/jax-ml/jax-triton/pull/321 with them verbatim.