### PR TITLE
fix for upstream triton

### DIFF
--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -365,7 +365,7 @@ def get_or_create_triton_kernel(
   for i, _, value in scalar_args:
     alignments[i] = value
   specialization = [
-      triton.runtime.jit.specialize_impl(
+      triton.runtime.jit.create_specialize_impl(lambda *_, **__: None)(
           types.SimpleNamespace(
               data_ptr=lambda: alignment, dtype=arg_dtype.removeprefix("*")
           ),


### PR DESCRIPTION
I think due to these Triton upstream changes:
https://github.com/triton-lang/triton/pull/6099
https://github.com/triton-lang/triton/pull/6109

users are seeing this error message:
AttributeError: module 'triton.runtime.jit' has no attribute 'specialize_impl'

e.g. #330

This PR might make the jax-triton code more robust to triton code changes. I haven't tested it yet...

But more broadly we should identify versions of Triton that jax-triton works with, have those in CI, and explain those in our install instructions. (At the moment, we only ensure jax-triton works with the version of Triton that XLA uses, i.e. [this commit](https://github.com/openxla/xla/blob/main/third_party/triton/workspace.bzl#L11).)
