### PR TITLE
Handle `TRITON_CACHE_DIR` changes

### DIFF
--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -66,7 +66,8 @@ except ImportError:
   pass
 
 
-os.environ["TRITON_CACHE_DIR"] = ""
+if "TRITON_CACHE_DIR" in os.environ:
+  del os.environ["TRITON_CACHE_DIR"]
 _JAX_TRITON_DUMP_DIR = os.environ.get("JAX_TRITON_DUMP_DIR")
 map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip


### PR DESCRIPTION
Integrates a change possibly missed in https://github.com/jax-ml/jax-triton/pull/344, the change to configuration handling in https://github.com/triton-lang/triton/pull/6467 (specifically https://github.com/triton-lang/triton/commit/850525276426fb9814399a8e0ee8fdf744229b02) from [this logic](https://github.com/triton-lang/triton/blob/819e9c8c29ad2ae96cbd93a1d3b8a3a0f4c8f09c/python/triton/runtime/cache.py#L64-L71) in v3.3.0 to

```python
            # create cache directory if it doesn't exist
            self.cache_dir = os.getenv("TRITON_CACHE_DIR", "").strip() or default_cache_dir()
            if self.cache_dir:
                self.cache_dir = os.path.join(self.cache_dir, self.key)
                self.lock_path = os.path.join(self.cache_dir, "lock")
                os.makedirs(self.cache_dir, exist_ok=True)
            else:
                raise RuntimeError("Could not create or locate cache dir")
```

to [this](https://github.com/triton-lang/triton/blob/c817b9b63d40ead1ed023b7663f5ea14f676f4bc/python/triton/runtime/cache.py#L48-L55) in v3.4.0.

```python
            # create cache directory if it doesn't exist
            self.cache_dir = knobs.cache.dir
            if self.cache_dir:
                self.cache_dir = os.path.join(self.cache_dir, self.key)
                self.lock_path = os.path.join(self.cache_dir, "lock")
                os.makedirs(self.cache_dir, exist_ok=True)
            else:
                raise RuntimeError("Could not create or locate cache dir")
```

Essentially, the difference is that if `TRITON_CACHE_DIR` was set to empty before, `""` would be false so the `default_cache_dir()` would be used (`~/.triton/cache`). With the new logic in `knobs`, `knobs.cache.dir` will simply take the value `""` which will cause `if self.cache_dir` to fail, raising the `RuntimeError`.

https://github.com/jax-ml/jax-triton/blob/3f0ac49e9500af39fc08dd97133f4eda16df51d2/jax_triton/triton_lib.py#L69

[knobs](https://github.com/triton-lang/triton/blob/c817b9b63d40ead1ed023b7663f5ea14f676f4bc/python/triton/knobs.py) contains the following.

<details>
<summary>knobs (excerpted) </summary>

```python
def getenv(key: str) -> Optional[str]:
    res = os.getenv(key)
    return res.strip() if res is not None else res

...

class env_base(Generic[SetType, GetType]):


    def __init__(self, key: str, default: Union[SetType, Callable[[], SetType]]) -> None:
        self.key = key
        self.default: Callable[[], SetType] = default if callable(default) else lambda: default


    def __set_name__(self, objclass: Type[object], name: str) -> None:
        self.name = name


    def __get__(self, obj: Optional[object], objclass: Optional[Type[object]]) -> GetType:
        if obj is None:
            raise AttributeError(f"Cannot access {type(self)} on non-instance")


        if self.name in obj.__dict__:
            return self.transform(obj.__dict__[self.name])
        else:
            return self.get()


    @property
    def env_val(self) -> str | None:
        return getenv(self.key)


    def get(self) -> GetType:
        env = self.env_val
        return self.transform(self.default() if env is None else self.from_env(env))

...

class cache_knobs(base_knobs):
    home_dir: env_str = env_str("TRITON_HOME", lambda: os.path.expanduser("~/"))


    dump_dir: env_str = env_str("TRITON_DUMP_DIR", lambda: cache.get_triton_dir("dump"))
    override_dir: env_str = env_str("TRITON_OVERRIDE_DIR", lambda: cache.get_triton_dir("override"))
    dir: env_str = env_str("TRITON_CACHE_DIR", lambda: cache.get_triton_dir("cache"))


    manager_class: env_class[CacheManager] = env_class("TRITON_CACHE_MANAGER", "CacheManager")
    remote_manager_class: env_class[RemoteCacheBackend] = env_class("TRITON_REMOTE_CACHE_BACKEND", "RemoteCacheBackend")


    def get_triton_dir(self, dirname: str) -> str:
        return os.path.join(self.home_dir, ".triton", dirname)
```

</details>

This causes the following code to fail (triton version of the add vectors tutorial) simply by importing `jax_triton`.

```python
import torch
import triton
import triton.language as tl
import jax_triton

DEVICE = "cuda"


@triton.jit
def add_kernel(x_ptr, y_ptr, output_ptr, block_size: tl.constexpr):
    """Adds two vectors."""
    pid = tl.program_id(axis=0)
    block_start = pid * block_size
    offsets = block_start + tl.arange(0, block_size)
    mask = offsets < 8
    x = tl.load(x_ptr + offsets, mask=mask)
    y = tl.load(y_ptr + offsets, mask=mask)
    output = x + y
    tl.store(output_ptr + offsets, output, mask=mask)


def add(x, y):
    output = torch.empty_like(x, device=DEVICE)
    n_elements = output.numel()
    grid = lambda meta: (triton.cdiv(n_elements, meta["block_size"]),)
    add_kernel[grid](x, y, output, block_size=1024)
    return output


if __name__ == "__main__":
    torch.manual_seed(0)
    x = torch.rand(8, device=DEVICE, dtype=torch.float32)
    y = torch.rand(8, device=DEVICE, dtype=torch.float32)
    add(x, y)
```

<details>
<summary>full traceback</summary>

```
Traceback (most recent call last):
  File "...", line 34, in <module>
    add(x, y)
  File "...", line 26, in add
    add_kernel[grid](x, y, output, block_size=1024)
  File "/nix/store/lzkr6v3bj9hbn9isvl0nvnyspqzycj1y-python3-3.12.11-env/lib/python3.12/site-packages/triton/runtime/jit.py", line 390, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/lzkr6v3bj9hbn9isvl0nvnyspqzycj1y-python3-3.12.11-env/lib/python3.12/site-packages/triton/runtime/jit.py", line 551, in run
    device = driver.active.get_current_device()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/lzkr6v3bj9hbn9isvl0nvnyspqzycj1y-python3-3.12.11-env/lib/python3.12/site-packages/triton/runtime/driver.py", line 30, in __getattr__
    return getattr(self._initialize_obj(), name)
                   ^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/lzkr6v3bj9hbn9isvl0nvnyspqzycj1y-python3-3.12.11-env/lib/python3.12/site-packages/triton/runtime/driver.py", line 26, in _initialize_obj
    self._obj = self._init_fn()
                ^^^^^^^^^^^^^^^
  File "/nix/store/lzkr6v3bj9hbn9isvl0nvnyspqzycj1y-python3-3.12.11-env/lib/python3.12/site-packages/triton/runtime/driver.py", line 12, in _create_driver
    return active_drivers[0]()
           ^^^^^^^^^^^^^^^^^^^
  File "/nix/store/lzkr6v3bj9hbn9isvl0nvnyspqzycj1y-python3-3.12.11-env/lib/python3.12/site-packages/triton/backends/nvidia/driver.py", line 719, in __init__
    self.utils = CudaUtils()  # TODO: make static
                 ^^^^^^^^^^^
  File "/nix/store/lzkr6v3bj9hbn9isvl0nvnyspqzycj1y-python3-3.12.11-env/lib/python3.12/site-packages/triton/backends/nvidia/driver.py", line 66, in __init__
    mod = compile_module_from_src(
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/lzkr6v3bj9hbn9isvl0nvnyspqzycj1y-python3-3.12.11-env/lib/python3.12/site-packages/triton/runtime/build.py", line 81, in compile_module_from_src
    cache = get_cache_manager(key)
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/lzkr6v3bj9hbn9isvl0nvnyspqzycj1y-python3-3.12.11-env/lib/python3.12/site-packages/triton/runtime/cache.py", line 246, in get_cache_manager
    return cls(_base32(key))
           ^^^^^^^^^^^^^^^^^
  File "/nix/store/lzkr6v3bj9hbn9isvl0nvnyspqzycj1y-python3-3.12.11-env/lib/python3.12/site-packages/triton/runtime/cache.py", line 55, in __init__
    raise RuntimeError("Could not create or locate cache dir")
RuntimeError: Could not create or locate cache dir
```

</details>

The previous behavior can be restored by clearing `TRITON_CACHE_DIR`, if it exists, to force the default directory to be used. I am not entirely sure if this is intended behavior.