### PR TITLE
Add Heuristics and Autotuner to type annotation

### DIFF
--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -703,7 +703,7 @@ class ShapeDtype(Protocol):
 
 def triton_call(
     *args: jax.Array | bool | int | float | np.float32,
-    kernel: triton.JITFunction,
+    kernel: triton.JITFunction | triton.runtime.Heuristics | triton.runtime.Autotuner,
     out_shape: ShapeDtype | Sequence[ShapeDtype],
     grid: GridOrLambda,
     name: str = "",


### PR DESCRIPTION
The kernel in `triton_call` can be `Heuristics` and `Autotuner` in addition to `JITFunction`.