### PR TITLE
Fix: Add oryx to optional deps and patch ROCm resource leak

### DIFF
--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -481,15 +481,22 @@ def get_or_create_triton_kernel(
             f" {compilation_result.cluster_dims}\n"
         )
 
-    kernel = triton_kernel_call_lib.TritonKernel(
-        kernel_name,
-        num_warps,
-        compilation_result.shared_mem_bytes,
-        compilation_result.binary,
-        ttir,
-        compute_capability,
-        *compilation_result.cluster_dims,
-    )
+    try:
+      kernel = triton_kernel_call_lib.TritonKernel(
+          kernel_name,
+          num_warps,
+          compilation_result.shared_mem_bytes,
+          compilation_result.binary,
+          ttir,
+          compute_capability,
+          *compilation_result.cluster_dims,
+      )
+
+    finally:
+      if platform == 'rocm':
+        # the hsaco path is a temporary file that should be removed.
+        # it's created in `compile_ttir_to_hsaco_inplace`.
+        os.remove(compilation_result.binary)
 
     _COMPILED_KERNEL_CACHE[cache_key] = kernel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ tests = [
   "pytest"
 ]
 
+experimental = [
+  "oryx"
+]
 
 [build-system]
 requires = ["setuptools", "setuptools-scm"]


### PR DESCRIPTION
I found these two issues while reading the repo, 


1) The experimental fusion module relies on oryx, but it was not listed as a dependency. I've added it to pyproject.toml under a new [project.optional-dependencies.experimental] group to make the dependency explicit for users of this feature.
2) The compile_ttir_to_hsaco_inplace function created a temporary file for the HSACO binary but never deleted it. I have wrapped the kernel instantiation in a try...finally block to ensure os.remove() is called on the temporary file, preventing a resource leak.

