### PR TITLE
0.5.0 add support for most Triton's features; large rewrite/refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# 0.5.0
+## Breaking changes
+- `float` now follows upstream convention and is represented as `fp32`, instead of old
+`fp64`
+- `zeroed_outputs=` parameter of `triton_call()` no longer supports zeroing of aliased
+input-output arguments.
+
+## New features / bugfixing
+- all possible backend initialization options is now fully supported and is handled
+similarly to the upstream (via single `kwargs` dictionary).
+- support for `@jt.kernel` decorator and a concise Triton-native form of launching a
+kernel with `kernel[grid](*args, **kwargs)` syntax.
+- arrays and other run-time values can now also be passed as a key-value pair to the
+launcher when `out_names=` is set or if a new dictionary form of `out_shape=` is used.
+- handling of kernel arguments specialization and defaults values is now fully delegated
+to the upstream Triton code, which enables full support for default values, kernel
+parameter annotations, related `@triton.jit()` arguments such as `do_not_specialize`,
+and also using tuples (including deeply nested), callables or strings as kernel
+arguments.
+- `out_shape`, `input_output_aliases` and `zeroed_outputs` handling is fully reworked
+to support nested tuples and now is based on a kernel signature coordinate system,
+instead of flat array indices, leading to a much clearer launcher syntax.
+- dictionary form of `input_output_aliases=` is deprecated, but is still fully supported
+- `CAN_USE_TRITON` guard is dropped due to obsolescence
+- tests grew 187 to 438 test cases
+
+
+# 0.4.0
+- Add support for Gluon kernels
+- fixed handling of `TRITON_CACHE_DIR` in line with the upstream treatment
+
+# 0.3.1
+- improve in-out parameters handling, getting rid of mandatory aliased parameters in
+kernel's signature
+- revamping and bugfixing to support `jax>=0.8.2`
+- monkeypatching Triton's `HIPBackend` to get rid of unnecessary dependency on `torch`

--- a/README.md
+++ b/README.md
@@ -65,10 +65,14 @@ print(add(x_val, y_val))
 print(jax.jit(add)(x_val, y_val))
 ```
 
-One could also use input-output parameters for kernels:
+Or better, we could use `@jt.kernel` decorator, capable of capturing `triton_call()`
+arguments in advance and allowing to use a familiar native Triton's
+`kernel[grid](*args, **kwargs)` syntax. Here's how to use it to cache kernel's
+input-output parameter specification:
 
 ```python
-
+@jt.kernel(input_output_aliases="y_inout_ptr")  # this tells triton_call() launcher that
+# argument of `y_inout_ptr` parameter is an in-out array
 @triton.jit
 def add_inplace_y_kernel(
     x_ptr,          # input vector
@@ -91,24 +95,89 @@ from functools import partial
 
 # jitting or jitting with donation isn't mandatory, but makes invocation more efficient.
 # Otherwise XLA would have to make a copy of each non-donated in-out argument before
-# calling a kernel, since JAX arrays by default are immutable.
+# calling a kernel, since JAX arrays are immutable by default.
 @partial(jax.jit, donate_argnames="y")
 def add_inplace_y(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
   block_size = 8
-  return jt.triton_call(
-      x,
-      y,            # explicit in-out argument
-      x.size,
-      kernel=add_inplace_y_kernel,
-      input_output_aliases={1: 0},  # input arg idx 1 (y) is the first output arg
-      out_shape=x,
-      grid=(x.size // block_size,),
-      block_size=block_size)
+  grid = x.size // block_size
+  return add_inplace_y_kernel[grid](x, y, x.size, out_shape=x, block_size=block_size)
 
 x_val = jnp.arange(8)
 y_val = jnp.arange(8, 16)
 print(add_inplace_y(x_val, y_val))
 ```
+
+Note that you could use advanced Triton features such as passing strings, tuples and
+callables, for example:
+
+```python
+from jax import random
+import numpy as np
+from triton.language.extra import libdevice
+from typing import NamedTuple
+import time
+
+class Function(NamedTuple):
+  fn: tl.constexpr
+  captured: tuple
+
+@triton.jit
+def func1(x_ptr, y_ptr: tl.const, SIZE: tl.constexpr):
+  off = tl.arange(0, SIZE)
+  x = tl.load(x_ptr + off)
+  y = tl.load(y_ptr + off)
+  x1 = libdevice.sin(x)
+  x2 = libdevice.cos(x)
+  z = x1 * x1 + x2 * x2
+  tl.store(x_ptr + off, z)
+  y = libdevice.asin(y) + libdevice.acos(y)
+  return z, libdevice.floor(2 * y)
+
+@triton.jit
+def floor_of_func(values, SIZE: tl.constexpr, FUNC_NAME: tl.constexpr):
+  off = tl.arange(0, SIZE)
+  return libdevice.floor(getattr(libdevice, FUNC_NAME)(values))
+
+@triton.jit
+def aggregate(Ptrs):
+  z = tl.zeros([], tl.float32)
+  for i in tl.static_range(len(Ptrs)):
+    z += Ptrs[i]
+  return z
+
+@jt.kernel
+@triton.jit
+def kernel(capture, out_ptr, SIZE: tl.constexpr, FUNC_NAME: tl.constexpr):
+  off = tl.arange(0, SIZE)
+  t1, t2 = capture.fn(*capture.captured, SIZE=SIZE)
+  t3 = floor_of_func(t1, SIZE=SIZE, FUNC_NAME=FUNC_NAME)
+  t4 = t2 * t3
+  result = aggregate((t4, t4 * t4)).to(tl.int32)
+  tl.store(out_ptr + off, result)
+
+size = 8
+k1, k2 = random.split(random.key(time.perf_counter_ns()), 2)
+x = random.uniform(k1, (size,), dtype=jnp.float32)
+y = random.uniform(k2, (size,), dtype=jnp.float32)
+
+fn = Function(func1, (x, y))
+out, x = kernel[(1,)](
+  fn,  # essentially a tuple of (func_name, (2 arrays in a subtuple))
+  SIZE=size,
+  FUNC_NAME="exp",
+  out_shape=jnp.zeros(size, dtype=jnp.int32),
+  input_output_aliases=("capture", 1, 0),  # a path inside `capture` argument, 0th
+  # element of 1st subtuple, i.e. `x`. Note that since this is a tuple, it
+  # references just a single element (or all its embedded arrays if it's a tuple,
+  # but in this invocation it references array `x`)
+)
+np.testing.assert_array_equal(out, jnp.full((size,), 42, dtype=jnp.int32))
+assert out.dtype == jnp.int32
+np.testing.assert_allclose(x, jnp.full((size,), 1.0, dtype=jnp.float32), rtol=5e-7)
+assert x.dtype == jnp.float32
+```
+
+For detailed information on `triton_call()` parameters, refer to its docstring.
 
 See [the examples
 directory](https://github.com/jax-ml/jax-triton/tree/main/examples), especially
@@ -116,7 +185,7 @@ directory](https://github.com/jax-ml/jax-triton/tree/main/examples), especially
 and [the fused attention
 ipynb](https://github.com/jax-ml/jax-triton/blob/main/examples/JAX_%2B_Triton_Flash_Attention.ipynb).
 
-Some other use-cases are also covered in [tests](https://github.com/jax-ml/jax-triton/tree/main/tests).
+Many use-cases are covered in [tests](https://github.com/jax-ml/jax-triton/tree/main/tests).
 
 ## Installation
 
@@ -129,7 +198,7 @@ Make sure you have a CUDA- or ROCm- compatible `jax` installed. For example you 
 $ pip install "jax[cuda12]"
 ```
 
-## Development
+## Development / Bleeding edge version
 
 To develop `jax-triton`, you can clone the repo with:
 ```bash
@@ -145,3 +214,28 @@ To run the `jax-triton` tests, you'll need `pytest`:
 $ pip install pytest
 $ pytest tests/
 ```
+
+## Known limitations (a non-exhaustive list)
+
+0. Due to JAX's custom call API restrictions, purely output parameters of a kernel
+should be defined last in the kernel's signature (ignoring constexpr's). Certain
+relaxations of this rule exist, but it's just simpler to always follow it by reordering
+kernel parameters.
+
+1. Be aware that a benign in the upstream Triton pattern of pre-allocating an empty
+buffer and passing it as `jax-triton`'s input-output buffer just to be only written to
+by the kernel, might have a cost of host -> device data copying in JAX. Use purely
+output arguments instead.
+
+2. Autotuner / heuristics might have support gaps, for example: `Config.pre_hook` /
+`Config.post_hook` hooks aren't implemented; custom `do_bench` / `perf_model` /
+`early_config_prune` / `top_k` on `triton.autotune` might not behave correctly.
+
+3. Triton Python-runtime features, such as `JITFunction.warmup`, `.preload` and others
+such as Interpreter mode, aren't supported.
+
+4. Might not work well on systems with several different GPU models.
+
+5. JAX-level transformations, such as `jax.grad`, `jax.jvp`, `jax.vjp` aren't supported
+on kernels.
+

--- a/jax_triton/__init__.py
+++ b/jax_triton/__init__.py
@@ -17,6 +17,7 @@
 __all__ = [
     "utils",
     "triton_call",
+    "kernel",
     "cdiv",
     "next_power_of_2",
     "strides_from_shape",
@@ -26,7 +27,7 @@ __all__ = [
 
 from jax._src.lib import gpu_triton
 from jax_triton import utils
-from jax_triton.triton_lib import triton_call
+from jax_triton.triton_lib import triton_call, kernel
 from jax.experimental.pallas import cdiv
 from jax.experimental.pallas import next_power_of_2
 from jax.experimental.pallas import strides_from_shape

--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -20,57 +20,58 @@ from collections.abc import Callable, Sequence
 import copy
 import dataclasses
 import functools
+from functools import cached_property
+import inspect
+import itertools
 import os
 import pprint
 import tempfile
-import types
 from typing import Any, Protocol, Union
 import zlib
 
-from absl import logging
 import jax
 from jax import tree_util
-from jax._src import core
-from jax._src import state
-from jax._src import util
+from jax._src import core, util
+from jax._src.interpreters import partial_eval as pe
 from jax._src.lib import gpu_triton as triton_kernel_call_lib
 import jax.extend as jex
-from jax.interpreters import ad
-from jax.interpreters import batching
-from jax.interpreters import mlir
-from jax.interpreters import xla
+from jax.interpreters import ad, batching, mlir, xla
 import jax.numpy as jnp
 import numpy as np
 
 
-CAN_USE_TRITON = False
-try:
-  import triton
-  from triton.compiler import compiler as tc
-  import triton.language as tl
-  from triton.runtime import autotuner
-  import triton._C.libtriton as _triton
-  import triton.backends.nvidia.compiler as cb
+import triton
+from triton.compiler import compiler as tc
+# import triton.language as tl
+from triton.runtime import autotuner
+import triton.runtime.jit as triton_runtime_jit
+import triton._C.libtriton as _triton
+import triton.backends.nvidia.compiler as cb
+import triton.backends.amd.compiler as hb
 
-  import triton.experimental.gluon._runtime as gl_runtime
-  from triton.experimental.gluon import language as gl
-
-  CAN_USE_TRITON = True
-except ModuleNotFoundError:
-  pass
-
-try:
-  import triton.backends.amd.compiler as hb
-except ImportError:
-  hb = None
-  pass
+import triton.experimental.gluon._runtime as gl_runtime
 
 
 if "TRITON_CACHE_DIR" in os.environ:
   del os.environ["TRITON_CACHE_DIR"]
+
 _JAX_TRITON_DUMP_DIR = os.environ.get("JAX_TRITON_DUMP_DIR")
 map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip
+
+Grid = Union[int, tuple[int], tuple[int, int], tuple[int, int, int]]
+GridOrLambda = Union[Grid, Callable[[dict[str, Any]], Grid]]
+
+# a coordinate of an element in kernel parameters coordinate space. The first int indexes
+# kernel parameter in order of its declaration in the signature, and the following ints
+# (if any) indexes into nested tuples inside the actual argument. So this is a kernel
+# call attribute, as it depends on actual argument values, not a kernel attribute (like
+# parameters are)
+# Triton calls a coordinate a path, so have to follow
+CanonicalKernelArgPath = tuple[int, ...]
+# CanonicalKernelArgPaths = tuple[CanonicalKernelArgPath, ...]
+KernelArgPath = tuple[int | str, *tuple[int, ...]]
+InOutSpec = int | str | tuple[int | str | KernelArgPath, ...]
 
 # b/447434580: Exceeding this limit will cause Triton to emit a single trap
 # instruction, which will cause the GPU to hang indefinitely. See
@@ -97,8 +98,62 @@ _JAX_TO_TRITON_TYPE_MAP = {
     jnp.dtype("bool"): "i1",
 }
 
-Grid = Union[int, tuple[int], tuple[int, int], tuple[int, int, int]]
-GridOrLambda = Union[Grid, Callable[[dict[str, Any]], Grid]]
+
+# Use of types is slightly messy here. First of all, Triton itself uses exact dtypes
+# for arrays, but for scalars (no matter if constexpr, or runtime), it accepts native
+# Python objects only. The actual type of a kernel parameter is determined from the
+# parameter type annotation only. So to feed specialization engine properly, we have to
+# typecast all scalars to Python types. Caveats:
+# 1. we must not typecast constexprs as it's a separate type influencing specialization.
+# 2. Triton's runtime specialization for scalars unconditionally turns all floats into
+# fp32. It's unclear if this is a bug or not - the respective code doesn't even have a
+# string to describe fp64. Probably Triton's kernel launcher doesn't support doubles,
+# but JAX's `create_scalar_parameter()` support doubles perfectly well. However, Triton
+# still makes binaries that expect floats only, so there's no point to handle it
+# differently.
+#
+# Fortunately, both (Triton and JAX) use the same (likely LLVM/MLIR based) type
+# identifiers, so the function below serves both goals - for Triton's specialization and
+# for JAX's launcher.
+def get_type_id(obj: Any) -> str:
+  """Returns a Triton/JAX type identifier for the given object. Expected to be used with
+  run-time values only. Constexprs (string are also constexprs only in Triton) don't
+  need type info."""
+  if hasattr(obj, "dtype"):
+    return _JAX_TO_TRITON_TYPE_MAP[obj.dtype]
+
+  if isinstance(obj, bool):  # True == isinstance(True, int) !!!
+    return "B"
+  if isinstance(obj, int):
+    if -(2**31) <= obj < 2**31:
+      return "i32"
+    elif 2**31 <= obj < 2**32:
+      return "u32"
+    elif -(2**63) <= obj < 2**63:
+      return "i64"
+    elif 2**63 <= obj < 2**64:
+      return "u64"
+    else:
+      raise ValueError(f"integer overflow representing {obj}")
+  if isinstance(obj, float):
+    return "fp32"  # Triton unconditionally treat all floats as fp32, see the note above
+  raise NotImplementedError(f"could not compute type name for {obj}: {type(obj)}")
+
+
+def to_python_type(arg: Any) -> Any:
+  """Typecasts a scalar to a native Python type."""
+  # Note that typecasting ints/floats to respective types also convert JAX's subclasses
+  # like TypedInt and TypedFloat, which choke nanobind's type caster in a default
+  # strict-mode.
+  if isinstance(arg, (bool, np.bool_)):
+    arg = bool(arg)
+  elif isinstance(arg, (int, np.integer)):
+    arg = int(arg)
+  elif isinstance(arg, (float, np.floating)):
+    arg = float(arg)
+  # else return as is and let it possibly, but not necessarily fail (constexprs and
+  # strings pass and the rest isn't expected to be here, so sparing cycles on that)
+  return arg
 
 
 def normalize_grid(grid: GridOrLambda, metaparams) -> tuple[int, int, int]:
@@ -115,35 +170,6 @@ def avals_to_layouts(avals):
   return [list(reversed(range(aval.ndim))) for aval in avals]
 
 
-def get_triton_type(obj: Any) -> str:
-  if isinstance(obj, (jax.core.ShapedArray, state.AbstractRef)):
-    return f"*{_JAX_TO_TRITON_TYPE_MAP[obj.dtype]}"
-  if isinstance(obj, (tl.constexpr, gl.constexpr)):
-    obj = obj.value
-  if isinstance(obj, bool):  # True == isinstance(True, int) !!!
-    return "B"
-  if isinstance(obj, int):
-    if -(2**31) <= obj < 2**31:
-      return "i32"
-    elif 2**31 <= obj < 2**32:
-      return "u32"
-    elif -(2**63) <= obj < 2**63:
-      return "i64"
-    elif 2**63 <= obj < 2**64:
-      return "u64"
-    else:
-      raise ValueError(f"integer overflow representing {obj}")
-  if isinstance(obj, float):
-    return "fp64"
-  if isinstance(obj, np.float32):
-    return "fp32"
-  if isinstance(obj, str):
-    return "str"
-  raise NotImplementedError(
-      f"could not compute type name for {obj}: {type(obj)}"
-  )
-
-
 triton_kernel_call_p = jex.core.Primitive("triton_kernel_call")
 triton_kernel_call_p.multiple_results = True
 triton_kernel_call_p.def_impl(
@@ -154,8 +180,7 @@ triton_kernel_call_p.def_impl(
 @triton_kernel_call_p.def_abstract_eval
 def triton_kernel_call_abstract_eval(*_, out_shapes, **__):
   return [
-      core.ShapedArray(out_shape.shape, out_shape.dtype)
-      for out_shape in out_shapes
+    core.ShapedArray(out_shape.shape, out_shape.dtype) for out_shape in out_shapes
   ]
 
 
@@ -170,10 +195,9 @@ def make_gpu_target_cuda(device, compute_capability):
 _IS_HIPBackend_PATCHED = False
 def _patch_hip_backend():
   """
-  This defuses a bomb planted into Triton's AMD-specific compilation path by
+  This fixes unconditional and totally unnecessary "import torch" in Triton's
+  AMD-specific compilation path added in
   https://github.com/triton-lang/triton/commit/37ff43c5efd6e1b84c00a599ba070a501181e832#diff-33c9a103282c05c9d9d213b94450ae7481b6db8c3c6d810f54f175b4735a3c72
-  In short: there's an unconditional and totally unnecessary "import torch" directive crashing
-  the code when torch isn't installed.
 
   Remove the patch once triton wheel package version is pinned to >= triton version with the fix.
   """
@@ -254,9 +278,7 @@ def compile_ttir_to_ptx_inplace(
     print(ttir)
   try:
     metadata = {}
-    opt_ttir = cuda_backend.make_ttir(
-        ttir, metadata, cuda_options, compute_capability
-    )
+    opt_ttir = cuda_backend.make_ttir(ttir, metadata, cuda_options, compute_capability)
     ttgir = cuda_backend.make_ttgir(
         opt_ttir,
         metadata,
@@ -353,31 +375,17 @@ def compile_ttir_to_hsaco_inplace(
   )
 
 
-_COMPILED_KERNEL_CACHE = {}  # TODO(cjfj): Convert to LRU cache?
+def make_backend(
+  make_gpu_target_func, compute_capability: int | None, num_ctas: int
+) -> tuple[triton.compiler.BaseBackend, triton.compiler.GPUTarget, int]:
+  """Resolves compute_capability and spawns triton's Backend and GPUTarget objects"""
 
-
-def get_or_create_triton_kernel(
-    make_gpu_target_func,
-    platform,
-    fn,
-    arg_dtypes,
-    scalar_args,
-    *,
-    num_warps,
-    num_stages,
-    num_ctas,
-    compute_capability,
-    enable_fp_fusion,
-    metaparams,
-    dump: bool,
-) -> tuple[triton_kernel_call_lib.TritonKernel, Any]:
-  if num_warps is None:
-    num_warps = 4
-  if num_stages is None:
-    num_stages = 3
   # TODO(sharadmv): handle multiple devices, right now we assume device 0
   # which is fine when we have multiple of the same GPU but this won't work in
-  # general.
+  # general. See also how Triton did this in JITFunction's
+  # `self.device_caches = defaultdict(self.create_binder)` -- it spawns a new set of
+  # precomputes for each new device with `x,y,.. = self.device_caches[device]` using the
+  # create_binder() factory function.
   device = 0
   if compute_capability is None:
     compute_capability = triton_kernel_call_lib.get_compute_capability(device)
@@ -387,132 +395,446 @@ def get_or_create_triton_kernel(
   gpu_target = make_gpu_target_func(device, compute_capability)
   backend = triton.compiler.make_backend(gpu_target)
 
-  signature = {fn.arg_names[i]: v for i, v in enumerate(arg_dtypes)}
-  # TODO(sharadmv,zhangqiaorjc): handle differently aligned pointers
-  # We assume that all arrays are aligned to 16 bytes, and Triton may use this
-  # assumption, unless array args are include in the `do_not_specialize` list.
-  alignments = [16] * len(arg_dtypes)
-  for i, _, _ in scalar_args:
-    alignments[i] = 0
-  specialize_impl = _triton.native_specialize_impl
-  is_const = False
-  do_specialize = True
-  specialization = [
-      specialize_impl(
-          backend,
-          types.SimpleNamespace(
-              data_ptr=lambda: alignment, dtype=arg_dtype.removeprefix("*")
-          ),
-          is_const,
-          do_specialize,
-          alignment > 0,
-      )
-      for arg_dtype, alignment in zip(arg_dtypes, alignments)
-  ]
-  attrs = {
-      (i,): backend.parse_attr(attr)
-      for i, (_, attr) in enumerate(specialization)
-  }
-  constants = dict(metaparams)
-  constants.update({k: None for _, k, v in scalar_args if v is None})
-  constants.update({fn.arg_names[i]: 1 for i, _, v in scalar_args if v == 1})
-  for constant in constants:
-    signature[constant] = "constexpr"
+  return backend, gpu_target, compute_capability
 
-  # Cache key should contain any parameter that can affect the compiler output.
-  cache_key = (
-      fn,
-      tuple(signature.items()),
-      tuple(specialization),
-      tuple(constants.items()),
-      num_warps,
-      num_stages,
-      num_ctas,
-      compute_capability,
-      enable_fp_fusion,
-  )
-  kernel = _COMPILED_KERNEL_CACHE.get(cache_key)
 
-  if kernel is None:
-    # First, check that the kernel signature and the reconstructed signature have the
-    # same number of parameters. A mismatch can occur due to differences in
-    # `triton_call(input_output_aliases=)` handling between jax-triton versions.
-    if len(fn.signature.parameters) != len(signature):
-      raise TypeError(
-        f"Number of parameters in the kernel '{fn}' signature "
-        f"({len(fn.signature.parameters)}: {fn.signature}) "
-        f"does not match reconstructed signature ({len(signature)}: {signature}). "
-        "If the kernel was working on an older version of jax-triton and its "
-        "triton_call() launcher uses `input_output_aliases` argument, note that "
-        "implicit output arguments are no longer required for aliased args."
+_BACKEND_OPTIONS_FIELD_NAMES = {
+  "cuda": frozenset(cb.CUDAOptions.__dataclass_fields__.keys()),
+  "hip": frozenset(hb.HIPOptions.__dataclass_fields__.keys()),
+}
+
+
+class JTKernel:
+  def __init__(self, kernel, triton_call_kwargs):
+    if not isinstance(
+      kernel,
+      (
+        triton.JITFunction,
+        gl_runtime.GluonJITFunction,
+        autotuner.Heuristics,
+        autotuner.Autotuner,
+        JTKernel,
+      ),
+    ):
+      raise ValueError(
+        "`kernel` must be a `JTKernel` or Triton's `JITFunction`, `GluonJITFunction`, `Heuristics` or `Autotuner` object."
       )
 
-    opts = {
-        "num_warps": num_warps,
-        "num_stages": num_stages,
-        "num_ctas": num_ctas,
-        "optimize_epilogue": False,
-        "debug": dump,
-        "enable_fp_fusion": enable_fp_fusion,
+    if isinstance(kernel, JTKernel):
+      triton_call_kwargs = {**kernel.triton_call_kwargs, **triton_call_kwargs}
+      kernel = kernel.kernel
+
+    self.kernel = kernel
+
+    if "grid" in triton_call_kwargs:
+      raise ValueError("grid must be provided as an indexing argument to this object")
+
+    # since this code works only once on a kernel declaration point, we could add as
+    # much validation as possible here, to avoid doing it on every kernel launch instead
+    if "out_names" in triton_call_kwargs:
+      # we rely on a user correctly specifying that the order of elements in "out_names"
+      # reflect that in the kernel's signature. Checking that here as much as possible
+      triton_call_kwargs = self._validate_out_names(kernel, triton_call_kwargs)
+
+    self.triton_call_kwargs = triton_call_kwargs
+
+  @staticmethod
+  def _validate_out_names(kernel, triton_call_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Validates as much as possible the order of elements in
+    triton_call_kwargs['out_names']"""
+    out_names = triton_call_kwargs["out_names"]
+    if isinstance(out_names, (str, int)):
+      out_names = (out_names,)
+    elif isinstance(out_names, list):  # won't do this in triton_call(), but here it
+      out_names = tuple(out_names)  # isn't expensive.
+    elif not isinstance(out_names, tuple):
+      raise ValueError("out_names must be a string, or a tuple of specific format")
+    triton_call_kwargs["out_names"] = out_names
+
+    jtfu = JTJITFunction(kernel)  # refactor this out if other validation funcs appear
+    arg_names = jtfu.arg_names
+    last_idx = -1
+    for i, out_elm in enumerate(out_names):
+      is_tuple = isinstance(out_elm, tuple)
+      if is_tuple and len(out_elm) <= 0:
+        raise ValueError(f"out_names[{i}] must be an nonempty tuple")
+      if is_tuple and any(not isinstance(e, int) for e in out_elm[1:]):
+        raise ValueError(
+          "A tuple form of out_names must contain only ints beyond the first element"
+        )
+      is_first_string = is_tuple and isinstance(out_elm[0], str)
+      if isinstance(out_elm, str) or is_first_string:
+        try:
+          param_idx = arg_names.index(out_elm[0] if is_first_string else out_elm)
+        except ValueError:
+          raise ValueError(f"out_names[{i}] must be a valid kernel parameter name")
+        # without args/kwargs we can't look deeper anyway
+      else:
+        param_idx = out_elm[0] if is_tuple else out_elm
+        if not isinstance(out_elm, int):
+          raise ValueError(f"out_names[{i}] must be an int or a string")
+
+      if param_idx <= last_idx:
+        raise ValueError(
+          "The order of elements in out_names must follow the kernel's signature"
+        )
+      last_idx = param_idx
+    return triton_call_kwargs
+
+  def __getitem__(self, grid):
+    return lambda *args, **kwargs: triton_call(
+      *args, kernel=self.kernel, grid=grid, **self.triton_call_kwargs, **kwargs
+    )
+
+
+def kernel(fn=None, **kwargs):
+  """
+  A decorator that wraps a Triton/Gluon kernel function and returns a JTKernel object
+  preserving kwargs to pass to triton_call() launcher.
+  Can be used in two ways:
+  - @jt.kernel
+    @triton.jit  # or @triton.experimental.gluon.jit
+    def kernel_func(x, y, z):
+      ...
+  - @jt.kernel(out_names="z")   # or any other set of key-value pairs for triton_call()
+    @triton.jit
+    def kernel_func(x, y, z):
+      ...
+  The JTKernel object can be used to launch the kernel with a given grid using a
+  familiar Triton syntax kernel_func[grid](x, y) (Note that output arguments are still
+  implicit and should not be passed to the launcher)
+  """
+  if len(kwargs) == 0 or fn is not None:
+    if fn is None:
+      raise ValueError("`kernel` decorator must be used with a kernel function")
+    return JTKernel(fn, kwargs)
+
+  return functools.partial(JTKernel, triton_call_kwargs=kwargs)
+
+
+class JTJITFunction:
+  """A wrapper around Triton's JITFunction/GluonJITFunction object to isolate the rest
+  of the code from Triton's internals and provide a unified interface to bits needed.
+
+  Additionally, it provides a persistence layer to ensure that a certain data doesn't
+  have to be re-created on each kernel launch. A user may assume that even when they
+  create a new JTJITFunction object for an object previously used JITFunction object,
+  the persistent data is reused.
+
+  Since we don't instantiate JTJITFunction objects the way JITFunction objects are
+  instantiated and JTJITFunction have a short lives, we have to store the data in the
+  very JITFunction object itself. For this we use custom attributes on the JITFunction
+  object, prefixed with `_jT_`. The capitalized letter `T` breaks conventions to reduce
+  a possibility of clashing with anything else. When we're ready to remove
+  `triton_call()` in favor of corresponding method of JTJITFunction to launch a kernel
+  similarly to how the upstream Triton does it, we'll be able to remove this since
+  JTJITFunction object will have a proper lifetime.
+  """
+
+  def __init__(
+    self,
+    fn: autotuner.Heuristics
+    | autotuner.Autotuner
+    | triton.JITFunction
+    | gl_runtime.GluonJITFunction,
+  ):
+    # peel off wrappers to get to the JITFunction object
+    if isinstance(fn, JTKernel):
+      fn = fn.kernel
+    if isinstance(fn, JTJITFunction):
+      fn = fn.fn
+    if isinstance(fn, autotuner.Autotuner):
+      fn = fn.fn
+    if isinstance(fn, autotuner.Heuristics):
+      fn = fn.fn
+
+    if not isinstance(fn, (triton.JITFunction, gl_runtime.GluonJITFunction)):
+      raise ValueError(
+        "`kernel` must be a Triton's `JITFunction`, `GluonJITFunction`, `Heuristics` or `Autotuner` object."
+      )
+    self.fn = fn
+
+  @cached_property
+  def arg_names(self) -> list[str]:
+    """Returns a list of the kernel parameter names in the order they are declared in
+    the kernel's signature."""
+    # JITFunction::arg_names is deprecated, as per comment
+    return (
+      self.fn.arg_names
+      if hasattr(self.fn, "arg_names")
+      else [p.name for p in self.fn.params]
+    )
+
+  @cached_property
+  def arg_name_to_index(self) -> dict[str, int]:
+    """Returns a dictionary mapping the kernel parameter names to their indices in the
+    kernel's signature."""
+    return {name: index for index, name in enumerate(self.arg_names)}
+
+  @property  # it's needed only for compiling once, so it's better have this like that
+  def params(self) -> list[triton.runtime.jit.KernelParam]:
+    return self.fn.params
+
+  @property
+  def is_gluon(self) -> bool:
+    return isinstance(self.fn, gl_runtime.GluonJITFunction)
+
+  @property
+  def signature(self) -> inspect.Signature:
+    return self.fn.signature
+
+  def _get_cached_kernel(
+    self,
+    compute_capability: int,
+    specialization: list[tuple[str, Any]],
+    kwargs: dict[str, Any],
+  ) -> tuple[str, triton_kernel_call_lib.TritonKernel | None]:
+    if "_cOmpute_capability" in kwargs:  # capitalization is intended!
+      raise ValueError("'_cOmpute_capability' key is reserved in the options/kwargs!")
+    kwargs["_cOmpute_capability"] = compute_capability
+
+    if not hasattr(self.fn, "_jT_kernel_cache_key"):
+      self.fn._jT_kernel_cache_key = {}
+
+    # two step key resolution is important for supporting callables
+    key = triton_runtime_jit.compute_cache_key(
+      self.fn._jT_kernel_cache_key, specialization, kwargs
+    )
+    del kwargs["_cOmpute_capability"]
+
+    if not hasattr(self.fn, "_jT_kernel_cache"):
+      self.fn._jT_kernel_cache = {}
+
+    return key, self.fn._jT_kernel_cache.get(key, None)
+
+  def _cache_kernel(
+    self,
+    key: str,
+    kernel: triton_kernel_call_lib.TritonKernel,
+    asm: dict | None = None,
+  ):
+    assert isinstance(self.fn._jT_kernel_cache, dict)
+    self.fn._jT_kernel_cache[key] = kernel
+    if asm is not None:
+      if not hasattr(self.fn, "_jT_asm"):
+        self.fn._jT_asm = {}
+      self.fn._jT_asm[key] = asm
+
+  @property
+  def asm(self) -> dict[str, dict] | None:
+    """Returns a dictionary of the assembly files for the kernel if these were saved
+    during compilation.
+    Not the best way to share access to that info, but likely no one needs it except for
+    our tests. If this needs a better support, we could make a getter to fetch at least
+    ttir from a corresponding triton_kernel_call_lib.TritonKernel object instead.
+    """
+    return self.fn._jT_asm if hasattr(self.fn, "_jT_asm") else None
+
+  @property
+  def compiled_kernels_cache_size(self) -> int:
+    return len(self.fn._jT_kernel_cache) if hasattr(self.fn, "_jT_kernel_cache") else 0
+
+  def _make_signature_constexprs(
+    self,
+    named_args: dict[str, Any],
+    sigvals: list[str],
+  ) -> tuple[dict[str, Any], dict[str, Any]]:
+    signature = dict(zip(self.arg_names, sigvals))
+
+    constexprs = triton_runtime_jit.find_paths_if(
+      sigvals, lambda _, val: val == "constexpr"
+    )
+    constexprs = {
+      path: triton_runtime_jit.get_iterable_path(list(named_args.values()), path)
+      for path in constexprs
     }
+    return signature, constexprs
 
-    options = backend.parse_options(opts)
+  @staticmethod
+  def _make_attrs_nonconstexprs_sigvals(
+    backend, specialization: list[tuple[str, Any]], named_args: dict[str, Any]
+  ) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    # We have to always make attributes, since we need them for launching the kernel
+    attrvals = [x[1] for x in specialization]
+    attrs = triton_runtime_jit.find_paths_if(attrvals, lambda _, x: isinstance(x, str))
+    attrs = {
+      k: backend.parse_attr(triton_runtime_jit.get_iterable_path(attrvals, k))
+      for k in attrs
+    }
+    # attrs keys are tuples of integers representing a path into the (possibly nested)
+    # kernel argument list as it is seen by the Triton compiler (i.e. including all
+    # constexprs and whatnot, - everything as in the signature)
 
-    kernel_hash = abs(hash(cache_key))
-    if _JAX_TRITON_DUMP_DIR:
-      os.makedirs(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}")
-      with open(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/config", "w") as f:
-        pprint.pprint(cache_key, stream=f)
-        pprint.pprint(options, stream=f)
-
-    context = _triton.ir.context()
-    _triton.ir.load_dialects(context)
-    backend.load_dialects(context)
-    codegen_fns = backend.get_codegen_implementation(options)
-
-    real_ASTSource = (
-      gl_runtime.GluonASTSource
-      if isinstance(fn, gl_runtime.GluonJITFunction)
-      else tc.ASTSource
+    sigvals = [x[0] for x in specialization]
+    non_constexprs = triton_runtime_jit.find_paths_if(
+      sigvals, lambda _, val: val != "constexpr"
     )
-    module = real_ASTSource(
-      fn, constexprs=constants, signature=signature, attrs=attrs
-    ).make_ir(gpu_target, options, codegen_fns, backend.get_module_map(), context)
+    non_constexprs = {
+      path: triton_runtime_jit.get_iterable_path(list(named_args.values()), path)
+      for path in non_constexprs
+    }
+    return attrs, non_constexprs, sigvals
 
-    ttir = str(module)
+  def _get_binder(
+    self, backend
+  ) -> Callable[
+    [Any, ..., Any], tuple[dict[str, Any], list[tuple[str, Any]], dict[str, Any]]
+  ]:
+    # This is important part needs to be fully understood.
+    # create_function_from_signature() is a very inventive optimization in Triton
+    # that one generates once per kernel a so called binder function that simultaneously
+    # and very efficiently:
+    # 1. assigns default values to all unspecified kernel arguments,
+    # 2. assembles a complete dict of parameter_name->value mapping for all arguments
+    # 3. runs a correct specialization pipeline for all arguments, respecting all
+    # user's annotations.
+    # 4. finds key-value elements of kwargs that don't have a match in the kernel
+    # signature.
+    # The dynamically generated binder function exists purely for performance — it
+    # avoids the overhead of branched algo of building the specialization and
+    # application of defaults on every kernel launch, while still computing the
+    # specialization tuples from the actual runtime argument values.
+    if not hasattr(self.fn, "_jT_binder"):
+      # In the upstream, a binder is per-device. Since JAX doesn't support mixed
+      # execution yet, we can safely ignore it.
+      self.fn._jT_binder = triton_runtime_jit.create_function_from_signature(
+        self.fn.signature, self.fn.params, backend
+      )
+    return self.fn._jT_binder
 
-    compilation_result = compile_ttir_inplace(
-        module, backend, options, compute_capability, platform
+  def get_or_create_triton_kernel(
+    self,
+    make_gpu_target_func,
+    platform: str,
+    args: list[Any],
+    *,
+    compute_capability: int | None,
+    kwargs: dict[str, Any],
+  ) -> tuple[triton_kernel_call_lib.TritonKernel, dict[str, Any], dict[str, Any]]:
+    num_warps = kwargs["num_warps"]
+    num_ctas = kwargs["num_ctas"]
+    assert all(
+      isinstance(v, int) for v in (num_warps, kwargs["num_stages"], num_ctas)
+    )  # internal sanity check
+
+    store_asm = False
+    if "_store_asm" in kwargs:
+      store_asm = kwargs["_store_asm"]
+      del kwargs["_store_asm"]  # this is JT internal, no need to leave it further
+
+    backend, gpu_target, compute_capability = make_backend(
+      make_gpu_target_func, compute_capability, num_ctas
     )
 
-    kernel_name = compilation_result.name
-    if _JAX_TRITON_DUMP_DIR:
-      with open(
-          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.ttir", "w"
-      ) as f:
-        f.write(ttir)
-      with open(
-          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.ptx", "w"
-      ) as f:
-        f.write(compilation_result.binary)
-      with open(
-          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.ttgir", "w"
-      ) as f:
-        f.write(compilation_result.ttgir)
-      with open(
-          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.llir", "w"
-      ) as f:
-        f.write(compilation_result.llir)
-      with open(
-          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.compile_info",
-          "w",
-      ) as f:
-        f.write(
-            f"{kernel_name}: shared_mem_bytes:"
-            f" {compilation_result.shared_mem_bytes}\n"
+    named_args, specialization, other_kwargs = self._get_binder(backend)(
+      *args, **kwargs
+    )
+    # named_args is complete dict of kernel param names -> actual values.
+    # other_kwargs is the kwargs with keys corresponding to kernel parameters removed
+    # specialization is a list[tuple[str, Any]], one entry per kernel parameter, that
+    # captures two things about each argument at call time:
+    #   1. Element 0 — the type string: e.g. "i32", "i64", "*fp16", "*ki32"
+    #     (pointer to const), "u1", "fp32", "constexpr", "tensordesc<...>".
+    #   2. Element 1 — the specialization value (the "key"): an attribute that may
+    #     trigger a separately compiled kernel variant. Currently possible values are:
+    #     - None — no runtime specialization (used for bools, floats, do_not_specialize
+    #         params)
+    #     - "D" — value/pointer is divisible by 16 (alignment hint)
+    #     - "" (empty string) — value/pointer is NOT divisible by 16
+    #     - The actual Python value itself — for constexpr parameters and int(1)
+    #     - A cache_key — for JITCallable (nested kernel) arguments. Note that in that
+    #         case the specialization value is a hash string (hopefully!!! lowercase).
+    #         Likely by a coincidence this doesn't hurt to `attrs` building later!
+    # The specialization values are determined at call time by native_specialize_impl in
+    # C++ (triton/python/src/specialize.cc).
+    # Specialization serves 3 goals: (1) affect kernel caching key, (2) discover
+    # additional vars to be turned into constexprs by the compiler, (3) source for the
+    # `attrs` spec.
+
+    attrs, non_constexprs, sigvals = self._make_attrs_nonconstexprs_sigvals(
+      backend, specialization, named_args
+    )
+
+    key, kernel = self._get_cached_kernel(
+      compute_capability, specialization, other_kwargs
+    )
+
+    if kernel is None:
+      # First, check that the kernel signature and the reconstructed signature have the
+      # same number of parameters. A mismatch can occur due to differences in
+      # `triton_call(input_output_aliases=)` handling between jax-triton versions.
+      if len(self.params) != len(named_args):
+        raise TypeError(
+          f"Number of parameters in the kernel '{self.fn}' signature "
+          f"({len(self.params)}: {self.signature}) "
+          f"does not match reconstructed signature ({len(named_args)}: {list(named_args.keys())}). "
+          "If the kernel was working on an older version of jax-triton and its "
+          "triton_call() launcher uses `input_output_aliases` argument, note that "
+          "implicit output arguments are no longer required for aliased args."
         )
 
-    kernel = triton_kernel_call_lib.TritonKernel(
+      signature, constexprs = self._make_signature_constexprs(named_args, sigvals)
+
+      backend_fields = _BACKEND_OPTIONS_FIELD_NAMES[gpu_target.backend]
+      unrecognized = set(kwargs.keys()) - set(named_args.keys()) - backend_fields
+      if len(unrecognized) > 0:
+        raise ValueError(
+          f"Unknown backend options: '{ {k: kwargs[k] for k in unrecognized} }' "
+          f"were found in kwargs! Known options are: {backend_fields}."
+        )
+
+      backend_options = backend.parse_options(kwargs)
+
+      if _JAX_TRITON_DUMP_DIR:
+        kernel_hash = abs(hash(key))
+        os.makedirs(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}")
+        with open(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/config", "w") as f:
+          pprint.pprint(key, stream=f)
+          pprint.pprint(backend_options, stream=f)
+
+      context = _triton.ir.context()
+      _triton.ir.load_dialects(context)
+      backend.load_dialects(context)
+      codegen_fns = backend.get_codegen_implementation(backend_options)
+
+      real_ASTSource = gl_runtime.GluonASTSource if self.is_gluon else tc.ASTSource
+      module = real_ASTSource(
+        self.fn, constexprs=constexprs, signature=signature, attrs=attrs
+      ).make_ir(
+        gpu_target, backend_options, codegen_fns, backend.get_module_map(), context
+      )
+
+      ttir = str(module)
+
+      # while triton_kernel_call_lib.TritonKernel() stores ttir internally,
+      # unfortunately, it doesn't provide access to it, so we have to store it manually
+      # elsewhere for proper testing.
+
+      compilation_result = compile_ttir_inplace(
+        module, backend, backend_options, compute_capability, platform
+      )
+
+      kernel_name = compilation_result.name
+      if _JAX_TRITON_DUMP_DIR:
+        with open(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.ttir", "w") as f:
+          f.write(ttir)
+        with open(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.ptx", "w") as f:
+          f.write(compilation_result.binary)
+        with open(
+          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.ttgir", "w"
+        ) as f:
+          f.write(compilation_result.ttgir)
+        with open(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.llir", "w") as f:
+          f.write(compilation_result.llir)
+        with open(
+          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.compile_info",
+          "w",
+        ) as f:
+          f.write(
+            f"{kernel_name}: shared_mem_bytes: {compilation_result.shared_mem_bytes}\n"
+          )
+
+      kernel = triton_kernel_call_lib.TritonKernel(
         kernel_name,
         num_warps,
         num_ctas,
@@ -520,246 +842,392 @@ def get_or_create_triton_kernel(
         compilation_result.binary,
         ttir,
         compute_capability,
+      )
+
+      asm = dict(ttir=ttir) if store_asm else None
+      self._cache_kernel(key, kernel, asm)
+
+    return kernel, attrs, non_constexprs
+
+
+def make_autotuner_configs(
+  fn: autotuner.Autotuner,
+  kwargs: dict[str, Any],
+  named_args: dict[str, Any],
+) -> list[triton.Config]:
+  """Make and prune redundant autotuner configs based on user-provided kwargs.
+
+  If any kwargs have been specified explicitly, we prune any configs that conflict.
+  The pruning serves a specific need in jax-triton's architecture: unlike native Triton
+  where autotuning happens dynamically at kernel launch, jax-triton must decide at
+  lowering/tracing time which configs to compile. If the user has already fixed certain
+  metaparameters (e.g., num_warps=4, BLOCK_SIZE=128), there's no point compiling or
+  benchmarking autotuner configs that specify different values for those same
+  parameters. The pruning eliminates those contradictory configs, reducing compilation
+  and benchmarking work.
+
+  Note that our implementation is more permissive than Triton's autotuner
+  implementation, which will throw an error if any keys match.
+  """
+  assert isinstance(fn, autotuner.Autotuner)
+
+  # Note this is different .arg_names than in JITFunction!
+  # key_idxs = [fn.arg_names.index(k) for k in fn.keys]
+  # if any(idx not in key_idxs for idx in scalar_args):
+  #  logging.warning(
+  #      "Auto-tuning key does not include all scalar arguments. "
+  #      "We may perform redundant auto-tuning."
+  #  )
+  # ^^^ The upstream doesn't care about this. Why should we?
+
+  prev_early_config_prune_fn = fn.early_config_prune
+
+  def prune_configs(configs, named_args, **conf_kwargs):
+    pruned_configs = []
+    for config in configs:
+      if config.pre_hook is not None:
+        raise NotImplementedError("`pre_hook` is not supported")
+
+      # Keep the config IFF for every user-provided kwargs(k->v), the config
+      # either doesn't specify k at all, or specifies the same value v. This ensures
+      # the config is coherent with explicit user choices
+      if all(config.kwargs.get(k, v) == v for k, v in kwargs.items()):
+        pruned_configs.append(config)
+    if prev_early_config_prune_fn is not None:
+      pruned_configs = prev_early_config_prune_fn(pruned_configs, named_args)
+    return pruned_configs
+
+  fn.early_config_prune = prune_configs
+  fn.nargs = named_args
+  configs = fn.prune_configs(kwargs)
+  return configs
+
+
+def make_configs_from_heuristics(
+  fn: autotuner.Heuristics,
+  configs: list[triton.Config],
+  orig_kwargs: dict[str, Any],
+  named_args: dict[str, Any],
+) -> list[triton.Config]:
+  """Applies heuristics to the configs and returns the updated configs."""
+  assert isinstance(fn, autotuner.Heuristics)
+
+  updated_configs = []
+  for config in configs:
+    kwargs = config.kwargs.copy()
+    for name, heuristic in fn.values.items():
+      kwargs[name] = heuristic({**named_args, **orig_kwargs, **kwargs})
+    updated_config = copy.copy(config)
+    updated_config.kwargs = kwargs
+    updated_configs.append(updated_config)
+  return updated_configs
+
+
+def make_kernel_params(
+  ctx,
+  outputs_offset: int,
+  kwargs: dict[str, Any],
+  grid,
+  zeroed_outputs,
+  configs: list[triton.Config],
+) -> list[dict[str, Any]]:
+  """Make kernel call parameters for each config."""
+  zeroed_outputs_callable = callable(zeroed_outputs)
+
+  kernel_params = []
+  for config in configs:
+    config_metaparams = {**kwargs, **config.kwargs}
+    # filling back backend related config params
+    config_metaparams["num_warps"] = config.num_warps
+    config_metaparams["num_stages"] = config.num_stages
+    config_metaparams["num_ctas"] = config.num_ctas
+    if config.maxnreg is None:
+      if "maxnreg" in config_metaparams:
+        del config_metaparams["maxnreg"]
+    else:
+      config_metaparams["maxnreg"] = config.maxnreg
+
+    config_grid = normalize_grid(grid, config_metaparams)
+
+    config_zeroed_outputs = (
+      zeroed_outputs(config_metaparams) if zeroed_outputs_callable else zeroed_outputs
     )
 
-    _COMPILED_KERNEL_CACHE[cache_key] = kernel
+    # zeroed_params_with_sizes is a dict raw_array_idx -> aval_size_bytes
+    # config_zeroed_outputs is a list of ordinal numbers of output arguments
+    zeroed_params_with_sizes = {
+      i + outputs_offset: aval_size_bytes(ctx.avals_out[i])
+      for i in config_zeroed_outputs
+    }
 
-  return kernel, attrs
+    kernel_params.append(
+      dict(
+        metaparams=config_metaparams,
+        grid=config_grid,
+        zeroed_params_with_sizes=zeroed_params_with_sizes,
+      )
+    )
+  return kernel_params
+
+
+def convert_zeroed_outputs(
+  jtfu: JTJITFunction,
+  kwargs: dict[str, Any],
+  zeroed_outputs: Sequence[InOutSpec] | Callable[[dict[str, Any]], Sequence[InOutSpec]],
+) -> tuple[int, ...]:
+  idx2name = jtfu.arg_names
+  assert zeroed_outputs
+
+  def _unwrap_compound(arg: Any) -> tuple[int, ...]:
+    if not isinstance(arg, tuple):
+      raise ValueError(
+        f"Element of zeroed_outputs must reference an array or a tuple of arrays. Found {arg} of type {type(arg)}"
+      )
+    flat, _ = tree_util.tree_flatten(arg)
+    assert all(isinstance(elm, JTArray) for elm in flat), (
+      "All elements of a compound must be arrays"
+    )
+    return tuple(elm.index for elm in flat)
+
+  def _unwrap(elm) -> tuple[int, ...]:
+    """For a single element of zeroed_outputs returns raw indices of all output arrays
+    it corresponds to"""
+    is_int = isinstance(elm, int)
+    if isinstance(elm, (int, str)):
+      arg_name = idx2name[elm] if is_int else elm
+      arg = kwargs[arg_name]
+      # we could perhaps have a check for it being output argument too by modifying JTArray
+      if isinstance(arg, JTArray):
+        return (arg.index,)
+      return _unwrap_compound(arg)
+    elif isinstance(elm, (tuple, list)):
+      if not elm:
+        raise ValueError("Empty tuple or list is not a valid element of zeroed_outputs")
+      top_elm = elm[0]
+      if not isinstance(top_elm, (int, str)):
+        raise ValueError(
+          "First element of a tuple or list in zeroed_outputs must be an int or a str"
+        )
+      arg_name = idx2name[top_elm] if isinstance(top_elm, int) else top_elm
+      arg = (
+        kwargs[arg_name]
+        if len(elm) == 1
+        else triton_runtime_jit.get_iterable_path(kwargs[arg_name], elm[1:])
+      )
+      if isinstance(arg, JTArray):
+        return (arg.index,)
+      return _unwrap_compound(arg)
+    else:
+      raise ValueError(f"Invalid element of zeroed_outputs: {elm}")
+
+  if callable(zeroed_outputs):
+    orig_zeroed = zeroed_outputs
+    zeroed_outputs = lambda kw: tuple(
+      itertools.chain.from_iterable(map(_unwrap, orig_zeroed(kw)))
+    )
+  else:
+    zeroed_outputs = tuple(itertools.chain.from_iterable(map(_unwrap, zeroed_outputs)))
+
+  return zeroed_outputs
+
+
+def add_output_args(
+  jtfu: JTJITFunction,
+  ctx,
+  out_info: tuple[int, tree_util.PyTreeDef],
+  args: list[Any],
+  kwargs: dict[str, Any],
+) -> dict[str, Any]:
+  """Add output arguments to the argument list/dictionary."""
+  num_pure_outputs, pure_out_tree = out_info
+  assert num_pure_outputs <= len(ctx.avals_out)
+
+  outputs = tree_util.tree_unflatten(
+    pure_out_tree, (JTArray(ctx.avals_out, i) for i in range(num_pure_outputs))
+  )
+  # outputs is a dict mapping out-spec->possibly nested structure of 1 or many JTArrays
+
+  idx2name = jtfu.arg_names
+  for out_spec, arrays in outputs.items():
+    assert isinstance(out_spec, tuple)
+    top_idx = out_spec[0]
+    assert isinstance(top_idx, int)
+    arg_name = idx2name[top_idx]
+    if top_idx < len(args):
+      raise ValueError(f"Output argument idx {top_idx}=>{arg_name} mustn't be in args")
+    if len(out_spec) == 1:
+      if arg_name in kwargs:
+        raise ValueError(f"Output argument {arg_name} mustn't be in kwargs")
+      kwargs[arg_name] = arrays
+    else:
+      # So this is a path into a compound, and this is a bit tricky, as we could only
+      # expect tuples as compounds and tuples are immutable. We'd have to rebuild the
+      # whole nested tuple structure to modify just a single element. For similar
+      # purposes (see triton._utils.set_iterable_path()) Triton uses
+      # triton.language.core.tuple class which is a list under the hood.
+      raise ValueError(
+        f"Output argument spec for {arg_name} is a nested {out_spec} and we don't currently support that"
+      )
+  return kwargs
 
 
 def triton_kernel_call_lowering(
-    make_gpu_target_func,
-    ctx,
-    *array_args,
-    fn,
-    scalar_args,
-    name,
-    custom_call_target_name,
-    out_shapes,
-    grid,
-    num_warps,
-    num_stages,
-    num_ctas,
-    compute_capability,
-    enable_fp_fusion,
-    input_output_aliases,
-    zeroed_outputs,
-    debug,
-    serialized_metadata,
-    metaparams: tuple[tuple[str, Any], ...],
+  make_gpu_target_func,
+  ctx,
+  *abstract_args,
+  fn,
+  kernel_call_name,
+  custom_call_target_name,
+  out_shapes,
+  grid,
+  compute_capability,
+  operand_output_aliases,
+  zeroed_outputs,
+  serialized_metadata,
+  args_kwargs,
+  out_info,
 ):
-  # we have to pass metaparams dictionary as a tuple to allow hashing necessary for
-  # lowering via xla_primitive_callable()
-  assert isinstance(metaparams, tuple), "metaparams must be tuple[tuple[str, Any], ...]"
-  metaparams = dict(metaparams)  # wil crash if tuple format is incompatible
+  operand_output_aliases = dict[int, int](operand_output_aliases)
 
-  kernel_call_name = name
-  args = list(ctx.avals_in)
-  arg_dtypes = list(map(get_triton_type, ctx.avals_in))
-  for idx, dtype, v in scalar_args:
-    args.insert(idx, v)
-    arg_dtypes.insert(idx, dtype)
-  # Extract only the output avals not referenced in the input_output_aliases mapping.
-  assert isinstance(input_output_aliases, tuple), "input_output_aliases must be a tuple"
-  input_output_aliases = dict(input_output_aliases)
-  strictly_out_avals = [
-    aval
-    for i, aval in enumerate(ctx.avals_out)
-    if i not in input_output_aliases.values()
-  ]
-  args.extend(strictly_out_avals)
-  arg_dtypes.extend(map(get_triton_type, strictly_out_avals))
+  jtfu = JTJITFunction(fn)
 
-  named_args = dict(unsafe_zip(fn.arg_names, args))
+  args, kwargs = deserialize_args_kwargs(ctx, abstract_args, args_kwargs)
 
-  if isinstance(fn, autotuner.Autotuner):
-    if hasattr(fn, "key_idx"):
-      key_idxs = fn.key_idx  # Triton <=3.2
-    else:
-      key_idxs = [fn.arg_names.index(k) for k in fn.keys]
-    if any(idx not in key_idxs for idx, _, _ in scalar_args):
-      logging.warning(
-          "Auto-tuning key does not include all scalar arguments. "
-          "We may perform redundant auto-tuning."
-      )
-
-    # If any metaparams have been specified explicitly, we prune any configs
-    # that conflict. Note that this is more permissive than Triton's autotuner
-    # implementation, which will throw an error if any keys match.
-    # TODO(cjfj): Prune explicit `num_warps` / `num_stages`.
-    prev_early_config_prune_fn = fn.early_config_prune
-
-    def prune_configs(configs, named_args, **kwargs):
-      pruned_configs = []
-      for config in configs:
-        if config.pre_hook is not None:
-          raise NotImplementedError("`pre_hook` is not supported")
-
-        if all(config.kwargs.get(k, v) == v for k, v in metaparams.items()):
-          pruned_configs.append(config)
-      if prev_early_config_prune_fn is not None:
-        pruned_configs = prev_early_config_prune_fn(pruned_configs, named_args)
-      return pruned_configs
-
-    fn.early_config_prune = prune_configs
-    fn.nargs = named_args
-    configs = fn.prune_configs(metaparams)
-    fn = fn.fn
-  else:
-    config = triton.Config(
-        {},
-        num_warps=num_warps,
-        num_stages=num_stages,
-        num_ctas=num_ctas,
-    )
-    configs = [config]
-
-  if isinstance(fn, autotuner.Heuristics):
-    updated_configs = []
-    for config in configs:
-      kwargs = config.kwargs.copy()
-      for name, heuristic in fn.values.items():
-        kwargs[name] = heuristic({**named_args, **metaparams, **kwargs})
-      updated_config = copy.copy(config)
-      updated_config.kwargs = kwargs
-      updated_configs.append(updated_config)
-    configs = updated_configs
-    fn = fn.fn
+  # extending with outputs
+  kwargs = add_output_args(jtfu, ctx, out_info, args, kwargs)
+  if zeroed_outputs:
+    zeroed_outputs = convert_zeroed_outputs(jtfu, kwargs, zeroed_outputs)
 
   if not isinstance(fn, (triton.JITFunction, gl_runtime.GluonJITFunction)):
-    raise ValueError(
-        "`kernel` must be a Triton `JITFunction`, `GluonJITFunction`, `Heuristics` or `Autotuner`."
+    # Note `fn.arg_names` below isn't `JITFunction::arg_names`: Autotuner and
+    # Heuristics classes have their own field and it's NOT deprecated.
+    named_args = dict(unsafe_zip(fn.arg_names, args))
+    # named_args are needed only for Autotuner/Heuristics handling.
+    # note that the above construction of named_args is based on positional args only.
+    # This is fully coherent with how upstream does it in Autotuner/Heuristics classes.
+    # These are genuinely name-value pairs for passed positional arguments only, and not
+    # `bound_args` constructed using kernel's signature.
+
+  if isinstance(fn, autotuner.Autotuner):
+    # We should unpack autotuner first and heuristics second to ensure we'd
+    # eventually get to a correct actual kernel `fn`.
+    configs = make_autotuner_configs(fn, kwargs, named_args)
+    fn = fn.fn
+  else:
+    ttcfg_args = dict(
+      num_warps=kwargs["num_warps"],
+      num_stages=kwargs["num_stages"],
+      num_ctas=kwargs["num_ctas"],
     )
+    if "maxnreg" in kwargs:
+      ttcfg_args["maxnreg"] = kwargs["maxnreg"]
+    configs = [triton.Config({}, **ttcfg_args)]
 
-  output2input = {v: k for k, v in input_output_aliases.items()}
-  if len(output2input) != len(input_output_aliases):
-    raise ValueError("input_output_aliases must be a bijection")
+  if isinstance(fn, autotuner.Heuristics):
+    configs = make_configs_from_heuristics(fn, configs, kwargs, named_args)
+    fn = fn.fn
 
-  outputs_offset = len(ctx.avals_in) + len(scalar_args)
-  config_params = []
-  for config in configs:
-    config_metaparams = {**metaparams, **config.kwargs}
-    config_grid = normalize_grid(grid, config_metaparams)
-
-    config_zeroed_outputs = zeroed_outputs
-    if callable(zeroed_outputs):
-      config_zeroed_outputs = config_zeroed_outputs(config_metaparams)
-
-    # zeroed_params_with_sizes is a dict output_arg_idx -> aval_size_bytes
-    # config_zeroed_outputs is output ordinal numbers
-    zeroed_params_with_sizes = {
-      output2input[i] if i in output2input else i + outputs_offset: aval_size_bytes(
-        ctx.avals_out[i]
-      )
-      for i in sorted(config_zeroed_outputs)
-    }
-
-    config_params.append(
-        dict(
-            metaparams=tuple(sorted(config_metaparams.items())),
-            num_warps=config.num_warps,
-            num_stages=config.num_stages,
-            num_ctas=config.num_ctas,
-            grid=config_grid,
-            zeroed_params_with_sizes=tuple(zeroed_params_with_sizes.items()),
-        )
-    )
+  kernel_params = make_kernel_params(
+    ctx,
+    len(abstract_args),
+    kwargs,
+    grid,
+    zeroed_outputs,
+    configs,
+  )
 
   kernel_calls = []
-  for params in config_params:
-    kernel, specialization_attr = get_or_create_triton_kernel(
-        make_gpu_target_func,
-        ctx.module_context.platforms[0],
-        fn,
-        arg_dtypes,
-        scalar_args,
-        num_warps=params["num_warps"],
-        num_stages=params["num_stages"],
-        num_ctas=params["num_ctas"],
-        compute_capability=compute_capability,
-        enable_fp_fusion=enable_fp_fusion,
-        metaparams=dict(params["metaparams"]),
-        dump=debug,
+  for params in kernel_params:
+    kernel, specialization_attr, non_constexprs = jtfu.get_or_create_triton_kernel(
+      make_gpu_target_func,
+      ctx.module_context.platforms[0],
+      args,
+      compute_capability=compute_capability,
+      kwargs=params["metaparams"],
     )
 
-    kernel_params = []
-    zeroed_params_with_sizes = dict(params["zeroed_params_with_sizes"])
-    equal_to_1 = {i for i, _, v in scalar_args if v == 1}
-    for i, (arg, dtype) in enumerate(zip(args, arg_dtypes)):
-      if isinstance(arg, core.ShapedArray):
-        arg_attrs = specialization_attr[(i,)]
-        kernel_params.append(
-            triton_kernel_call_lib.create_array_parameter(
-                zeroed_params_with_sizes.get(i, 0),
-                16 if (["tt.divisibility", 16] in arg_attrs) else 0,
-            )
+    call_params = []
+    zeroed_params_with_sizes = params["zeroed_params_with_sizes"]
+    array_idx = 0
+
+    for path, arg in non_constexprs.items():
+      if isinstance(arg, JTArray):
+        arg_attrs = specialization_attr[path]
+        call_params.append(
+          triton_kernel_call_lib.create_array_parameter(
+            zeroed_params_with_sizes.get(array_idx, 0),
+            16 if (["tt.divisibility", 16] in arg_attrs) else 0,
+            # TODO improve above ^^
+          )
         )
-      elif i not in equal_to_1:
-        # Convert TypedInt/TypedFloat subclasses to plain Python types,
-        # as nanobind's strict-mode integer caster rejects subclasses.
-        if isinstance(arg, bool):
-          arg = bool(arg)
-        elif isinstance(arg, int):
-          arg = int(arg)
-        elif isinstance(arg, float):
-          arg = float(arg)
-        kernel_params.append(
-            triton_kernel_call_lib.create_scalar_parameter(arg, dtype)
-        )
+        array_idx += 1
+      else:
+        dtype = get_type_id(arg)
+        call_params.append(triton_kernel_call_lib.create_scalar_parameter(arg, dtype))
 
     kernel_calls.append(
-        triton_kernel_call_lib.TritonKernelCall(
-            kernel,
-            params["grid"][0],
-            params["grid"][1],
-            params["grid"][2],
-            kernel_params,
-        )
+      triton_kernel_call_lib.TritonKernelCall(
+        kernel,
+        params["grid"][0],
+        params["grid"][1],
+        params["grid"][2],
+        call_params,
+      )
     )
 
   if len(kernel_calls) > 1:
-    named_scalar_args = {fn.arg_names[i]: v for i, _, v in scalar_args}
+    # named_scalar_args seems to be only used for naming of the autotune call, which is
+    # only used for logging, so this doesn't seem too important use-case to care
+    # specifically about scalars here.
+    # named_scalar_args = {fn.arg_names[i]: v for i, v in scalar_args.items()}
+    # TODO agree on that on PR review
+
     input_output_aliases_with_sizes = tuple(
-        (input_idx, output_idx, aval_size_bytes(ctx.avals_in[input_idx]))
-        for input_idx, output_idx in input_output_aliases.items()
+      (input_idx, output_idx, aval_size_bytes(ctx.avals_in[input_idx]))
+      for input_idx, output_idx in operand_output_aliases.items()
     )
     kernel_call = triton_kernel_call_lib.TritonAutotunedKernelCall(
-        f"{kernel_call_name} ({fn.fn.__name__}) {named_scalar_args}",
-        [(call, str(config)) for call, config in zip(kernel_calls, configs)],
-        input_output_aliases_with_sizes,
+      # f"{kernel_call_name} ({fn.fn.__name__}) {named_scalar_args}",
+      f"{kernel_call_name} ({fn.fn.__name__})",
+      [(call, str(config)) for call, config in zip(kernel_calls, configs)],
+      input_output_aliases_with_sizes,
     )
   else:
     kernel_call = kernel_calls[0]
 
   call_proto = kernel_call.to_proto(kernel_call_name, serialized_metadata)
+  # Note, `operand_output_aliases` parameter uses raw positional indices into the
+  # operands that are seen by MLIR custom_call(). Scalars in JAX-Triton are embedded
+  # into `backend_config`/`call_proto` and aren't passed as MLIR operands, hence indices
+  # of `operand_output_aliases` count only arrays among all inputs.
   rule = jax.ffi.ffi_lowering(
-      custom_call_target_name,
-      api_version=2,
-      backend_config=zlib.compress(call_proto),
-      operand_output_aliases=input_output_aliases,
+    custom_call_target_name,
+    api_version=2,
+    backend_config=zlib.compress(call_proto),
+    operand_output_aliases=operand_output_aliases,
   )
-  return rule(ctx, *array_args)
+  return rule(ctx, *abstract_args)
 
 
 mlir.register_lowering(
-    triton_kernel_call_p,
-    functools.partial(triton_kernel_call_lowering, make_gpu_target_cuda),
-    platform="cuda",
+  triton_kernel_call_p,
+  functools.partial(triton_kernel_call_lowering, make_gpu_target_cuda),
+  platform="cuda",
 )
 
 mlir.register_lowering(
-    triton_kernel_call_p,
-    functools.partial(triton_kernel_call_lowering, make_gpu_target_hip),
-    platform="rocm",
+  triton_kernel_call_p,
+  functools.partial(triton_kernel_call_lowering, make_gpu_target_hip),
+  platform="rocm",
 )
 
 
 def triton_kernel_call_raise_on_jvp(*args, **kwargs):
   del args, kwargs  # unused
   raise NotImplementedError(
-      "jax_triton.triton_call does not support automatic differentiation. Use "
-      "jax.custom_jvp or jax.custom_vjp to implement a custom automatic "
-      "differentiation rule for your kernel."
+    "jax_triton.triton_call does not support automatic differentiation. Use "
+    "jax.custom_jvp or jax.custom_vjp to implement a custom automatic "
+    "differentiation rule for your kernel."
   )
 
 
@@ -769,52 +1237,508 @@ ad.primitive_jvps[triton_kernel_call_p] = triton_kernel_call_raise_on_jvp
 def triton_kernel_call_raise_on_vmap(*args, **kwargs):
   del args, kwargs  # unused
   raise NotImplementedError(
-      "jax_triton.triton_call does not support batching with jax.vmap. Use "
-      "jax.custom_batching.custom_vmap to implement a custom batching rule for "
-      "your kernel."
+    "jax_triton.triton_call does not support batching with jax.vmap. Use "
+    "jax.custom_batching.custom_vmap to implement a custom batching rule for "
+    "your kernel."
   )
 
 
-batching.primitive_batchers[triton_kernel_call_p] = (
-    triton_kernel_call_raise_on_vmap
-)
+batching.primitive_batchers[triton_kernel_call_p] = triton_kernel_call_raise_on_vmap
 
 
 class ShapeDtype(Protocol):
+  @property
+  def shape(self) -> tuple[int, ...]: ...
 
   @property
-  def shape(self) -> tuple[int, ...]:
-    ...
+  def dtype(self) -> np.dtype: ...
 
-  @property
-  def dtype(self) -> np.dtype:
-    ...
+
+def serialize_args_kwargs(jtfu: JTJITFunction, args: list, kwargs: dict):
+  """Prepares args and kwargs for passing through JAX's primitive system by separating
+  things that must be traced from things that must be passed as is.
+
+  Returns two sequences of traced values, a mapping: array id -> flat array index to
+  construct operand_output_aliases mapping, and a tuple of hashable reconstruction info.
+  Assumes that a caller adheres to the Triton's rules about argument types, so no
+  special checks for hashability are done for performance reasons.
+
+  Note that the function consumes kwargs, i.e. its state is modified in place.
+  """
+  assert isinstance(jtfu, JTJITFunction), "jtfu must be a JTJITFunction object"
+  # JAX's Primitive.bind(*args, **params) has a strict dichotomy:
+  # - *args (positional) are dynamic operands — values that participate in JAX's
+  # tracing/transformation system (jit, grad, vmap). During JIT compilation, they become
+  # abstract values (ShapedArray) and then MLIR SSA values in the lowered IR.
+  # - **params (keyword) are static parameters — they must be hashable, are passed
+  # through verbatim, and retain their concrete Python values across the entire
+  # compilation pipeline.
+  # Hence to pass data through JAX's primitive system we must separate things that must
+  # be traced from things that must be passed as is. The restriction is that since JAX
+  # arrays must be managed by XLA, they must be passed as traced items. The rest could
+  # go concrete helping to specialize the kernel properly.
+  # We must implement the separation in a way that (1) allows to reconstruct both `args`
+  # and `kwargs` back exactly on the other end to process them properly, and (2) all JAX
+  # array arguments go into .bind() call in exactly the same order as the kernel expects
+  # them (so we don't have to reshuffle them later during the lowering). In that we
+  # assume that no JAX array could be specialized to a constexpr for compiling, which
+  # holds in the upstream Triton too (small arrays could be passed as tuples/lists
+  # though to constexpr annotated params).
+
+  flat_args, args_tree = tree_util.tree_flatten(args, is_leaf=lambda x: x is None)
+  # We must let Nones to pass through flattening and `is_leaf` semantic is additive.
+
+  # Since there's usually much more non-vector parameters than vectors, extract
+  # vectors from flat_args. Jax explicitly guarantee that `isinstance(x, jax.Array)`
+  # check behaves correctly for raw arrays as well as for tracers. For jitting all/most
+  # of Python scalars are mapped to ShapedArray avals too, so they are treated as arrays
+  # by the check. However, there's no use-case where we might want to pass a scalar as a
+  # traceable thing into the kernel call, so we can safely assume a user will mark it as
+  # a static argument for jitting (the old implementation relied on that too).
+  abs_args = {i: v for i, v in enumerate(flat_args) if isinstance(v, jax.Array)}
+  # counting raw arrays to build `operand_output_aliases` mapping
+  array_id2idx = {id(v): idx for idx, v in enumerate(abs_args.values())}
+  # Note that we assume user won't pass the same array several times in args or in
+  # kwargs AND would want to alias it, so not checking this here and below
+
+  static_args = (to_python_type(v) for v in flat_args if not isinstance(v, jax.Array))
+  # we're going to pass flat_args as static params now. There's a caveat at least for
+  # tl.constexpr() objects: JAX's lowering code seems to require only hashability
+  # and correct equality semantics for static objects, and this is true for
+  # tl.constexpr() with a nuance: on comparison it returns not a bool True/False, but
+  # another tl.constexpr() object with a bool value. So if there's a silly check in JAX
+  # that the `(a==b) is True`, or `type(a==b) is bool` - it'll break.
+
+  # Now do the same for kwargs with a caveat - we must traverse them in order of kernel
+  # parameters declaration to ensure arrays ends up in a correct order
+  def contain_arrays(v):
+    if isinstance(v, jax.Array):
+      return True
+    elif isinstance(v, tuple):  # among pytrees only tuples could be passed as arguments
+      return any(contain_arrays(x) for x in v)
+    return False
+
+  class _FakeVal: ...
+
+  abs_kwargs_list = []  # only values to abstract
+  abs_kwargs_meta = {}  # hashable reconstruction info, keyed by a parameter name
+  idx_offset = len(array_id2idx)
+  # iterating over param names ensures correct serialization ordering
+  for aname in jtfu.arg_names:
+    # if kwargs has that parameter AND the value contains an array somewhere (including
+    # nested tuples/lists), we handle the whole arg value differently to be able to
+    # reconstruct it correctly. Otherwise we just skip the arg to pass it along with
+    # other kwargs, such as backend options.
+    arg_val = kwargs.get(aname, _FakeVal())
+    if contain_arrays(arg_val):
+      del kwargs[aname]  # handle the value differently
+      if isinstance(arg_val, jax.Array):  # shortcutting if the value is a raw array
+        abs_kwargs_list.append(arg_val)
+        abs_kwargs_meta[aname] = None
+        array_id2idx[id(arg_val)] = idx_offset
+        idx_offset += 1
+      else:  # do full flattening
+        flat_v, the_tree = tree_util.tree_flatten(arg_val)
+        abs_v = {i: v for i, v in enumerate(flat_v) if isinstance(v, jax.Array)}
+        array_id2idx.update(
+          (id(v), idx + idx_offset) for idx, v in enumerate(abs_v.values())
+        )
+        idx_offset += len(abs_v)
+        static_v = (to_python_type(v) for v in flat_v if not isinstance(v, jax.Array))
+        abs_kwargs_list.extend(abs_v.values())
+        abs_kwargs_meta[aname] = (tuple(static_v), tuple(abs_v.keys()), the_tree)
+
+  # Primitive's bind() doesn't support passing unhashable values as key-value arguments,
+  # however, kwargs might also contain backend options, and some of them are dicts. So
+  # far, there's only one such option - `extern_libs`, both in AMD and NVIDIA backends.
+  # While it might be possible to just use `tree_util.tree_flatten(metaparams)` here,
+  # it's too expensive for handling such a rare case. Instead, we do this manually.
+  # This is somewhat fragile and might require some maintenance to adapt to new options
+  # but the kernel launcher is a hot path, so this seem tolerable.
+  if "extern_libs" in kwargs:
+    kwargs["extern_libs"] = tuple(kwargs["extern_libs"].items())
+
+  return (
+    abs_args.values(),  # intentionally not materialized
+    abs_kwargs_list,
+    array_id2idx,  # mapping: array id -> flat array index
+    (  # first go args info
+      args_tree,  # structure of args
+      tuple(abs_args.keys()),  # array positions in args
+      tuple(static_args),  # leftover args after arrays removed
+      # then kwargs info
+      tuple(abs_kwargs_meta.items()),
+      tuple(kwargs.items()),  # leftover kwargs
+    ),
+  )
+
+
+class JTArray:
+  _default_alignment = 16
+
+  def __init__(self, avals: list, idx: int):
+    self.dtype = get_type_id(avals[idx])
+    self.index = idx  # index into a corresponding avals arrays.
+    # TODO(sharadmv,zhangqiaorjc): handle differently aligned pointers
+    self.data_ptr = lambda: JTArray._default_alignment
+    # self.shape = aval.shape  # might be redundant
+
+
+def deserialize_args_kwargs(
+  ctx, abstract_args: list, args_kwargs_meta: tuple
+) -> tuple[list, dict]:
+  """Reconstructs args and kwargs from the serialized form. Abstract arguments are
+  replaced by stubs."""
+  args_tree, abs_args_keys, static_args, abs_kwargs_meta, kwargs = args_kwargs_meta
+  abs_kwargs_meta = dict[str, None | tuple[tuple, tuple, Any]](abs_kwargs_meta)
+  # abstract_args is a concatenation of abs_args.values() and abs_kwargs_list, but
+  # abs_kwargs_meta has a more complex inner structure and its length could be smaller
+  # than a corresponding portion of abstract_args storing abs_kwargs_list.
+  assert len(abstract_args) == len(ctx.avals_in)
+
+  args = list(static_args)
+  kwargs_ofs = len(abs_args_keys)
+  abs_v = [JTArray(ctx.avals_in, i) for i in range(kwargs_ofs)]
+  for i, v in unsafe_zip(abs_args_keys, abs_v):
+    args.insert(i, v)
+  args = list(tree_util.tree_unflatten(args_tree, args))
+
+  # this reverses additional kwargs modifications by serializer
+  assert isinstance(kwargs, tuple), "kwargs must be a tuple here"
+  kwargs = dict(kwargs)
+  if "extern_libs" in kwargs:
+    kwargs["extern_libs"] = dict(kwargs["extern_libs"])
+
+  # now restore the rest of kwargs
+  for aname, meta in abs_kwargs_meta.items():
+    assert aname not in kwargs
+    if meta is None:
+      kwargs[aname] = JTArray(ctx.avals_in, kwargs_ofs)
+      kwargs_ofs += 1
+    else:
+      static_v, abs_v_keys, the_tree = meta
+      n_keys = len(abs_v_keys)
+      abs_v = [JTArray(ctx.avals_in, kwargs_ofs + j) for j in range(n_keys)]
+      kwargs_ofs += n_keys
+      static_v = list(static_v)
+      for k, v in unsafe_zip(abs_v_keys, abs_v):  # assume sorted keys
+        static_v.insert(k, v)
+      kwargs[aname] = tree_util.tree_unflatten(the_tree, static_v)
+  assert kwargs_ofs == len(abstract_args)
+
+  return args, kwargs
+
+
+ArrayId = int
+OutShapeId = int
+
+
+def _in_spec_to_ShapeDtypeStruct(
+  elm: InOutSpec,
+  args: list[Any],
+  kwargs: dict[str, Any],
+  name2idx: dict[str, int],
+  idx2name: list[str],
+  aliases: dict[ArrayId, OutShapeId],  # mutable
+  shapes: list[jax.ShapeDtypeStruct],  # mutable
+):
+  """For an :in-spec: element `elm` traverses the `args`/`kwargs` to find all arrays
+  addressed by it and updates a list of ShapeDtypeStruct objects describing the arrays
+  and a dict mapping from array identifiers to the ShapeDtypeStruct identifiers.
+  """
+  # this code runs each kernel launch, so proper validation is expensive here, so
+  # we skip most of checks allowing it just to fail, should the spec be incorrect.
+  # We might check some things later on the go.
+  orig_name = None
+  if isinstance(elm, int):
+    path = (elm,)
+  elif isinstance(elm, str):
+    orig_name = elm
+    path = (name2idx[elm],)  # user is responsible for correct indexing
+  elif isinstance(elm, (tuple, list)):
+    param_idx = elm[0]  # first element is an index into signature parameter list
+    if isinstance(param_idx, str):
+      orig_name = param_idx
+      path = (name2idx[param_idx], *elm[1:])
+    else:
+      path = elm
+  else:
+    raise ValueError(f"Invalid in_spec element: {elm}")
+  # checking if the path refers to a terminal array, or to a compound
+  param_idx = path[0]
+  if param_idx < len(args):  # must be in args by construction
+    arg = triton_runtime_jit.get_iterable_path(args, path)
+  else:  # must be in kwargs by construction
+    arg = triton_runtime_jit.get_iterable_path(
+      kwargs[idx2name[param_idx] if orig_name is None else orig_name], path[1:]
+    )
+
+  def _unpack_arg(_, elm: Any):
+    nonlocal shapes, aliases
+    if isinstance(elm, jax.Array):
+      shape = jax.ShapeDtypeStruct(elm.shape, elm.dtype)
+      aid = id(elm)
+      if aid in aliases:
+        raise ValueError(f"Array {elm} found under path {path} can't be aliased twice")
+      aliases[aid] = id(shape)
+      shapes.append(shape)
+    elif not isinstance(elm, tuple):
+      raise ValueError(
+        f"Aliased element {elm} under path {path} is not a jax.Array or a tuple of them"
+      )
+
+  if isinstance(arg, jax.Array):
+    _unpack_arg(None, arg)
+  elif not isinstance(arg, tuple):
+    raise ValueError(
+      f"Aliased element {arg} at path {path} is not a jax.Array or a tuple of them"
+    )
+  else:
+    functools.reduce(_unpack_arg, arg, None)
+
+
+def make_aliased_shapes(
+  jtfu: JTJITFunction,
+  input_output_aliases: dict[int, int] | Sequence[InOutSpec],
+  pure_out_shapes: dict[CanonicalKernelArgPath, Sequence[jax.ShapeDtypeStruct]],
+  orig_aliased_shapes: Sequence[jax.ShapeDtypeStruct],
+  args: list[Any],
+  kwargs: dict[str, Any],
+) -> tuple[tuple[jax.ShapeDtypeStruct], dict[ArrayId, OutShapeId]]:
+  """Uses `input_output_aliases` to produce a tuple of aliased shapes to append to
+  `out_shapes` for the Primitive's .bind() call, and a dict mapping input array
+  identifiers to output array identifiers. After serialization, we'll be able to
+  create `operand_output_aliases` dictionary based on raw array indices using this
+  mapping."""
+  assert isinstance(jtfu, JTJITFunction), "jtfu must be a JTJITFunction object"
+  # building aliased_shapes from in_spec
+  is_dict = isinstance(input_output_aliases, dict)
+  in_spec = list(input_output_aliases.keys()) if is_dict else input_output_aliases
+  if isinstance(in_spec, (int, str)) or (
+    isinstance(in_spec, tuple) and in_spec and not isinstance(in_spec[0], (tuple, list))
+  ):
+    in_spec = [in_spec]
+
+  name2idx = jtfu.arg_name_to_index
+  idx2name = jtfu.arg_names
+  aliases = {}
+
+  def _make_aliased(elm: Any, shapes: list[jax.ShapeDtypeStruct]) -> None:
+    inner_shapes = []
+    if isinstance(elm, list) or (
+      isinstance(elm, tuple) and isinstance(elm[0], (tuple, list))
+    ):
+      tuple(_make_aliased(e, inner_shapes) for e in elm)
+      assert len(inner_shapes) == len(elm)
+      shapes.append(tuple(inner_shapes))
+    else:
+      nonlocal aliases
+      _in_spec_to_ShapeDtypeStruct(
+        elm, args, kwargs, name2idx, idx2name, aliases, inner_shapes
+      )
+      inner_shapes = inner_shapes[0] if len(inner_shapes) == 1 else tuple(inner_shapes)
+      shapes.append(inner_shapes)
+
+  aliased_shapes = []
+  tuple(_make_aliased(e, aliased_shapes) for e in in_spec)
+  # aliased_shapes = _make_aliased(in_spec) if in_spec else []
+
+  # TODO perhaps remove it to spare cycles?
+  # if it's a dict, validating that out_shapes match to aliased_shapes
+  if is_dict:  # and kwargs["debug"]:
+    # getting a starting index of aliased shapes in the original out_shape for reading
+    # a dict values
+    aliased_idx = len(pure_out_shapes)
+    for oidx in input_output_aliases.values():
+      oidx -= aliased_idx
+      if oidx < 0 or oidx >= len(aliased_shapes):
+        raise ValueError(f"Output index {oidx} is out of range for aliased shapes")
+      if aliased_shapes[oidx] != orig_aliased_shapes[oidx]:
+        raise ValueError(
+          f"Output shape {aliased_shapes[oidx]} at index {oidx} doesn't match to the shape "
+          f"in `out_shape[{oidx + aliased_idx}]` {orig_aliased_shapes[oidx]}"
+        )
+  return tuple(aliased_shapes), aliases
+
+
+def _split_out_values(
+  out_values: Sequence,
+  out_names: None | InOutSpec,
+  input_output_aliases: dict[int, int] | Sequence[InOutSpec],
+) -> tuple[tuple, Sequence]:
+  """Splits `out_values` into a tuple of purely output values and a tuple of aliased
+  values."""
+  # If we know `out_names`, the first len(out_names) elements in `out_values`
+  # must describe pure outputs. Else if there's a dict form of `input_output_aliases`,
+  # then len(input_output_aliases) is the number of aliased buffers/shapes. Else -
+  # there are no aliased elements.
+  if out_names is not None:
+    num_purely_output = len(out_names)
+    num_aliased = len(out_values) - num_purely_output
+    if num_aliased < 0 or (
+      isinstance(input_output_aliases, dict)
+      and num_aliased != len(input_output_aliases)
+    ):
+      raise ValueError(
+        "Content of `out_shape` doesn't match to `out_names` and `input_output_aliases` specification"
+      )
+  elif isinstance(input_output_aliases, dict):
+    num_aliased = len(input_output_aliases)
+    num_purely_output = len(out_values) - num_aliased
+    if num_purely_output < 0:
+      raise ValueError(
+        "There was specified more aliased buffers than there are output arguments"
+      )
+  else:
+    num_aliased = 0
+    num_purely_output = len(out_values)
+
+  if num_aliased > 0:
+    aliased_shapes = out_values[num_purely_output:]
+    out_values = out_values[:num_purely_output]
+  else:
+    aliased_shapes = []
+  return out_values, aliased_shapes
+
+
+def canonicalize_out_shape(
+  jtfu: JTJITFunction,
+  out_shape: ShapeDtype | Sequence[ShapeDtype] | dict[InOutSpec, Sequence[ShapeDtype]],
+  out_names: None | InOutSpec,
+  args: list[Any],  # positional args passed to the launcher
+  input_output_aliases: dict[int, int] | Sequence[InOutSpec],  # original aliases
+) -> tuple[
+  dict[CanonicalKernelArgPath, Sequence[jax.ShapeDtypeStruct]],
+  Sequence[jax.ShapeDtypeStruct],
+]:
+  """Converts different forms of out_shape and out_names to a single dict mapping from
+  output kernel argument paths to shapes/dtypes of the output arguments for output-only
+  arguments (those have corresponding parameters in the kernel's signature), and a
+  sequence of shapes/dtypes of aliased arguments (those don't have separate output
+  parameters in the kernel's signature since they reuse some input parameters).
+  """
+  assert isinstance(jtfu, JTJITFunction), "jtfu must be a JTJITFunction object"
+  if isinstance(out_names, (int, str)):
+    out_names = (out_names,)
+  # a basic validation that should be evicted on compilation for jitting is fine
+  if out_names is not None and not isinstance(out_names, (tuple, list)):
+    raise ValueError(
+      "out_names must be None, a string, an int, or a tuple/list of specific format"
+    )
+
+  if isinstance(out_shape, dict):
+    # The dictionary form doesn't have info on aliased buffers
+    if out_names is None:
+      out_names = tuple(out_shape.keys())
+      out_values = tuple(out_shape.values())  # must materialize
+    else:
+      # TODO: remove the check to speedup things/check only lengths, or add cache?
+      if frozenset(out_names) != frozenset(out_shape.keys()):
+        raise ValueError("out_names and out_shape must have the same keys")
+      out_values = tuple(out_shape[name] for name in out_names)  # reorder
+
+    aliased_shapes = []
+  else:
+    if isinstance(out_shape, list):
+      out_shape = tuple(out_shape)
+    out_values = out_shape if isinstance(out_shape, tuple) else (out_shape,)
+    # out_values here might contain shapes for aliased elements, we need to split them
+    out_values, aliased_shapes = _split_out_values(
+      out_values, out_names, input_output_aliases
+    )
+    # TODO we could perhaps even drop `aliased_shapes` entirely, as we reconstruct them
+    # from the signature
+    if out_names is None:
+      # building out_names from the assumption that `args` contain all input arguments
+      arg_names = jtfu.arg_names
+      # out_values may contain compounds, hence we must consider non-flattened shapes
+      out_names = tuple(arg_names[i + len(args)] for i in range(len(out_values)))
+    if len(out_names) != len(out_values):  # this checks only top level specs
+      raise ValueError("out_shape specification mismatches out_names")
+  # no use of out_shape below this line
+
+  def _to_ShapeDtypeStruct(a: Any) -> jax.ShapeDtypeStruct:
+    return jax.ShapeDtypeStruct(a.shape, a.dtype)
+
+  if aliased_shapes:
+    aliased_shapes = tree_util.tree_map(_to_ShapeDtypeStruct, aliased_shapes)
+  out_values = tree_util.tree_map(_to_ShapeDtypeStruct, out_values)
+
+  # now finally canonicalizing out_names using the out_values.
+  pure_out_shapes: dict[CanonicalKernelArgPath, Sequence[jax.ShapeDtypeStruct]] = {}
+  name2idx = jtfu.arg_name_to_index
+  for i, outn in enumerate(out_names):
+    ospec = _canonicalize_out_spec_element(outn, name2idx)
+    pure_out_shapes[ospec] = out_values[i]
+  # While ordering of pure_out_shapes here reflects ordering of out_names, it doesn't
+  # mean that this ordering will be used for passing arguments to the kernel and
+  # producing outputs! There are two things that affect that:
+  # First, we'll use `tree_util.tree_flatten()` to serialize compound data structures
+  # including output args information, and JAX is built on assumption that the
+  # flattening also sorts keys of dictionaries (otherwise it'll break whole Primitive
+  # calls caching system). Keys here are tuple(int,...) where ints are kernel signature
+  # parameter indices, so it'll make them sorted accordingly. An escape hatch of
+  # OrderedDict() could be used here to bypass it, but that won't help, since later
+  # we'll make Triton variables for the output arguments by injecting corresponding
+  # arrays into `kwargs`. This will also nullify any imposed ordering by using
+  # kernel signature ordering. Later upon the kernel launch, we'll iterate over kernel
+  # arguments in the kernel signature order too, to properly pass arguments to the
+  # kernel. Hence, effectively, there's only one ordering - kernel signature's one.
+
+  return pure_out_shapes, aliased_shapes
+
+
+def _canonicalize_out_spec_element(
+  elm: InOutSpec,
+  name2idx: dict[str, int],
+) -> CanonicalKernelArgPath:
+  orig_name = None
+  if isinstance(elm, int):
+    path = (elm,)
+  elif isinstance(elm, str):
+    orig_name = elm
+    path = (name2idx[elm],)  # user is responsible for correct indexing
+  elif isinstance(elm, tuple):
+    prim_idx = elm[0]
+    if isinstance(prim_idx, str):
+      orig_name = prim_idx
+      path = (name2idx[prim_idx], *elm[1:])
+    else:
+      if not isinstance(prim_idx, int):
+        raise ValueError(f"Invalid first element of this out-spec: {elm}")
+      path = elm
+  else:
+    raise ValueError(f"Invalid out-spec element: {elm}")
+  # we don't need to dive deeper. We'll just create a variable for Triton with whatever
+  # a corresponding element of out_shape has
+  return path
 
 
 def triton_call(
-    *args: jax.Array | bool | int | float | np.float32,
-    kernel: (
-        triton.JITFunction
-        | gl_runtime.GluonJITFunction
-        | triton.runtime.Heuristics
-        | triton.runtime.Autotuner
-    ),
-    out_shape: ShapeDtype | Sequence[ShapeDtype],
-    grid: GridOrLambda,
-    name: str = "",
-    custom_call_target_name: str = "triton_kernel_call",
-    num_warps: int | None = None,
-    num_stages: int | None = None,
-    num_ctas: int = 1,  # TODO(giorgioa): Add support for dimensions tuple.
-    compute_capability: int | None = None,
-    enable_fp_fusion: bool = True,
-    input_output_aliases: dict[int, int] | None = None,
-    zeroed_outputs: (
-        Sequence[int] | Callable[[dict[str, Any]], Sequence[int]]
-    ) = (),
-    debug: bool = False,
-    serialized_metadata: bytes = b"",
-    **metaparams: Any,
+  *args: jax.Array | bool | int | float | np.float32,
+  kernel: (
+    triton.JITFunction
+    | gl_runtime.GluonJITFunction
+    | triton.runtime.Heuristics
+    | triton.runtime.Autotuner
+  ),
+  grid: GridOrLambda,
+  out_shape: ShapeDtype | Sequence[ShapeDtype] | dict[str, ShapeDtype] = (),
+  out_names: None | str | tuple[str, ...] = None,
+  name: str = "",
+  custom_call_target_name: str = "triton_kernel_call",
+  num_warps: int | None = None,
+  num_stages: int | None = None,
+  num_ctas: int = 1,  # TODO(giorgioa): Add support for dimensions tuple.
+  compute_capability: int | None = None,
+  enable_fp_fusion: bool = True,
+  input_output_aliases: dict[int, int] | None = None,
+  zeroed_outputs: (
+    Sequence[InOutSpec] | Callable[[dict[str, Any]], Sequence[InOutSpec]]
+  ) = (),
+  debug: bool = False,
+  serialized_metadata: bytes = b"",
+  **kwargs: Any,
 ) -> Any:
   """Calls a Triton kernel with `jax.Array` arguments.
 
@@ -851,13 +1775,12 @@ def triton_call(
   import jax_triton as jt
 
   def add(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
-    out_shape = jax.ShapeDtypeStruct(shape=x.shape, dtype=x.dtype)
     block_size = 8
     return jt.triton_call(
         x,
         y,
         kernel=add_kernel,
-        out_shape=out_shape,
+        out_shape=x,
         grid=(x.size // block_size,),
         block_size=block_size)
 
@@ -867,82 +1790,281 @@ def triton_call(
   print(jax.jit(add)(x_val, y_val))
   ```
 
-  Args:
-    *args: Inputs for the Triton kernel.
-    kernel: A Triton kernel (e.g. a function decorated with `triton.jit`). All
-      static values should be annotated with `triton.language.constexpr` or
-      `triton.experimental.gluon.language.constexpr`.
-    out_shape: A `jax.ShapeDtypeStruct` (or something that has `.shape` and
-      `.dtype` attributes) or a sequence thereof that specify the output(s) of
-      the kernel. Pointers for each of the `jax.ShapeDtypeStruct`s in
-      `out_shape` will be passed into `kernel` following the input parameters.
+  You can find much more use examples in the tests directory.
+
+  Kernel outputs and aliasing specification is a mandatory complexity on top of Triton
+  to interoperate with JAX properly. To describe it, a concept of "Kernel's signature
+  coordinate system" is used - it's a hashable method of addressing an individual
+  array in a random (*args,**kwargs) position of kernel's arguments, no matter how
+  deeply nested it is. A "coordinate" refers to either a single array or all arrays
+  nested into the addressed tuple. It can be:
+    - an int: indexes a kernel signature parameter.
+    - a string - parameter name in the kernel's signature.
+    - a tuple, with [0] being a string, as above, identifies parameter name in the
+      kernel's signature; otherwise must be an int indexing a kernel signature
+      parameter. All other elements of the tuple must be ints indexing into the
+      compound argument corresponding to the parameter mentioned in the [0] tuple's
+      element.
+      For example: a tuple `("Ptrs", 0, 1)` refers to `Ptrs` parameter of the kernel,
+      and expects a corresponding argument to be a tuple, with its 0-th being another
+      tuple, whose 1-st element being an array, or a tuple of arrays/tuples.
+
+  `triton_call()` parameters:
+    *args: Positional inputs for the Triton kernel. In the kernel signature, purely
+      output parameters should go after the last input parameter to be passed as
+      a positional argument to `triton_call()`.
+
+    kernel: Triton (e.g. a function decorated with `triton.jit`) or a Gluon kernel.
+      All static values should be annotated with `triton.language.constexpr` or
+      `triton.experimental.gluon.language.constexpr`. All other Triton annotations are
+      also supported.
+
+    out_shape: Description of shapes and dtypes of output parameters of the kernel.
+      Could be one of the following:
+
+      (1) a single ShapeDtype-like object (something that has `.shape` and
+      `.dtype` attributes) describing a single output parameter of the kernel; or an
+      ordered, potentially nested, sequence of ShapeDtype-like objects corresponding to
+      a one or many output parameters, where each root-level element of the sequence
+      describes one kernel output parameter in its signature (the nesting defines a form
+      of the individual argument, for example, `out_shape=((a,b),c)` defines two output
+      arguments, the first is a tuple of arrays having shapes and dtypes of arrays a
+      and b, and the second is an array having shape and dtype of array c). Ordering of
+      elements in the sequence must correspond to the ordering of the output parameters
+      in the kernel's signature.
+
+      (2) a dictionary mapping kernel's output parameter names or indices to
+      one ShapeDtype-like object or an ordered, potentially nested, sequence of such
+      objects. The nested structure of elements in sequences of the dictionary values
+      defines the structure of the output argument. For example,
+      `out_shape={"a": (x,y), "b": z}` defines that the kernel has two output
+      parameters: param named as "a" is a tuple of 2 arrays, borrowing their shapes and
+      dtypes from arrays x and y, and "b" is a single `z`-like array.
+      If `out_names` is specified, the `out_shape` must have the same keys. Ordering
+      of the kernel signature parameters takes precedence over the ordering of the
+      dictionary keys.
+      If `input_output_aliases` is needed and a dictionary form of `out_shape` is used,
+      the `input_output_aliases` could only use a non-dictionary form, enumerating
+      input arrays only.
+
+      Contrary to the Triton itself, JAX/XLA must manage memory buffers and organize
+      data copying between host and device memory for all array parameters, so
+      `out_shape` helps it with providing the necessary information.
+      Also due to a JAX custom call API there's currently a restriction associated with
+      ordering of input/output parameters in the kernel signature: all purely output
+      parameters must reside after the last non-constexpr input parameter in a flattened
+      sequence of kernel's signature parameters. Interleaving input and output
+      parameters in the signature is not supported.
+
+      If `out_shape` uses a dictionary form, or if `out_names` is provided, then there
+      are no other restrictions. Other cases also require that all input arguments not
+      specialized as constexprs, are passed strictly as positional `args`. `out_names`
+      are inferred from an assumption that output parameters follow the positional
+      parameter values passed as `args` to `triton_call()`.
+
+      Note that no matter which form of `out_shape` is used, arguments corresponding to
+      strictly output parameters should never be passed to a `triton_call()` as a part
+      of `args` or `kwargs`, - these arguments are added implicitly by the launcher. If
+      an argument is going to be an input-output argument, set `input_output_aliases`
+      accordingly.
+
+    out_names: A sequence of output parameter names.
+      This is another way to specify the output parameter names of the kernel. This one
+      is useful to employ in conjunction with the `@kernel` decorator.
+      If `out_shape` is a dictionary, its keys must be in sync with `out_names`.
+
     grid: An integer, tuple of up to 3 integers, or a function that returns a
       tuple of up to 3 integers. When `grid` is an integer, `kernel` is
-      invocated in `grid`-many parallel executions. When `grid` is a sequence of
+      invoked in `grid`-many parallel executions. When `grid` is a sequence of
       integers, `kernel` is launched in a `prod(grid)`-many parallel execution.
-      When `grid` is a function, it is passed `**metaparams` and should return a
-      tuple of up to 3 integers.
-    input_output_aliases: A dictionary mapping input argument indices to output
-      indices. Providing a mapping will alias the corresponding buffers.
-    zeroed_outputs: A sequence of indices, or a function returning a sequence of
-      indices, for outputs that should be zeroed before the kernel is launched.
-      Note that this also supports zeroing input-output (i.e. aliased through
-      `input_output_aliases`) arguments that should be treated as outputs in this
-      argument.
+      When `grid` is a function, it is passed `kwargs` and should return a tuple of up
+      to 3 integers.
+
+    input_output_aliases: tells JAX/XLA backend which input arguments not only supply
+      input data to the kernel, but also serve as output buffers (hence requiring the
+      backend to arrange not only `host->device` data copying before kernel launch, but
+      also `device->host` data copying after kernel execution). Might take two forms:
+
+      (1 - deprecated): A dictionary mapping an input array coordinate in the kernel's
+      signature coordinate space to the `out_shape` sequence coordinate space.
+      Important note: if the kernel also has purely output arguments, they must go first
+      in the `out_shape` sequence, and aliased buffers must go last in the sequence.
+      Interleaving output with in/out argument shapes in `out_shape` isn't supported.
+      User is responsible for adhering to the requirement.
+
+      (2 - recommended): an ordered, potentially nested, sequence of input array
+      coordinates in the kernel's signature coordinate space. When this form is used
+      there should be no corresponding output arguments in the `out_shape`. Shapes and
+      dtypes are inferred from referenced input arguments automatically (JAX/XLA doesn't
+      support typecasting of aliased buffers anyway, so `out_shape` for aliased buffers
+      are always redundant). This could be specifically:
+      - a single int, or a string, or a tuple having an int or a string as a first
+        element: describes an input array in the kernel's signature coordinate space.
+      - a list: ordered, possibly nested, sequence of the above. The nested structure of
+        the sequence describes the structure of the corresponding output argument,
+        containing aliased buffers as it's returned by the `triton_call()`. For example,
+        `input_output_aliases=["out_ptr",[(2,0), "out_ptr2"]]` describes three aliased
+        (input-output) buffers: the first is an input array, passed to `out_ptr` kernel
+        parameter, the second is an array passed at index 0 of a tuple passed to the
+        third positional parameter, and the third is an input array passed for
+        `out_ptr2` kernel parameter. These three buffers (assuming all are single
+        arrays) are returned from the `triton_call()` as a tuple of two elements: [0] is
+        a new array wrapping around the same buffer as was used for `out_ptr` kernel
+        parameter, and [1] is a tuple of two new arrays wrapping the other two array
+        buffers. If some referenced input argument is not an array, but a possibly
+        nested tuple of arrays, all its internal arrays are considered to be aliased,
+        and are returned as a flat tuple of arrays by this call.
+        Note that tuples can also be used instead of lists, just remember that if a
+        tuple's first element is not another iterable, it's always treated as a
+        coordinate descriptor, which might be not what you want. For example,
+        `input_output_aliases=(0,1)` is always treated as a reference to an array at
+        the second position of a tuple passed to the first kernel parameter, but
+        `input_output_aliases=[0,1]` references two arrays passed to the first and the
+        second kernel parameters respectively. Hence for clarity it's recommended,
+        to use tuples only when describing a single input array coordinate.
+      Note that if a kernel needs to start working with an initially zeroed read-write
+      buffer that should be returned as an output (for example, for doing sparse
+      updates), you should designate a purely output argument for it with a proper
+      `out_shape` specification, and mention the buffer coordinate in `out_shape` in
+      `zeroed_outputs` parameter.
+
+    zeroed_outputs: A sequence of kernel signature coordinates of output arguments, or
+      a function taking a dict of metaparameters and returning a sequence of such
+      coordinates, for outputs that should be zeroed before the kernel is launched.
+
+      BREAKING: This argument does NOT support zeroing input-output (i.e. aliased
+      through `input_output_aliases`) arguments anymore since this breaks the semantic
+      of the input-output parameters - with that you can't pass an information in the
+      buffer from the host to the kernel, effectively turning an input-output argument
+      into a purely output argument. Mind a little of terminological mess here:
+      inputs-outputs are considered from the backend's perspective, whose job
+      is to manage memory buffers and arrange data copying between host and device
+      memory for all array parameters. A kernel could always read from what is called a
+      purely output argument above, so if you need the kernel to start working with a
+      buffer from a definite zeroed state, just declare the buffer as a purely output
+      argument in `out_shape` and mention the buffer's coordinate in `zeroed_outputs`.
+
+      Note that a callable form of `zeroed_outputs` is allowed to modify the
+      metaparameters dict passed to it if and only if the modification does not affect
+      kernel compilation (for example, through changing parameters affecting kernel
+      specialization variant), and that modification is propagated to the
+      kernel call. If the modification does affect kernel compilation, the behavior is
+      undefined.
+
     num_warps: The number of warps used to execute the Triton kernel.
     num_stages: The number of stages emitted by the Triton compiler.
     num_ctas: The size of thread blocks per cluster to be used on GPUs with
       compute capabilities >= 9.0. It must be less or equal to 8.
-    debug: Prints out intermediate IRs if True for debugging purposes.
+    enable_fp_fusion: Whether to enable floating-point operands fusion for the kernel.
+    debug: Prints out intermediate IRs if True for debugging purposes. Also used as a
+      the backend options argument.
     serialized_metadata: Arbitrary metadata that will be added into the
       serialized kernel call.
-    metaparams: A dictionary of arguments that will be provided to a `grid`
-      (if it is a function) and to the Triton kernel as `constexpr` arguments.
+
+    kwargs: Key-value pairs (num_warps, num_stages, num_ctas, debug and enable_fp_fusion
+      arguments are added there automatically) that will be provided to:
+      - a `grid` (if it is a function),
+      - backend options constructor (only recognized arguments are passed),
+      - the Triton kernel as `constexpr` arguments (constexprs must always be scalars)
+        or regular runtime arguments.
 
   Returns:
-    Outputs from the Triton kernel.
+    Outputs from the Triton kernel. First go all purely output arguments, then all
+    input-output arguments.
   """
-  if not CAN_USE_TRITON:
-    raise ValueError(
-        "`triton_call` is only available when `triton` is installed."
-    )
-  out_shape = tree_util.tree_map(
-      lambda a: jax.ShapeDtypeStruct(a.shape, a.dtype), out_shape
-  )
-  flat_args, _ = tree_util.tree_flatten(args)
-  # TODO(sharadmv): check in_tree is flat (no Pytrees allowed in triton_call)
-  flat_out_shapes, out_tree = tree_util.tree_flatten(out_shape)
+  # TODO(Arech) improve error reporting and check assumptions violation. We have a ton
+  # of assumptions, requiring a certain behavior from a user. For most if not all of the
+  # assumptions it's possible to verify them. We just don't do this b/c of performance
+  # or other reasons and that hurts user experience. We can have an extensive validation
+  # in at least two cases: (1) some kernel launching parameters aren't vary much between
+  # all possible call, b/c they reflect certain properties of the kernel, so processing
+  # of such parameters could be cached. In that case we can have a proper validation
+  # with the uncached run and all subsequent runs will be blazingly fast. (2) we already
+  # have a `debug` parameter that is meant precisely for that.
 
-  array_args = []
-  scalar_args = []
-  for i, arg in enumerate(flat_args):
-    if isinstance(arg, (bool, int, float)):
-      scalar_args.append((i, get_triton_type(arg), arg))
-    elif isinstance(arg, np.float32):
-      scalar_args.append((i, get_triton_type(arg), float(arg)))
-    else:
-      array_args.append(arg)
+  # Python guarantees the keys don't exist. The original Triton has a single namespace
+  # for both constexprs and backend options, and we're doing the same to unify processing
+  # We are setting defaults here early, since we use values early.
+  kwargs["num_warps"] = num_warps if num_warps is not None else 4
+  kwargs["num_stages"] = num_stages if num_stages is not None else 3
+  kwargs["num_ctas"] = num_ctas
+  kwargs["enable_fp_fusion"] = enable_fp_fusion
+  kwargs["debug"] = debug
 
   if input_output_aliases is None:
-    input_output_aliases = {}
+    input_output_aliases = []
+
+  jtfu = JTJITFunction(kernel)
+  pure_out_shapes, aliased_shapes = canonicalize_out_shape(
+    jtfu, out_shape, out_names, args, input_output_aliases
+  )
+  # now the structure of `pure_out_shapes` would let us reconstruct the output variables
+  # for Triton using ctx.avals_out instead of arrays, and the dict keys would let us
+  # place them correctly into args/kwargs. And also to properly structure returned
+  # outputs from the call
+
+  if input_output_aliases or input_output_aliases == 0:
+    aliased_shapes, aliases = make_aliased_shapes(
+      jtfu, input_output_aliases, pure_out_shapes, aliased_shapes, args, kwargs
+    )
+  else:  # quick shortcut
+    aliases = {}
+    if aliased_shapes:
+      raise ValueError("out_shape isn't coherent with input_output_aliases!")
+
+  # structure of `aliased_shapes` would help to return aliased arrays in a proper form,
+  # and flattened values are simply the shapes to pass to the .bind() method.
+  # `aliases` would help to generate properly array-only indexed
+  # `operand_output_aliases` property to use ffi interface
+  abs_args, abs_kwargs, array_id2idx, args_kwargs_meta = serialize_args_kwargs(
+    jtfu, args, kwargs
+  )
+
+  pure_out_shapes_flat, pure_out_tree = tree_util.tree_flatten(pure_out_shapes)
+  num_pure_outputs = len(pure_out_shapes_flat)
+
+  aliased_shapes_flat, aliased_tree = tree_util.tree_flatten(aliased_shapes)
+  aliased_shape_id2idx = {  # shape id -> raw output array idx
+    id(s): i + num_pure_outputs for i, s in enumerate(aliased_shapes_flat)
+  }
+  operand_output_aliases = {
+    array_id2idx[arr_id]: aliased_shape_id2idx[shp_id]
+    for arr_id, shp_id in aliases.items()
+  }
+  num_aliased_outputs = len(aliased_shapes_flat)
+
+  if num_pure_outputs + num_aliased_outputs == 0:
+    raise ValueError(
+      "No outputs specified for the kernel, DCE will eliminate the call entirely"
+    )
 
   out_flat = triton_kernel_call_p.bind(
-      *array_args,
-      fn=kernel,
-      scalar_args=tuple(scalar_args),
-      name=name,
-      custom_call_target_name=custom_call_target_name,
-      out_shapes=tuple(flat_out_shapes),
-      grid=grid,
-      num_warps=num_warps,
-      num_stages=num_stages,
-      num_ctas=num_ctas,
-      compute_capability=compute_capability,
-      enable_fp_fusion=enable_fp_fusion,
-      input_output_aliases=tuple(input_output_aliases.items()),
-      zeroed_outputs=zeroed_outputs,
-      debug=debug,
-      serialized_metadata=serialized_metadata,
-      metaparams=tuple(metaparams.items()),
+    *abs_args,
+    *abs_kwargs,
+    fn=kernel,
+    kernel_call_name=name,
+    custom_call_target_name=custom_call_target_name,
+    # out_shapes must be a flat sequence of shapes of ALL arrays whose result must be
+    # returned, i.e. output + input-output=aliased arrays.
+    out_shapes=tuple(pure_out_shapes_flat) + tuple(aliased_shapes_flat),
+    grid=grid,
+    compute_capability=compute_capability,
+    operand_output_aliases=tuple(operand_output_aliases.items()),
+    zeroed_outputs=zeroed_outputs,
+    serialized_metadata=serialized_metadata,
+    args_kwargs=args_kwargs_meta,
+    out_info=(num_pure_outputs, pure_out_tree),
   )
-  return tree_util.tree_unflatten(out_tree, out_flat)
+
+  pure_outs = (
+    tree_util.tree_unflatten(pure_out_tree, out_flat[:num_pure_outputs])
+    if num_pure_outputs > 0
+    else {}
+  )
+  aliased_outs = (
+    tree_util.tree_unflatten(aliased_tree, out_flat[num_pure_outputs:])
+    if num_aliased_outputs > 0
+    else ()
+  )
+  ret = tuple(pure_outs.values()) + aliased_outs
+  return ret[0] if len(ret) == 1 else ret

--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -14,63 +14,59 @@
 
 """Module for calling Triton or Triton.Gluon kernels from JAX."""
 
-from __future__ import annotations
-
 from collections.abc import Callable, Sequence
 import copy
 import dataclasses
 import functools
+from functools import cached_property
+import inspect
+import itertools
 import os
 import pprint
 import tempfile
-import types
 from typing import Any, Protocol, Union
 import zlib
 
-from absl import logging
 import jax
 from jax import tree_util
-from jax._src import core
-from jax._src import state
-from jax._src import util
+from jax._src import core, util
 from jax._src.lib import gpu_triton as triton_kernel_call_lib
 import jax.extend as jex
-from jax.interpreters import ad
-from jax.interpreters import batching
-from jax.interpreters import mlir
-from jax.interpreters import xla
+from jax.interpreters import ad, batching, mlir, xla
 import jax.numpy as jnp
 import numpy as np
 
 
-CAN_USE_TRITON = False
-try:
-  import triton
-  from triton.compiler import compiler as tc
-  import triton.language as tl
-  from triton.runtime import autotuner
-  import triton._C.libtriton as _triton
-  import triton.backends.nvidia.compiler as cb
+import triton
+from triton.compiler import compiler as tc
+from triton.runtime import autotuner
+import triton.runtime.jit as triton_runtime_jit
+import triton._C.libtriton as _triton
+import triton.backends.nvidia.compiler as cb
+import triton.backends.amd.compiler as hb
 
-  import triton.experimental.gluon._runtime as gl_runtime
-  from triton.experimental.gluon import language as gl
-
-  CAN_USE_TRITON = True
-except ModuleNotFoundError:
-  pass
-
-try:
-  import triton.backends.amd.compiler as hb
-except ImportError:
-  hb = None
-  pass
+import triton.experimental.gluon._runtime as gl_runtime
 
 
 if "TRITON_CACHE_DIR" in os.environ:
   del os.environ["TRITON_CACHE_DIR"]
+
 _JAX_TRITON_DUMP_DIR = os.environ.get("JAX_TRITON_DUMP_DIR")
 map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip
+
+Grid = Union[int, tuple[int], tuple[int, int], tuple[int, int, int]]
+GridOrLambda = Union[Grid, Callable[[dict[str, Any]], Grid]]
+
+# a coordinate of an element in kernel parameters coordinate space. The first int indexes
+# kernel parameter in order of its declaration in the signature, and the following ints
+# (if any) indexes into nested tuples inside the actual argument. So this is a kernel
+# call attribute, as it depends on actual argument values, not a kernel attribute (like
+# parameters are)
+# Triton calls a coordinate a path, so have to follow
+CanonicalKernelArgPath = tuple[int, ...]
+KernelArgPath = tuple[int | str, *tuple[int, ...]]
+InOutSpec = int | str | KernelArgPath | tuple[int | str | KernelArgPath, ...]
 
 # b/447434580: Exceeding this limit will cause Triton to emit a single trap
 # instruction, which will cause the GPU to hang indefinitely. See
@@ -97,8 +93,62 @@ _JAX_TO_TRITON_TYPE_MAP = {
     jnp.dtype("bool"): "i1",
 }
 
-Grid = Union[int, tuple[int], tuple[int, int], tuple[int, int, int]]
-GridOrLambda = Union[Grid, Callable[[dict[str, Any]], Grid]]
+
+# Use of types is slightly messy here. First of all, Triton itself uses exact dtypes
+# for arrays, but for scalars (no matter if constexpr, or runtime), it accepts native
+# Python objects only. The actual type of a kernel parameter is determined from the
+# parameter type annotation only. So to feed specialization engine properly, we have to
+# typecast all scalars to Python types. Caveats:
+# 1. we must not typecast constexprs as it's a separate type influencing specialization.
+# 2. Triton's runtime specialization for scalars unconditionally turns all floats into
+# fp32. It's unclear if this is a bug or not - the respective code doesn't even have a
+# string to describe fp64. Probably Triton's kernel launcher doesn't support doubles,
+# but JAX's `create_scalar_parameter()` support doubles perfectly well. However, Triton
+# still makes binaries that expect floats only, so there's no point to handle it
+# differently.
+#
+# Fortunately, both (Triton and JAX) use the same (likely LLVM/MLIR based) type
+# identifiers, so the function below serves both goals - for Triton's specialization and
+# for JAX's launcher.
+def get_type_id(obj: Any) -> str:
+  """Returns a Triton/JAX type identifier for the given object. Expected to be used with
+  run-time values only. Constexprs (string are also constexprs only in Triton) don't
+  need type info."""
+  if hasattr(obj, "dtype"):
+    return _JAX_TO_TRITON_TYPE_MAP[obj.dtype]
+
+  if isinstance(obj, bool):  # True == isinstance(True, int) !!!
+    return "B"
+  if isinstance(obj, int):
+    if -(2**31) <= obj < 2**31:
+      return "i32"
+    elif 2**31 <= obj < 2**32:
+      return "u32"
+    elif -(2**63) <= obj < 2**63:
+      return "i64"
+    elif 2**63 <= obj < 2**64:
+      return "u64"
+    else:
+      raise ValueError(f"integer overflow representing {obj}")
+  if isinstance(obj, float):
+    return "fp32"  # Triton unconditionally treat all floats as fp32, see the note above
+  raise NotImplementedError(f"could not compute type name for {obj}: {type(obj)}")
+
+
+def to_python_type(arg: Any) -> Any:
+  """Typecasts a scalar to a native Python type."""
+  # Note that typecasting ints/floats to respective types also convert JAX's subclasses
+  # like TypedInt and TypedFloat, which choke nanobind's type caster in a default
+  # strict-mode.
+  if isinstance(arg, (bool, np.bool_)):
+    arg = bool(arg)
+  elif isinstance(arg, (int, np.integer)):
+    arg = int(arg)
+  elif isinstance(arg, (float, np.floating)):
+    arg = float(arg)
+  # else return as is and let it possibly, but not necessarily fail (constexprs and
+  # strings pass and the rest isn't expected to be here, so sparing cycles on that)
+  return arg
 
 
 def normalize_grid(grid: GridOrLambda, metaparams) -> tuple[int, int, int]:
@@ -115,35 +165,6 @@ def avals_to_layouts(avals):
   return [list(reversed(range(aval.ndim))) for aval in avals]
 
 
-def get_triton_type(obj: Any) -> str:
-  if isinstance(obj, (jax.core.ShapedArray, state.AbstractRef)):
-    return f"*{_JAX_TO_TRITON_TYPE_MAP[obj.dtype]}"
-  if isinstance(obj, (tl.constexpr, gl.constexpr)):
-    obj = obj.value
-  if isinstance(obj, bool):  # True == isinstance(True, int) !!!
-    return "B"
-  if isinstance(obj, int):
-    if -(2**31) <= obj < 2**31:
-      return "i32"
-    elif 2**31 <= obj < 2**32:
-      return "u32"
-    elif -(2**63) <= obj < 2**63:
-      return "i64"
-    elif 2**63 <= obj < 2**64:
-      return "u64"
-    else:
-      raise ValueError(f"integer overflow representing {obj}")
-  if isinstance(obj, float):
-    return "fp64"
-  if isinstance(obj, np.float32):
-    return "fp32"
-  if isinstance(obj, str):
-    return "str"
-  raise NotImplementedError(
-      f"could not compute type name for {obj}: {type(obj)}"
-  )
-
-
 triton_kernel_call_p = jex.core.Primitive("triton_kernel_call")
 triton_kernel_call_p.multiple_results = True
 triton_kernel_call_p.def_impl(
@@ -154,8 +175,7 @@ triton_kernel_call_p.def_impl(
 @triton_kernel_call_p.def_abstract_eval
 def triton_kernel_call_abstract_eval(*_, out_shapes, **__):
   return [
-      core.ShapedArray(out_shape.shape, out_shape.dtype)
-      for out_shape in out_shapes
+    core.ShapedArray(out_shape.shape, out_shape.dtype) for out_shape in out_shapes
   ]
 
 
@@ -170,10 +190,9 @@ def make_gpu_target_cuda(device, compute_capability):
 _IS_HIPBackend_PATCHED = False
 def _patch_hip_backend():
   """
-  This defuses a bomb planted into Triton's AMD-specific compilation path by
+  This fixes unconditional and totally unnecessary "import torch" in Triton's
+  AMD-specific compilation path added in
   https://github.com/triton-lang/triton/commit/37ff43c5efd6e1b84c00a599ba070a501181e832#diff-33c9a103282c05c9d9d213b94450ae7481b6db8c3c6d810f54f175b4735a3c72
-  In short: there's an unconditional and totally unnecessary "import torch" directive crashing
-  the code when torch isn't installed.
 
   Remove the patch once triton wheel package version is pinned to >= triton version with the fix.
   """
@@ -254,9 +273,7 @@ def compile_ttir_to_ptx_inplace(
     print(ttir)
   try:
     metadata = {}
-    opt_ttir = cuda_backend.make_ttir(
-        ttir, metadata, cuda_options, compute_capability
-    )
+    opt_ttir = cuda_backend.make_ttir(ttir, metadata, cuda_options, compute_capability)
     ttgir = cuda_backend.make_ttgir(
         opt_ttir,
         metadata,
@@ -353,31 +370,17 @@ def compile_ttir_to_hsaco_inplace(
   )
 
 
-_COMPILED_KERNEL_CACHE = {}  # TODO(cjfj): Convert to LRU cache?
+def make_backend(
+  make_gpu_target_func, compute_capability: int | None, num_ctas: int
+) -> tuple[tc.BaseBackend, tc.GPUTarget, int]:
+  """Resolves compute_capability and creates triton's Backend and GPUTarget objects"""
 
-
-def get_or_create_triton_kernel(
-    make_gpu_target_func,
-    platform,
-    fn,
-    arg_dtypes,
-    scalar_args,
-    *,
-    num_warps,
-    num_stages,
-    num_ctas,
-    compute_capability,
-    enable_fp_fusion,
-    metaparams,
-    dump: bool,
-) -> tuple[triton_kernel_call_lib.TritonKernel, Any]:
-  if num_warps is None:
-    num_warps = 4
-  if num_stages is None:
-    num_stages = 3
   # TODO(sharadmv): handle multiple devices, right now we assume device 0
   # which is fine when we have multiple of the same GPU but this won't work in
-  # general.
+  # general. See also how Triton did this in JITFunction's
+  # `self.device_caches = defaultdict(self.create_binder)` -- it spawns a new set of
+  # precomputes for each new device with `x,y,.. = self.device_caches[device]` using the
+  # create_binder() factory function.
   device = 0
   if compute_capability is None:
     compute_capability = triton_kernel_call_lib.get_compute_capability(device)
@@ -387,132 +390,446 @@ def get_or_create_triton_kernel(
   gpu_target = make_gpu_target_func(device, compute_capability)
   backend = triton.compiler.make_backend(gpu_target)
 
-  signature = {fn.arg_names[i]: v for i, v in enumerate(arg_dtypes)}
-  # TODO(sharadmv,zhangqiaorjc): handle differently aligned pointers
-  # We assume that all arrays are aligned to 16 bytes, and Triton may use this
-  # assumption, unless array args are include in the `do_not_specialize` list.
-  alignments = [16] * len(arg_dtypes)
-  for i, _, _ in scalar_args:
-    alignments[i] = 0
-  specialize_impl = _triton.native_specialize_impl
-  is_const = False
-  do_specialize = True
-  specialization = [
-      specialize_impl(
-          backend,
-          types.SimpleNamespace(
-              data_ptr=lambda: alignment, dtype=arg_dtype.removeprefix("*")
-          ),
-          is_const,
-          do_specialize,
-          alignment > 0,
-      )
-      for arg_dtype, alignment in zip(arg_dtypes, alignments)
-  ]
-  attrs = {
-      (i,): backend.parse_attr(attr)
-      for i, (_, attr) in enumerate(specialization)
-  }
-  constants = dict(metaparams)
-  constants.update({k: None for _, k, v in scalar_args if v is None})
-  constants.update({fn.arg_names[i]: 1 for i, _, v in scalar_args if v == 1})
-  for constant in constants:
-    signature[constant] = "constexpr"
+  return backend, gpu_target, compute_capability
 
-  # Cache key should contain any parameter that can affect the compiler output.
-  cache_key = (
-      fn,
-      tuple(signature.items()),
-      tuple(specialization),
-      tuple(constants.items()),
-      num_warps,
-      num_stages,
-      num_ctas,
-      compute_capability,
-      enable_fp_fusion,
-  )
-  kernel = _COMPILED_KERNEL_CACHE.get(cache_key)
 
-  if kernel is None:
-    # First, check that the kernel signature and the reconstructed signature have the
-    # same number of parameters. A mismatch can occur due to differences in
-    # `triton_call(input_output_aliases=)` handling between jax-triton versions.
-    if len(fn.signature.parameters) != len(signature):
-      raise TypeError(
-        f"Number of parameters in the kernel '{fn}' signature "
-        f"({len(fn.signature.parameters)}: {fn.signature}) "
-        f"does not match reconstructed signature ({len(signature)}: {signature}). "
-        "If the kernel was working on an older version of jax-triton and its "
-        "triton_call() launcher uses `input_output_aliases` argument, note that "
-        "implicit output arguments are no longer required for aliased args."
+_BACKEND_OPTIONS_FIELD_NAMES = {
+  "cuda": frozenset(cb.CUDAOptions.__dataclass_fields__.keys()),
+  "hip": frozenset(hb.HIPOptions.__dataclass_fields__.keys()),
+}
+
+
+class JTKernel:
+  def __init__(self, kernel, triton_call_kwargs):
+    if not isinstance(
+      kernel,
+      (
+        triton.JITFunction,
+        gl_runtime.GluonJITFunction,
+        autotuner.Heuristics,
+        autotuner.Autotuner,
+        JTKernel,
+      ),
+    ):
+      raise ValueError(
+        "`kernel` must be a `JTKernel` or Triton's `JITFunction`, `GluonJITFunction`, `Heuristics` or `Autotuner` object."
       )
 
-    opts = {
-        "num_warps": num_warps,
-        "num_stages": num_stages,
-        "num_ctas": num_ctas,
-        "optimize_epilogue": False,
-        "debug": dump,
-        "enable_fp_fusion": enable_fp_fusion,
+    if isinstance(kernel, JTKernel):
+      triton_call_kwargs = {**kernel.triton_call_kwargs, **triton_call_kwargs}
+      kernel = kernel.kernel
+
+    self.kernel = kernel
+
+    if "grid" in triton_call_kwargs:
+      raise ValueError("grid must be provided as an indexing argument to this object")
+
+    # since this code works only once on a kernel declaration point, we could add as
+    # much validation as possible here, to avoid doing it on every kernel launch instead
+    if "out_names" in triton_call_kwargs:
+      # we rely on a user correctly specifying that the order of elements in "out_names"
+      # reflect that in the kernel's signature. Checking that here as much as possible
+      triton_call_kwargs = self._validate_out_names(kernel, triton_call_kwargs)
+
+    self.triton_call_kwargs = triton_call_kwargs
+
+  @staticmethod
+  def _validate_out_names(kernel, triton_call_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Validates as much as possible the order of elements in
+    triton_call_kwargs['out_names']"""
+    out_names = triton_call_kwargs["out_names"]
+    if isinstance(out_names, (str, int)):
+      out_names = (out_names,)
+    elif isinstance(out_names, list):  # won't do this in triton_call(), but here it
+      out_names = tuple(out_names)  # isn't expensive.
+    elif not isinstance(out_names, tuple):
+      raise ValueError("out_names must be a string, or a tuple of specific format")
+    triton_call_kwargs["out_names"] = out_names
+
+    jtfu = JTJITFunction(kernel)  # refactor this out if other validation funcs appear
+    arg_names = jtfu.arg_names
+    last_idx = -1
+    for i, out_elm in enumerate(out_names):
+      is_tuple = isinstance(out_elm, tuple)
+      if is_tuple and len(out_elm) <= 0:
+        raise ValueError(f"out_names[{i}] must be an nonempty tuple")
+      if is_tuple and any(not isinstance(e, int) for e in out_elm[1:]):
+        raise ValueError(
+          "A tuple form of out_names must contain only ints beyond the first element"
+        )
+      is_first_string = is_tuple and isinstance(out_elm[0], str)
+      if isinstance(out_elm, str) or is_first_string:
+        try:
+          param_idx = arg_names.index(out_elm[0] if is_first_string else out_elm)
+        except ValueError:
+          raise ValueError(f"out_names[{i}] must be a valid kernel parameter name")
+        # without args/kwargs we can't look deeper anyway
+      else:
+        param_idx = out_elm[0] if is_tuple else out_elm
+        if not isinstance(out_elm, int):
+          raise ValueError(f"out_names[{i}] must be an int or a string")
+
+      if param_idx <= last_idx:
+        raise ValueError(
+          "The order of elements in out_names must follow the kernel's signature"
+        )
+      last_idx = param_idx
+    return triton_call_kwargs
+
+  def __getitem__(self, grid):
+    return lambda *args, **kwargs: triton_call(
+      *args, kernel=self.kernel, grid=grid, **self.triton_call_kwargs, **kwargs
+    )
+
+
+def kernel(fn=None, **kwargs):
+  """
+  A decorator that wraps a Triton/Gluon kernel function and returns a JTKernel object
+  preserving kwargs to pass to triton_call() launcher.
+  Can be used in two ways:
+  - @jt.kernel
+    @triton.jit  # or @triton.experimental.gluon.jit
+    def kernel_func(x, y, z):
+      ...
+  - @jt.kernel(out_names="z")   # or any other set of key-value pairs for triton_call()
+    @triton.jit
+    def kernel_func(x, y, z):
+      ...
+  The JTKernel object can be used to launch the kernel with a given grid using a
+  familiar Triton syntax kernel_func[grid](x, y) (Note that output arguments are still
+  implicit and should not be passed to the launcher)
+  """
+  if len(kwargs) == 0 or fn is not None:
+    if fn is None:
+      raise ValueError("`kernel` decorator must be used with a kernel function")
+    return JTKernel(fn, kwargs)
+
+  return functools.partial(JTKernel, triton_call_kwargs=kwargs)
+
+
+class JTJITFunction:
+  """A wrapper around Triton's JITFunction/GluonJITFunction object to isolate the rest
+  of the code from Triton's internals and provide a unified interface to bits needed.
+
+  Additionally, it provides a persistence layer to ensure that a certain data doesn't
+  have to be re-created on each kernel launch. A user may assume that even when they
+  create a new JTJITFunction object for an object previously used JITFunction object,
+  the persistent data is reused.
+
+  Since we don't instantiate JTJITFunction objects the way JITFunction objects are
+  instantiated and JTJITFunction have a short lives, we have to store the data in the
+  very JITFunction object itself. For this we use custom attributes on the JITFunction
+  object, prefixed with `_jT_`. The capitalized letter `T` breaks conventions to reduce
+  a possibility of clashing with anything else. When we're ready to remove
+  `triton_call()` in favor of corresponding method of JTJITFunction to launch a kernel
+  similarly to how the upstream Triton does it, we'll be able to remove this since
+  JTJITFunction object will have a proper lifetime.
+  """
+
+  def __init__(
+    self,
+    fn: autotuner.Heuristics
+    | autotuner.Autotuner
+    | triton.JITFunction
+    | gl_runtime.GluonJITFunction,
+  ):
+    # peel off wrappers to get to the JITFunction object
+    if isinstance(fn, JTKernel):
+      fn = fn.kernel
+    if isinstance(fn, JTJITFunction):
+      fn = fn.fn
+    if isinstance(fn, autotuner.Autotuner):
+      fn = fn.fn
+    if isinstance(fn, autotuner.Heuristics):
+      fn = fn.fn
+
+    if not isinstance(fn, (triton.JITFunction, gl_runtime.GluonJITFunction)):
+      raise ValueError(
+        "`kernel` must be a Triton's `JITFunction`, `GluonJITFunction`, `Heuristics` or `Autotuner` object."
+      )
+    self.fn = fn
+
+  @cached_property
+  def arg_names(self) -> list[str]:
+    """Returns a list of the kernel parameter names in the order they are declared in
+    the kernel's signature."""
+    # JITFunction::arg_names is deprecated, as per comment
+    return (
+      self.fn.arg_names
+      if hasattr(self.fn, "arg_names")
+      else [p.name for p in self.fn.params]
+    )
+
+  @cached_property
+  def arg_name_to_index(self) -> dict[str, int]:
+    """Returns a dictionary mapping the kernel parameter names to their indices in the
+    kernel's signature."""
+    return {name: index for index, name in enumerate(self.arg_names)}
+
+  @property  # it's needed only for compiling once, so it's better have this like that
+  def params(self) -> list[triton.runtime.jit.KernelParam]:
+    return self.fn.params
+
+  @property
+  def is_gluon(self) -> bool:
+    return isinstance(self.fn, gl_runtime.GluonJITFunction)
+
+  @property
+  def signature(self) -> inspect.Signature:
+    return self.fn.signature
+
+  def _get_cached_kernel(
+    self,
+    compute_capability: int,
+    specialization: list[tuple[str, Any]],
+    kwargs: dict[str, Any],
+  ) -> tuple[str, triton_kernel_call_lib.TritonKernel | None]:
+    if "_cOmpute_capability" in kwargs:  # capitalization is intended!
+      raise ValueError("'_cOmpute_capability' key is reserved in the options/kwargs!")
+    kwargs["_cOmpute_capability"] = compute_capability
+
+    if not hasattr(self.fn, "_jT_kernel_cache_key"):
+      self.fn._jT_kernel_cache_key = {}
+
+    # two step key resolution is important for supporting callables
+    key = triton_runtime_jit.compute_cache_key(
+      self.fn._jT_kernel_cache_key, specialization, kwargs
+    )
+    del kwargs["_cOmpute_capability"]
+
+    if not hasattr(self.fn, "_jT_kernel_cache"):
+      self.fn._jT_kernel_cache = {}
+
+    return key, self.fn._jT_kernel_cache.get(key, None)
+
+  def _cache_kernel(
+    self,
+    key: str,
+    kernel: triton_kernel_call_lib.TritonKernel,
+    asm: dict | None = None,
+  ):
+    assert isinstance(self.fn._jT_kernel_cache, dict)
+    self.fn._jT_kernel_cache[key] = kernel
+    if asm is not None:
+      if not hasattr(self.fn, "_jT_asm"):
+        self.fn._jT_asm = {}
+      self.fn._jT_asm[key] = asm
+
+  @property
+  def asm(self) -> dict[str, dict] | None:
+    """Returns a dictionary of the assembly files for the kernel if these were saved
+    during compilation.
+    Not the best way to share access to that info, but likely no one needs it except for
+    our tests. If this needs a better support, we could make a getter to fetch at least
+    ttir from a corresponding triton_kernel_call_lib.TritonKernel object instead.
+    """
+    return self.fn._jT_asm if hasattr(self.fn, "_jT_asm") else None
+
+  @property
+  def compiled_kernels_cache_size(self) -> int:
+    return len(self.fn._jT_kernel_cache) if hasattr(self.fn, "_jT_kernel_cache") else 0
+
+  def _make_signature_constexprs(
+    self,
+    named_args: dict[str, Any],
+    sigvals: list[str],
+  ) -> tuple[dict[str, Any], dict[str, Any]]:
+    signature = dict(zip(self.arg_names, sigvals))
+
+    constexprs = triton_runtime_jit.find_paths_if(
+      sigvals, lambda _, val: val == "constexpr"
+    )
+    constexprs = {
+      path: triton_runtime_jit.get_iterable_path(list(named_args.values()), path)
+      for path in constexprs
     }
+    return signature, constexprs
 
-    options = backend.parse_options(opts)
+  @staticmethod
+  def _make_attrs_nonconstexprs_sigvals(
+    backend, specialization: list[tuple[str, Any]], named_args: dict[str, Any]
+  ) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    # We have to always make attributes, since we need them for launching the kernel
+    attrvals = [x[1] for x in specialization]
+    attrs = triton_runtime_jit.find_paths_if(attrvals, lambda _, x: isinstance(x, str))
+    attrs = {
+      k: backend.parse_attr(triton_runtime_jit.get_iterable_path(attrvals, k))
+      for k in attrs
+    }
+    # attrs keys are tuples of integers representing a path into the (possibly nested)
+    # kernel argument list as it is seen by the Triton compiler (i.e. including all
+    # constexprs and whatnot, - everything as in the signature)
 
-    kernel_hash = abs(hash(cache_key))
-    if _JAX_TRITON_DUMP_DIR:
-      os.makedirs(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}")
-      with open(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/config", "w") as f:
-        pprint.pprint(cache_key, stream=f)
-        pprint.pprint(options, stream=f)
-
-    context = _triton.ir.context()
-    _triton.ir.load_dialects(context)
-    backend.load_dialects(context)
-    codegen_fns = backend.get_codegen_implementation(options)
-
-    real_ASTSource = (
-      gl_runtime.GluonASTSource
-      if isinstance(fn, gl_runtime.GluonJITFunction)
-      else tc.ASTSource
+    sigvals = [x[0] for x in specialization]
+    non_constexprs = triton_runtime_jit.find_paths_if(
+      sigvals, lambda _, val: val != "constexpr"
     )
-    module = real_ASTSource(
-      fn, constexprs=constants, signature=signature, attrs=attrs
-    ).make_ir(gpu_target, options, codegen_fns, backend.get_module_map(), context)
+    non_constexprs = {
+      path: triton_runtime_jit.get_iterable_path(list(named_args.values()), path)
+      for path in non_constexprs
+    }
+    return attrs, non_constexprs, sigvals
 
-    ttir = str(module)
+  def _get_binder(
+    self, backend
+  ) -> Callable[
+    [Any, ..., Any], tuple[dict[str, Any], list[tuple[str, Any]], dict[str, Any]]
+  ]:
+    # This is important part needs to be fully understood.
+    # create_function_from_signature() is a very inventive optimization in Triton
+    # that one generates once per kernel a so called binder function that simultaneously
+    # and very efficiently:
+    # 1. assigns default values to all unspecified kernel arguments,
+    # 2. assembles a complete dict of parameter_name->value mapping for all arguments
+    # 3. runs a correct specialization pipeline for all arguments, respecting all
+    # user's annotations.
+    # 4. finds key-value elements of kwargs that don't have a match in the kernel
+    # signature.
+    # The dynamically generated binder function exists purely for performance — it
+    # avoids the overhead of branched algo of building the specialization and
+    # application of defaults on every kernel launch, while still computing the
+    # specialization tuples from the actual runtime argument values.
+    if not hasattr(self.fn, "_jT_binder"):
+      # In the upstream, a binder is per-device. Since JAX doesn't support mixed
+      # execution yet, we can safely ignore it.
+      self.fn._jT_binder = triton_runtime_jit.create_function_from_signature(
+        self.fn.signature, self.fn.params, backend
+      )
+    return self.fn._jT_binder
 
-    compilation_result = compile_ttir_inplace(
-        module, backend, options, compute_capability, platform
+  def get_or_create_triton_kernel(
+    self,
+    make_gpu_target_func,
+    platform: str,
+    args: list[Any],
+    *,
+    compute_capability: int | None,
+    kwargs: dict[str, Any],
+  ) -> tuple[triton_kernel_call_lib.TritonKernel, dict[str, Any], dict[str, Any]]:
+    num_warps = kwargs["num_warps"]
+    num_ctas = kwargs["num_ctas"]
+    assert all(
+      isinstance(v, int) for v in (num_warps, kwargs["num_stages"], num_ctas)
+    )  # internal sanity check
+
+    store_asm = False
+    if "_store_asm" in kwargs:
+      store_asm = kwargs["_store_asm"]
+      del kwargs["_store_asm"]  # this is JT internal, no need to leave it further
+
+    backend, gpu_target, compute_capability = make_backend(
+      make_gpu_target_func, compute_capability, num_ctas
     )
 
-    kernel_name = compilation_result.name
-    if _JAX_TRITON_DUMP_DIR:
-      with open(
-          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.ttir", "w"
-      ) as f:
-        f.write(ttir)
-      with open(
-          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.ptx", "w"
-      ) as f:
-        f.write(compilation_result.binary)
-      with open(
-          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.ttgir", "w"
-      ) as f:
-        f.write(compilation_result.ttgir)
-      with open(
-          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.llir", "w"
-      ) as f:
-        f.write(compilation_result.llir)
-      with open(
-          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.compile_info",
-          "w",
-      ) as f:
-        f.write(
-            f"{kernel_name}: shared_mem_bytes:"
-            f" {compilation_result.shared_mem_bytes}\n"
+    named_args, specialization, other_kwargs = self._get_binder(backend)(
+      *args, **kwargs
+    )
+    # named_args is complete dict of kernel param names -> actual values.
+    # other_kwargs is the kwargs with keys corresponding to kernel parameters removed
+    # specialization is a list[tuple[str, Any]], one entry per kernel parameter, that
+    # captures two things about each argument at call time:
+    #   1. Element 0 — the type string: e.g. "i32", "i64", "*fp16", "*ki32"
+    #     (pointer to const), "u1", "fp32", "constexpr", "tensordesc<...>".
+    #   2. Element 1 — the specialization value (the "key"): an attribute that may
+    #     trigger a separately compiled kernel variant. Currently possible values are:
+    #     - None — no runtime specialization (used for bools, floats, do_not_specialize
+    #         params)
+    #     - "D" — value/pointer is divisible by 16 (alignment hint)
+    #     - "" (empty string) — value/pointer is NOT divisible by 16
+    #     - The actual Python value itself — for constexpr parameters and int(1)
+    #     - A cache_key — for JITCallable (nested kernel) arguments. Note that in that
+    #         case the specialization value is a hash string (hopefully!!! lowercase).
+    #         Likely by a coincidence this doesn't hurt to `attrs` building later!
+    # The specialization values are determined at call time by native_specialize_impl in
+    # C++ (triton/python/src/specialize.cc).
+    # Specialization serves 3 goals: (1) affect kernel caching key, (2) discover
+    # additional vars to be turned into constexprs by the compiler, (3) source for the
+    # `attrs` spec.
+
+    attrs, non_constexprs, sigvals = self._make_attrs_nonconstexprs_sigvals(
+      backend, specialization, named_args
+    )
+
+    key, kernel = self._get_cached_kernel(
+      compute_capability, specialization, other_kwargs
+    )
+
+    if kernel is None:
+      # First, check that the kernel signature and the reconstructed signature have the
+      # same number of parameters. A mismatch can occur due to differences in
+      # `triton_call(input_output_aliases=)` handling between jax-triton versions.
+      if len(self.params) != len(named_args):
+        raise TypeError(
+          f"Number of parameters in the kernel '{self.fn}' signature "
+          f"({len(self.params)}: {self.signature}) "
+          f"does not match reconstructed signature ({len(named_args)}: {list(named_args.keys())}). "
+          "If the kernel was working on an older version of jax-triton and its "
+          "triton_call() launcher uses `input_output_aliases` argument, note that "
+          "implicit output arguments are no longer required for aliased args."
         )
 
-    kernel = triton_kernel_call_lib.TritonKernel(
+      signature, constexprs = self._make_signature_constexprs(named_args, sigvals)
+
+      backend_fields = _BACKEND_OPTIONS_FIELD_NAMES[gpu_target.backend]
+      unrecognized = set(kwargs.keys()) - set(named_args.keys()) - backend_fields
+      if len(unrecognized) > 0:
+        raise ValueError(
+          f"Unknown backend options: '{ {k: kwargs[k] for k in unrecognized} }' "
+          f"were found in kwargs! Known options are: {backend_fields}."
+        )
+
+      backend_options = backend.parse_options(kwargs)
+
+      if _JAX_TRITON_DUMP_DIR:
+        kernel_hash = abs(hash(key))
+        os.makedirs(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}")
+        with open(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/config", "w") as f:
+          pprint.pprint(key, stream=f)
+          pprint.pprint(backend_options, stream=f)
+
+      context = _triton.ir.context()
+      _triton.ir.load_dialects(context)
+      backend.load_dialects(context)
+      codegen_fns = backend.get_codegen_implementation(backend_options)
+
+      real_ASTSource = gl_runtime.GluonASTSource if self.is_gluon else tc.ASTSource
+      module = real_ASTSource(
+        self.fn, constexprs=constexprs, signature=signature, attrs=attrs
+      ).make_ir(
+        gpu_target, backend_options, codegen_fns, backend.get_module_map(), context
+      )
+
+      ttir = str(module)
+
+      # while triton_kernel_call_lib.TritonKernel() stores ttir internally,
+      # unfortunately, it doesn't provide access to it, so we have to store it manually
+      # elsewhere for proper testing.
+
+      compilation_result = compile_ttir_inplace(
+        module, backend, backend_options, compute_capability, platform
+      )
+
+      kernel_name = compilation_result.name
+      if _JAX_TRITON_DUMP_DIR:
+        with open(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.ttir", "w") as f:
+          f.write(ttir)
+        with open(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.ptx", "w") as f:
+          f.write(compilation_result.binary)
+        with open(
+          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.ttgir", "w"
+        ) as f:
+          f.write(compilation_result.ttgir)
+        with open(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.llir", "w") as f:
+          f.write(compilation_result.llir)
+        with open(
+          f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/{kernel_name}.compile_info",
+          "w",
+        ) as f:
+          f.write(
+            f"{kernel_name}: shared_mem_bytes: {compilation_result.shared_mem_bytes}\n"
+          )
+
+      kernel = triton_kernel_call_lib.TritonKernel(
         kernel_name,
         num_warps,
         num_ctas,
@@ -520,217 +837,359 @@ def get_or_create_triton_kernel(
         compilation_result.binary,
         ttir,
         compute_capability,
+      )
+
+      asm = dict(ttir=ttir) if store_asm else None
+      self._cache_kernel(key, kernel, asm)
+
+    return kernel, attrs, non_constexprs
+
+
+def make_autotuner_configs(
+  fn: autotuner.Autotuner,
+  kwargs: dict[str, Any],
+  named_args: dict[str, Any],
+) -> list[triton.Config]:
+  """Make and prune redundant autotuner configs based on user-provided kwargs.
+
+  If any kwargs have been specified explicitly, we prune any configs that conflict.
+  The pruning serves a specific need in jax-triton's architecture: unlike native Triton
+  where autotuning happens dynamically at kernel launch, jax-triton must decide at
+  lowering/tracing time which configs to compile. If the user has already fixed certain
+  metaparameters (e.g., num_warps=4, BLOCK_SIZE=128), there's no point compiling or
+  benchmarking autotuner configs that specify different values for those same
+  parameters. The pruning eliminates those contradictory configs, reducing compilation
+  and benchmarking work.
+
+  Note that our implementation is more permissive than Triton's autotuner
+  implementation, which will throw an error if any keys match.
+  """
+  assert isinstance(fn, autotuner.Autotuner)
+
+  # Note this is different .arg_names than in JITFunction!
+  # key_idxs = [fn.arg_names.index(k) for k in fn.keys]
+  # if any(idx not in key_idxs for idx in scalar_args):
+  #  logging.warning(
+  #      "Auto-tuning key does not include all scalar arguments. "
+  #      "We may perform redundant auto-tuning."
+  #  )
+  # ^^^ The upstream doesn't care about this. Why should we?
+
+  prev_early_config_prune_fn = fn.early_config_prune
+
+  def prune_configs(configs, named_args, **conf_kwargs):
+    pruned_configs = []
+    for config in configs:
+      if config.pre_hook is not None:
+        raise NotImplementedError("`pre_hook` is not supported")
+
+      # Keep the config IFF for every user-provided kwargs(k->v), the config
+      # either doesn't specify k at all, or specifies the same value v. This ensures
+      # the config is coherent with explicit user choices
+      if all(config.kwargs.get(k, v) == v for k, v in kwargs.items()):
+        pruned_configs.append(config)
+    if prev_early_config_prune_fn is not None:
+      pruned_configs = prev_early_config_prune_fn(pruned_configs, named_args)
+    return pruned_configs
+
+  fn.early_config_prune = prune_configs
+  fn.nargs = named_args
+  configs = fn.prune_configs(kwargs)
+  return configs
+
+
+def make_configs_from_heuristics(
+  fn: autotuner.Heuristics,
+  configs: list[triton.Config],
+  orig_kwargs: dict[str, Any],
+  named_args: dict[str, Any],
+) -> list[triton.Config]:
+  """Applies heuristics to the configs and returns the updated configs."""
+  assert isinstance(fn, autotuner.Heuristics)
+
+  updated_configs = []
+  for config in configs:
+    kwargs = config.kwargs.copy()
+    for name, heuristic in fn.values.items():
+      kwargs[name] = heuristic({**named_args, **orig_kwargs, **kwargs})
+    updated_config = copy.copy(config)
+    updated_config.kwargs = kwargs
+    updated_configs.append(updated_config)
+  return updated_configs
+
+
+def make_kernel_params(
+  ctx,
+  outputs_offset: int,
+  kwargs: dict[str, Any],
+  grid,
+  zeroed_outputs,
+  configs: list[triton.Config],
+) -> list[dict[str, Any]]:
+  """Make kernel call parameters for each config."""
+  zeroed_outputs_callable = callable(zeroed_outputs)
+
+  kernel_params = []
+  for config in configs:
+    config_metaparams = {**kwargs, **config.kwargs}
+    # filling back backend related config params
+    config_metaparams["num_warps"] = config.num_warps
+    config_metaparams["num_stages"] = config.num_stages
+    config_metaparams["num_ctas"] = config.num_ctas
+    if config.maxnreg is None:
+      if "maxnreg" in config_metaparams:
+        del config_metaparams["maxnreg"]
+    else:
+      config_metaparams["maxnreg"] = config.maxnreg
+
+    config_grid = normalize_grid(grid, config_metaparams)
+
+    config_zeroed_outputs = (
+      zeroed_outputs(config_metaparams) if zeroed_outputs_callable else zeroed_outputs
     )
 
-    _COMPILED_KERNEL_CACHE[cache_key] = kernel
+    # zeroed_params_with_sizes is a dict raw_array_idx -> aval_size_bytes
+    # config_zeroed_outputs is a list of ordinal numbers of output arguments
+    zeroed_params_with_sizes = {
+      i + outputs_offset: aval_size_bytes(ctx.avals_out[i])
+      for i in config_zeroed_outputs
+    }
 
-  return kernel, attrs
+    kernel_params.append(
+      dict(
+        metaparams=config_metaparams,
+        grid=config_grid,
+        zeroed_params_with_sizes=zeroed_params_with_sizes,
+      )
+    )
+  return kernel_params
+
+
+def convert_zeroed_outputs(
+  jtfu: JTJITFunction,
+  kwargs: dict[str, Any],
+  zeroed_outputs: Sequence[InOutSpec] | Callable[[dict[str, Any]], Sequence[InOutSpec]],
+) -> tuple[int, ...]:
+  idx2name = jtfu.arg_names
+  assert zeroed_outputs
+
+  def _unwrap_compound(arg: Any) -> tuple[int, ...]:
+    if not isinstance(arg, tuple):
+      raise ValueError(
+        f"Element of zeroed_outputs must reference an array or a tuple of arrays. Found {arg} of type {type(arg)}"
+      )
+    flat, _ = tree_util.tree_flatten(arg)
+    assert all(isinstance(elm, JTArray) for elm in flat), (
+      "All elements of a compound must be arrays"
+    )
+    return tuple(elm.index for elm in flat)
+
+  def _unwrap(elm) -> tuple[int, ...]:
+    """For a single element of zeroed_outputs returns raw indices of all output arrays
+    it corresponds to"""
+    is_int = isinstance(elm, int)
+    if isinstance(elm, (int, str)):
+      arg_name = idx2name[elm] if is_int else elm
+      arg = kwargs[arg_name]
+      # we could perhaps have a check for it being output argument too by modifying JTArray
+      if isinstance(arg, JTArray):
+        return (arg.index,)
+      return _unwrap_compound(arg)
+    elif isinstance(elm, (tuple, list)):
+      if not elm:
+        raise ValueError("Empty tuple or list is not a valid element of zeroed_outputs")
+      top_elm = elm[0]
+      if not isinstance(top_elm, (int, str)):
+        raise ValueError(
+          "First element of a tuple or list in zeroed_outputs must be an int or a str"
+        )
+      arg_name = idx2name[top_elm] if isinstance(top_elm, int) else top_elm
+      arg = (
+        kwargs[arg_name]
+        if len(elm) == 1
+        else triton_runtime_jit.get_iterable_path(kwargs[arg_name], elm[1:])
+      )
+      if isinstance(arg, JTArray):
+        return (arg.index,)
+      return _unwrap_compound(arg)
+    else:
+      raise ValueError(f"Invalid element of zeroed_outputs: {elm}")
+
+  if callable(zeroed_outputs):
+    orig_zeroed = zeroed_outputs
+    zeroed_outputs = lambda kw: tuple(
+      itertools.chain.from_iterable(map(_unwrap, orig_zeroed(kw)))
+    )
+  else:
+    zeroed_outputs = tuple(itertools.chain.from_iterable(map(_unwrap, zeroed_outputs)))
+
+  return zeroed_outputs
+
+
+def add_output_args(
+  jtfu: JTJITFunction,
+  ctx,
+  out_info: tuple[int, tree_util.PyTreeDef],
+  args: list[Any],
+  kwargs: dict[str, Any],
+) -> dict[str, Any]:
+  """Add output arguments to the argument list/dictionary."""
+  num_pure_outputs, pure_out_tree = out_info
+  assert num_pure_outputs <= len(ctx.avals_out)
+
+  outputs = tree_util.tree_unflatten(
+    pure_out_tree,
+    (JTArray.from_avals_by_idx(ctx.avals_out, i) for i in range(num_pure_outputs)),
+  )
+  # outputs is a dict mapping out-spec->possibly nested structure of 1 or many JTArrays
+
+  idx2name = jtfu.arg_names
+  for out_spec, arrays in outputs.items():
+    assert isinstance(out_spec, tuple)
+    top_idx = out_spec[0]
+    assert isinstance(top_idx, int)
+    arg_name = idx2name[top_idx]
+    if top_idx < len(args):
+      raise ValueError(f"Output argument idx {top_idx}=>{arg_name} mustn't be in args")
+    if len(out_spec) == 1:
+      if arg_name in kwargs:
+        raise ValueError(f"Output argument {arg_name} mustn't be in kwargs")
+      kwargs[arg_name] = arrays
+    else:
+      # So this is a path into a compound, and this is a bit tricky, as we could only
+      # expect tuples as compounds and tuples are immutable. We'd have to rebuild the
+      # whole nested tuple structure to modify just a single element. For similar
+      # purposes (see triton._utils.set_iterable_path()) Triton uses
+      # triton.language.core.tuple class which is a list under the hood.
+      raise ValueError(
+        f"Output argument spec for {arg_name} is a nested {out_spec} and we don't currently support that"
+      )
+  return kwargs
 
 
 def triton_kernel_call_lowering(
-    make_gpu_target_func,
-    ctx,
-    *array_args,
-    fn,
-    scalar_args,
-    name,
-    out_shapes,
-    grid,
-    num_warps,
-    num_stages,
-    num_ctas,
-    compute_capability,
-    enable_fp_fusion,
-    input_output_aliases,
-    zeroed_outputs,
-    debug,
-    serialized_metadata,
-    metaparams: tuple[tuple[str, Any], ...],
+  make_gpu_target_func,
+  ctx,
+  *abstract_args,
+  fn,
+  kernel_call_name,
+  out_shapes,
+  grid,
+  compute_capability,
+  operand_output_aliases,
+  zeroed_outputs,
+  serialized_metadata,
+  args_kwargs,
+  out_info,
 ):
-  # we have to pass metaparams dictionary as a tuple to allow hashing necessary for
-  # lowering via xla_primitive_callable()
-  assert isinstance(metaparams, tuple), "metaparams must be tuple[tuple[str, Any], ...]"
-  metaparams = dict(metaparams)  # wil crash if tuple format is incompatible
+  operand_output_aliases = dict[int, int](operand_output_aliases)
 
-  kernel_call_name = name
-  args = list(ctx.avals_in)
-  arg_dtypes = list(map(get_triton_type, ctx.avals_in))
-  for idx, dtype, v in scalar_args:
-    args.insert(idx, v)
-    arg_dtypes.insert(idx, dtype)
-  # Extract only the output avals not referenced in the input_output_aliases mapping.
-  assert isinstance(input_output_aliases, tuple), "input_output_aliases must be a tuple"
-  input_output_aliases = dict(input_output_aliases)
-  strictly_out_avals = [
-    aval
-    for i, aval in enumerate(ctx.avals_out)
-    if i not in input_output_aliases.values()
-  ]
-  args.extend(strictly_out_avals)
-  arg_dtypes.extend(map(get_triton_type, strictly_out_avals))
+  jtfu = JTJITFunction(fn)
 
-  named_args = dict(unsafe_zip(fn.arg_names, args))
+  args, kwargs, nonabstracted = deserialize_args_kwargs(ctx, abstract_args, args_kwargs)
 
-  if isinstance(fn, autotuner.Autotuner):
-    if hasattr(fn, "key_idx"):
-      key_idxs = fn.key_idx  # Triton <=3.2
-    else:
-      key_idxs = [fn.arg_names.index(k) for k in fn.keys]
-    if any(idx not in key_idxs for idx, _, _ in scalar_args):
-      logging.warning(
-          "Auto-tuning key does not include all scalar arguments. "
-          "We may perform redundant auto-tuning."
-      )
-
-    # If any metaparams have been specified explicitly, we prune any configs
-    # that conflict. Note that this is more permissive than Triton's autotuner
-    # implementation, which will throw an error if any keys match.
-    # TODO(cjfj): Prune explicit `num_warps` / `num_stages`.
-    prev_early_config_prune_fn = fn.early_config_prune
-
-    def prune_configs(configs, named_args, **kwargs):
-      pruned_configs = []
-      for config in configs:
-        if config.pre_hook is not None:
-          raise NotImplementedError("`pre_hook` is not supported")
-
-        if all(config.kwargs.get(k, v) == v for k, v in metaparams.items()):
-          pruned_configs.append(config)
-      if prev_early_config_prune_fn is not None:
-        pruned_configs = prev_early_config_prune_fn(pruned_configs, named_args)
-      return pruned_configs
-
-    fn.early_config_prune = prune_configs
-    fn.nargs = named_args
-    configs = fn.prune_configs(metaparams)
-    fn = fn.fn
-  else:
-    config = triton.Config(
-        {},
-        num_warps=num_warps,
-        num_stages=num_stages,
-        num_ctas=num_ctas,
-    )
-    configs = [config]
-
-  if isinstance(fn, autotuner.Heuristics):
-    updated_configs = []
-    for config in configs:
-      kwargs = config.kwargs.copy()
-      for name, heuristic in fn.values.items():
-        kwargs[name] = heuristic({**named_args, **metaparams, **kwargs})
-      updated_config = copy.copy(config)
-      updated_config.kwargs = kwargs
-      updated_configs.append(updated_config)
-    configs = updated_configs
-    fn = fn.fn
+  # extending with outputs
+  kwargs = add_output_args(jtfu, ctx, out_info, args, kwargs)
+  if zeroed_outputs:
+    zeroed_outputs = convert_zeroed_outputs(jtfu, kwargs, zeroed_outputs)
 
   if not isinstance(fn, (triton.JITFunction, gl_runtime.GluonJITFunction)):
-    raise ValueError(
-        "`kernel` must be a Triton `JITFunction`, `GluonJITFunction`, `Heuristics` or `Autotuner`."
+    # Note `fn.arg_names` below isn't `JITFunction::arg_names`: Autotuner and
+    # Heuristics classes have their own field and it's NOT deprecated.
+    named_args = dict(unsafe_zip(fn.arg_names, args))
+    # named_args are needed only for Autotuner/Heuristics handling.
+    # note that the above construction of named_args is based on positional args only.
+    # This is fully coherent with how upstream does it in Autotuner/Heuristics classes.
+    # These are genuinely name-value pairs for passed positional arguments only, and not
+    # `bound_args` constructed using kernel's signature.
+
+  if isinstance(fn, autotuner.Autotuner):
+    # We should unpack autotuner first and heuristics second to ensure we'd
+    # eventually get to a correct actual kernel `fn`.
+    configs = make_autotuner_configs(fn, kwargs, named_args)
+    fn = fn.fn
+  else:
+    ttcfg_args = dict(
+      num_warps=kwargs["num_warps"],
+      num_stages=kwargs["num_stages"],
+      num_ctas=kwargs["num_ctas"],
     )
+    if "maxnreg" in kwargs:
+      ttcfg_args["maxnreg"] = kwargs["maxnreg"]
+    configs = [triton.Config({}, **ttcfg_args)]
 
-  output2input = {v: k for k, v in input_output_aliases.items()}
-  if len(output2input) != len(input_output_aliases):
-    raise ValueError("input_output_aliases must be a bijection")
+  if isinstance(fn, autotuner.Heuristics):
+    configs = make_configs_from_heuristics(fn, configs, kwargs, named_args)
+    fn = fn.fn
 
-  outputs_offset = len(ctx.avals_in) + len(scalar_args)
-  config_params = []
-  for config in configs:
-    config_metaparams = {**metaparams, **config.kwargs}
-    config_grid = normalize_grid(grid, config_metaparams)
-
-    config_zeroed_outputs = zeroed_outputs
-    if callable(zeroed_outputs):
-      config_zeroed_outputs = config_zeroed_outputs(config_metaparams)
-
-    # zeroed_params_with_sizes is a dict output_arg_idx -> aval_size_bytes
-    # config_zeroed_outputs is output ordinal numbers
-    zeroed_params_with_sizes = {
-      output2input[i] if i in output2input else i + outputs_offset: aval_size_bytes(
-        ctx.avals_out[i]
-      )
-      for i in sorted(config_zeroed_outputs)
-    }
-
-    config_params.append(
-        dict(
-            metaparams=tuple(sorted(config_metaparams.items())),
-            num_warps=config.num_warps,
-            num_stages=config.num_stages,
-            num_ctas=config.num_ctas,
-            grid=config_grid,
-            zeroed_params_with_sizes=tuple(zeroed_params_with_sizes.items()),
-        )
-    )
+  kernel_params = make_kernel_params(
+    ctx,
+    len(abstract_args),
+    kwargs,
+    grid,
+    zeroed_outputs,
+    configs,
+  )
 
   kernel_calls = []
-  for params in config_params:
-    kernel, specialization_attr = get_or_create_triton_kernel(
-        make_gpu_target_func,
-        ctx.module_context.platforms[0],
-        fn,
-        arg_dtypes,
-        scalar_args,
-        num_warps=params["num_warps"],
-        num_stages=params["num_stages"],
-        num_ctas=params["num_ctas"],
-        compute_capability=compute_capability,
-        enable_fp_fusion=enable_fp_fusion,
-        metaparams=dict(params["metaparams"]),
-        dump=debug,
+  for params in kernel_params:
+    kernel, specialization_attr, non_constexprs = jtfu.get_or_create_triton_kernel(
+      make_gpu_target_func,
+      ctx.module_context.platforms[0],
+      args,
+      compute_capability=compute_capability,
+      kwargs=params["metaparams"],
     )
 
-    kernel_params = []
-    zeroed_params_with_sizes = dict(params["zeroed_params_with_sizes"])
-    equal_to_1 = {i for i, _, v in scalar_args if v == 1}
-    for i, (arg, dtype) in enumerate(zip(args, arg_dtypes)):
-      if isinstance(arg, core.ShapedArray):
-        arg_attrs = specialization_attr[(i,)]
-        kernel_params.append(
-            triton_kernel_call_lib.create_array_parameter(
-                zeroed_params_with_sizes.get(i, 0),
-                16 if (["tt.divisibility", 16] in arg_attrs) else 0,
-            )
+    call_params = []
+    zeroed_params_with_sizes = params["zeroed_params_with_sizes"]
+    array_idx = 0
+
+    for path, arg in non_constexprs.items():
+      if isinstance(arg, JTArray):
+        arg_attrs = specialization_attr[path]
+        call_params.append(
+          triton_kernel_call_lib.create_array_parameter(
+            zeroed_params_with_sizes.get(array_idx, 0),
+            16 if (["tt.divisibility", 16] in arg_attrs) else 0,
+            # TODO shouldn't we take "tt.divisibility" attr value instead from arg_attrs
+            # if it's there?
+          )
         )
-      elif i not in equal_to_1:
-        # Convert TypedInt/TypedFloat subclasses to plain Python types,
-        # as nanobind's strict-mode integer caster rejects subclasses.
-        if isinstance(arg, bool):
-          arg = bool(arg)
-        elif isinstance(arg, int):
-          arg = int(arg)
-        elif isinstance(arg, float):
-          arg = float(arg)
-        kernel_params.append(
-            triton_kernel_call_lib.create_scalar_parameter(arg, dtype)
-        )
+        array_idx += 1
+      else:
+        dtype = get_type_id(arg)
+        call_params.append(triton_kernel_call_lib.create_scalar_parameter(arg, dtype))
 
     kernel_calls.append(
-        triton_kernel_call_lib.TritonKernelCall(
-            kernel,
-            params["grid"][0],
-            params["grid"][1],
-            params["grid"][2],
-            kernel_params,
-        )
+      triton_kernel_call_lib.TritonKernelCall(
+        kernel,
+        params["grid"][0],
+        params["grid"][1],
+        params["grid"][2],
+        call_params,
+      )
     )
 
   if len(kernel_calls) > 1:
-    named_scalar_args = {fn.arg_names[i]: v for i, _, v in scalar_args}
     input_output_aliases_with_sizes = tuple(
-        (input_idx, output_idx, aval_size_bytes(ctx.avals_in[input_idx]))
-        for input_idx, output_idx in input_output_aliases.items()
+      (input_idx, output_idx, aval_size_bytes(ctx.avals_in[input_idx]))
+      for input_idx, output_idx in operand_output_aliases.items()
     )
     kernel_call = triton_kernel_call_lib.TritonAutotunedKernelCall(
-        f"{kernel_call_name} ({fn.fn.__name__}) {named_scalar_args}",
-        [(call, str(config)) for call, config in zip(kernel_calls, configs)],
-        input_output_aliases_with_sizes,
+      f"{kernel_call_name} ({fn.fn.__name__}) {nonabstracted}",
+      [(call, str(config)) for call, config in zip(kernel_calls, configs)],
+      input_output_aliases_with_sizes,
     )
   else:
     kernel_call = kernel_calls[0]
 
   call_proto = kernel_call.to_proto(kernel_call_name, serialized_metadata)
+
+  # Note, `operand_output_aliases` parameter uses raw positional indices into the
+  # operands that are seen by MLIR custom_call(). Scalars in JAX-Triton are embedded
+  # into `backend_config`/`call_proto` and aren't passed as MLIR operands, hence indices
+  # of `operand_output_aliases` count only arrays among all inputs.
 
   # TODO(phawkins): remove forward_compat after 2026-05-04
   if jax.__version_info__ < (0, 10, 1) or ctx.is_forward_compat():
@@ -738,37 +1197,37 @@ def triton_kernel_call_lowering(
         "triton_kernel_call",
         api_version=2,
         backend_config=zlib.compress(call_proto),
-        operand_output_aliases=input_output_aliases,
+        operand_output_aliases=operand_output_aliases,
     )
-    return rule(ctx, *array_args)
+    return rule(ctx, *abstract_args)
   else:
     rule = jax.ffi.ffi_lowering(
         "triton_kernel_call_ffi",
         api_version=4,
-        operand_output_aliases=input_output_aliases,
+        operand_output_aliases=operand_output_aliases,
     )
-    return rule(ctx, *array_args, opaque=zlib.compress(call_proto))
+    return rule(ctx, *abstract_args, opaque=zlib.compress(call_proto))
 
 
 mlir.register_lowering(
-    triton_kernel_call_p,
-    functools.partial(triton_kernel_call_lowering, make_gpu_target_cuda),
-    platform="cuda",
+  triton_kernel_call_p,
+  functools.partial(triton_kernel_call_lowering, make_gpu_target_cuda),
+  platform="cuda",
 )
 
 mlir.register_lowering(
-    triton_kernel_call_p,
-    functools.partial(triton_kernel_call_lowering, make_gpu_target_hip),
-    platform="rocm",
+  triton_kernel_call_p,
+  functools.partial(triton_kernel_call_lowering, make_gpu_target_hip),
+  platform="rocm",
 )
 
 
 def triton_kernel_call_raise_on_jvp(*args, **kwargs):
   del args, kwargs  # unused
   raise NotImplementedError(
-      "jax_triton.triton_call does not support automatic differentiation. Use "
-      "jax.custom_jvp or jax.custom_vjp to implement a custom automatic "
-      "differentiation rule for your kernel."
+    "jax_triton.triton_call does not support automatic differentiation. Use "
+    "jax.custom_jvp or jax.custom_vjp to implement a custom automatic "
+    "differentiation rule for your kernel."
   )
 
 
@@ -778,51 +1237,378 @@ ad.primitive_jvps[triton_kernel_call_p] = triton_kernel_call_raise_on_jvp
 def triton_kernel_call_raise_on_vmap(*args, **kwargs):
   del args, kwargs  # unused
   raise NotImplementedError(
-      "jax_triton.triton_call does not support batching with jax.vmap. Use "
-      "jax.custom_batching.custom_vmap to implement a custom batching rule for "
-      "your kernel."
+    "jax_triton.triton_call does not support batching with jax.vmap. Use "
+    "jax.custom_batching.custom_vmap to implement a custom batching rule for "
+    "your kernel."
   )
 
 
-batching.primitive_batchers[triton_kernel_call_p] = (
-    triton_kernel_call_raise_on_vmap
-)
+batching.primitive_batchers[triton_kernel_call_p] = triton_kernel_call_raise_on_vmap
 
 
 class ShapeDtype(Protocol):
+  @property
+  def shape(self) -> tuple[int, ...]: ...
 
   @property
-  def shape(self) -> tuple[int, ...]:
-    ...
+  def dtype(self) -> np.dtype: ...
 
-  @property
-  def dtype(self) -> np.dtype:
-    ...
+
+class JTArray:
+  _default_alignment = 16
+
+  @classmethod
+  def from_avals_by_idx(cls, avals: list, idx: int):
+    """Instantiate a JTArray from a list of avals and an index into the list."""
+    return cls(avals[idx], idx)
+
+  def __init__(self, aval, idx: int):
+    self.dtype = get_type_id(aval)
+    self.index = idx  # index into a corresponding avals array.
+    # TODO(sharadmv,zhangqiaorjc): handle differently aligned pointers
+    self.data_ptr = lambda: JTArray._default_alignment
+
+
+def serialize_args_kwargs(jtfu, args, kwargs):
+  """Prepares args and kwargs for passing through JAX's primitive system by separating
+  things that must be traced from things that must be passed as is.
+
+  Returns a sequence of traced values, a mapping: array id -> flat array index to
+  construct operand_output_aliases mapping, and a tuple of hashable reconstruction info.
+  Assumes that a caller adheres to the Triton's rules about argument types, so no
+  special checks for hashability are done for performance reasons.
+  """
+  assert isinstance(jtfu, JTJITFunction), "jtfu must be a JTJITFunction object"
+  leaves, treedef = tree_util.tree_flatten((args, kwargs))
+  is_array = tuple(isinstance(v, jax.Array) for v in leaves)
+  dyn_leaves = [v for v, b in zip(leaves, is_array) if b]
+  static_leaves = tuple(to_python_type(v) for v, b in zip(leaves, is_array) if not b)
+  array_id2idx = {id(v): i for i, v in enumerate(dyn_leaves)}
+  return dyn_leaves, array_id2idx, (treedef, is_array, static_leaves)
+
+
+def deserialize_args_kwargs(ctx, abstract_args, args_kwargs_meta):
+  """Reconstructs args and kwargs from the serialized form. Abstract arguments are
+  replaced by stubs."""
+  treedef, is_array, static_leaves = args_kwargs_meta
+  abs_iter = (
+    JTArray.from_avals_by_idx(ctx.avals_in, i) for i in range(len(abstract_args))
+  )
+  static_iter = iter(static_leaves)
+  leaves = [next(abs_iter) if b else next(static_iter) for b in is_array]
+  args, kwargs = tree_util.tree_unflatten(treedef, leaves)
+  return args, kwargs, static_leaves
+
+
+ArrayId = int
+OutShapeId = int
+
+
+def _in_spec_to_ShapeDtypeStruct(
+  elm: InOutSpec,
+  args: list[Any],
+  kwargs: dict[str, Any],
+  name2idx: dict[str, int],
+  idx2name: list[str],
+  aliases: dict[ArrayId, OutShapeId],  # mutable
+  shapes: list[jax.ShapeDtypeStruct],  # mutable
+):
+  """For an :in-spec: element `elm` traverses the `args`/`kwargs` to find all arrays
+  addressed by it and updates a list of ShapeDtypeStruct objects describing the arrays
+  and a dict mapping from array identifiers to the ShapeDtypeStruct identifiers.
+  """
+  # this code runs each kernel launch, so proper validation is expensive here, so
+  # we skip most of checks allowing it just to fail, should the spec be incorrect.
+  # We might check some things later on the go.
+  orig_name = None
+  if isinstance(elm, int):
+    path = (elm,)
+  elif isinstance(elm, str):
+    orig_name = elm
+    path = (name2idx[elm],)  # user is responsible for correct indexing
+  elif isinstance(elm, (tuple, list)):
+    param_idx = elm[0]  # first element is an index into signature parameter list
+    if isinstance(param_idx, str):
+      orig_name = param_idx
+      path = (name2idx[param_idx], *elm[1:])
+    else:
+      path = elm
+  else:
+    raise ValueError(f"Invalid in_spec element: {elm}")
+  # checking if the path refers to a terminal array, or to a compound
+  param_idx = path[0]
+  if param_idx < len(args):  # must be in args by construction
+    arg = triton_runtime_jit.get_iterable_path(args, path)
+  else:  # must be in kwargs by construction
+    arg = triton_runtime_jit.get_iterable_path(
+      kwargs[idx2name[param_idx] if orig_name is None else orig_name], path[1:]
+    )
+
+  def _unpack_arg(_, elm: Any):
+    nonlocal shapes, aliases
+    if isinstance(elm, jax.Array):
+      shape = jax.ShapeDtypeStruct(elm.shape, elm.dtype)
+      aid = id(elm)
+      if aid in aliases:
+        raise ValueError(f"Array {elm} found under path {path} can't be aliased twice")
+      aliases[aid] = id(shape)
+      shapes.append(shape)
+    elif not isinstance(elm, tuple):
+      raise ValueError(
+        f"Aliased element {elm} under path {path} is not a jax.Array or a tuple of them"
+      )
+
+  if isinstance(arg, jax.Array):
+    _unpack_arg(None, arg)
+  elif not isinstance(arg, tuple):
+    raise ValueError(
+      f"Aliased element {arg} at path {path} is not a jax.Array or a tuple of them"
+    )
+  else:
+    functools.reduce(_unpack_arg, arg, None)
+
+
+def make_aliased_shapes(
+  jtfu: JTJITFunction,
+  input_output_aliases: dict[int, int] | Sequence[InOutSpec],
+  pure_out_shapes: dict[CanonicalKernelArgPath, Sequence[jax.ShapeDtypeStruct]],
+  orig_aliased_shapes: Sequence[jax.ShapeDtypeStruct],
+  args: list[Any],
+  kwargs: dict[str, Any],
+) -> tuple[tuple[jax.ShapeDtypeStruct], dict[ArrayId, OutShapeId]]:
+  """Uses `input_output_aliases` to produce a tuple of aliased shapes to append to
+  `out_shapes` for the Primitive's .bind() call, and a dict mapping input array
+  identifiers to output array identifiers. After serialization, we'll be able to
+  create `operand_output_aliases` dictionary based on raw array indices using this
+  mapping."""
+  assert isinstance(jtfu, JTJITFunction), "jtfu must be a JTJITFunction object"
+  # building aliased_shapes from in_spec
+  is_dict = isinstance(input_output_aliases, dict)
+  in_spec = list(input_output_aliases.keys()) if is_dict else input_output_aliases
+  if isinstance(in_spec, (int, str)) or (
+    isinstance(in_spec, tuple) and in_spec and not isinstance(in_spec[0], (tuple, list))
+  ):
+    in_spec = [in_spec]
+
+  name2idx = jtfu.arg_name_to_index
+  idx2name = jtfu.arg_names
+  aliases = {}
+
+  def _make_aliased(elm: Any, shapes: list[jax.ShapeDtypeStruct]) -> None:
+    inner_shapes = []
+    if isinstance(elm, list) or (
+      isinstance(elm, tuple) and isinstance(elm[0], (tuple, list))
+    ):
+      tuple(_make_aliased(e, inner_shapes) for e in elm)
+      assert len(inner_shapes) == len(elm)
+      shapes.append(tuple(inner_shapes))
+    else:
+      nonlocal aliases
+      _in_spec_to_ShapeDtypeStruct(
+        elm, args, kwargs, name2idx, idx2name, aliases, inner_shapes
+      )
+      inner_shapes = inner_shapes[0] if len(inner_shapes) == 1 else tuple(inner_shapes)
+      shapes.append(inner_shapes)
+
+  aliased_shapes = []
+  tuple(_make_aliased(e, aliased_shapes) for e in in_spec)
+  # aliased_shapes = _make_aliased(in_spec) if in_spec else []
+
+  # TODO perhaps remove it to spare cycles?
+  # if it's a dict, validating that out_shapes match to aliased_shapes
+  if is_dict:  # and kwargs["debug"]:
+    # getting a starting index of aliased shapes in the original out_shape for reading
+    # a dict values
+    aliased_idx = len(pure_out_shapes)
+    for oidx in input_output_aliases.values():
+      oidx -= aliased_idx
+      if oidx < 0 or oidx >= len(aliased_shapes):
+        raise ValueError(f"Output index {oidx} is out of range for aliased shapes")
+      if aliased_shapes[oidx] != orig_aliased_shapes[oidx]:
+        raise ValueError(
+          f"Output shape {aliased_shapes[oidx]} at index {oidx} doesn't match to the shape "
+          f"in `out_shape[{oidx + aliased_idx}]` {orig_aliased_shapes[oidx]}"
+        )
+  return tuple(aliased_shapes), aliases
+
+
+def _split_out_values(
+  out_values: Sequence,
+  out_names: None | InOutSpec,
+  input_output_aliases: dict[int, int] | Sequence[InOutSpec],
+) -> tuple[tuple, Sequence]:
+  """Splits `out_values` into a tuple of purely output values and a tuple of aliased
+  values."""
+  # If we know `out_names`, the first len(out_names) elements in `out_values`
+  # must describe pure outputs. Else if there's a dict form of `input_output_aliases`,
+  # then len(input_output_aliases) is the number of aliased buffers/shapes. Else -
+  # there are no aliased elements.
+  if out_names is not None:
+    num_purely_output = len(out_names)
+    num_aliased = len(out_values) - num_purely_output
+    if num_aliased < 0 or (
+      isinstance(input_output_aliases, dict)
+      and num_aliased != len(input_output_aliases)
+    ):
+      raise ValueError(
+        "Content of `out_shape` doesn't match to `out_names` and `input_output_aliases` specification"
+      )
+  elif isinstance(input_output_aliases, dict):
+    num_aliased = len(input_output_aliases)
+    num_purely_output = len(out_values) - num_aliased
+    if num_purely_output < 0:
+      raise ValueError(
+        "There was specified more aliased buffers than there are output arguments"
+      )
+  else:
+    num_aliased = 0
+    num_purely_output = len(out_values)
+
+  if num_aliased > 0:
+    aliased_shapes = out_values[num_purely_output:]
+    out_values = out_values[:num_purely_output]
+  else:
+    aliased_shapes = []
+  return out_values, aliased_shapes
+
+
+def canonicalize_out_shape(
+  jtfu: JTJITFunction,
+  out_shape: ShapeDtype | Sequence[ShapeDtype] | dict[InOutSpec, Sequence[ShapeDtype]],
+  out_names: None | InOutSpec,
+  args: list[Any],  # positional args passed to the launcher
+  input_output_aliases: dict[int, int] | Sequence[InOutSpec],  # original aliases
+) -> tuple[
+  dict[CanonicalKernelArgPath, Sequence[jax.ShapeDtypeStruct]],
+  Sequence[jax.ShapeDtypeStruct],
+]:
+  """Converts different forms of out_shape and out_names to a single dict mapping from
+  output kernel argument paths to shapes/dtypes of the output arguments for output-only
+  arguments (those have corresponding parameters in the kernel's signature), and a
+  sequence of shapes/dtypes of aliased arguments (those don't have separate output
+  parameters in the kernel's signature since they reuse some input parameters).
+  """
+  assert isinstance(jtfu, JTJITFunction), "jtfu must be a JTJITFunction object"
+  if isinstance(out_names, (int, str)):
+    out_names = (out_names,)
+  # a basic validation that should be evicted on compilation for jitting is fine
+  if out_names is not None and not isinstance(out_names, (tuple, list)):
+    raise ValueError(
+      "out_names must be None, a string, an int, or a tuple/list of specific format"
+    )
+
+  if isinstance(out_shape, dict):
+    # The dictionary form doesn't have info on aliased buffers
+    if out_names is None:
+      out_names = tuple(out_shape.keys())
+      out_values = tuple(out_shape.values())  # must materialize
+    else:
+      # TODO: remove the check to speedup things/check only lengths, or add cache?
+      if frozenset(out_names) != frozenset(out_shape.keys()):
+        raise ValueError("out_names and out_shape must have the same keys")
+      out_values = tuple(out_shape[name] for name in out_names)  # reorder
+
+    aliased_shapes = []
+  else:
+    if isinstance(out_shape, list):
+      out_shape = tuple(out_shape)
+    out_values = out_shape if isinstance(out_shape, tuple) else (out_shape,)
+    # out_values here might contain shapes for aliased elements, we need to split them
+    out_values, aliased_shapes = _split_out_values(
+      out_values, out_names, input_output_aliases
+    )
+    # TODO we could perhaps even drop `aliased_shapes` entirely, as we reconstruct them
+    # from the signature
+    if out_names is None:
+      # building out_names from the assumption that `args` contain all input arguments
+      arg_names = jtfu.arg_names
+      # out_values may contain compounds, hence we must consider non-flattened shapes
+      out_names = tuple(arg_names[i + len(args)] for i in range(len(out_values)))
+    if len(out_names) != len(out_values):  # this checks only top level specs
+      raise ValueError("out_shape specification mismatches out_names")
+  # no use of out_shape below this line
+
+  def _to_ShapeDtypeStruct(a: Any) -> jax.ShapeDtypeStruct:
+    return jax.ShapeDtypeStruct(a.shape, a.dtype)
+
+  if aliased_shapes:
+    aliased_shapes = tree_util.tree_map(_to_ShapeDtypeStruct, aliased_shapes)
+  out_values = tree_util.tree_map(_to_ShapeDtypeStruct, out_values)
+
+  # now finally canonicalizing out_names using the out_values.
+  pure_out_shapes: dict[CanonicalKernelArgPath, Sequence[jax.ShapeDtypeStruct]] = {}
+  name2idx = jtfu.arg_name_to_index
+  for i, outn in enumerate(out_names):
+    ospec = _canonicalize_out_spec_element(outn, name2idx)
+    pure_out_shapes[ospec] = out_values[i]
+  # While ordering of pure_out_shapes here reflects ordering of out_names, it doesn't
+  # mean that this ordering will be used for passing arguments to the kernel and
+  # producing outputs! There are two things that affect that:
+  # First, we'll use `tree_util.tree_flatten()` to serialize compound data structures
+  # including output args information, and JAX is built on assumption that the
+  # flattening also sorts keys of dictionaries (otherwise it'll break whole Primitive
+  # calls caching system). Keys here are tuple(int,...) where ints are kernel signature
+  # parameter indices, so it'll make them sorted accordingly. An escape hatch of
+  # OrderedDict() could be used here to bypass it, but that won't help, since later
+  # we'll make Triton variables for the output arguments by injecting corresponding
+  # arrays into `kwargs`. This will also nullify any imposed ordering by using
+  # kernel signature ordering. Later upon the kernel launch, we'll iterate over kernel
+  # arguments in the kernel signature order too, to properly pass arguments to the
+  # kernel. Hence, effectively, there's only one ordering - kernel signature's one.
+
+  return pure_out_shapes, aliased_shapes
+
+
+def _canonicalize_out_spec_element(
+  elm: InOutSpec,
+  name2idx: dict[str, int],
+) -> CanonicalKernelArgPath:
+  orig_name = None
+  if isinstance(elm, int):
+    path = (elm,)
+  elif isinstance(elm, str):
+    orig_name = elm
+    path = (name2idx[elm],)  # user is responsible for correct indexing
+  elif isinstance(elm, tuple):
+    prim_idx = elm[0]
+    if isinstance(prim_idx, str):
+      orig_name = prim_idx
+      path = (name2idx[prim_idx], *elm[1:])
+    else:
+      if not isinstance(prim_idx, int):
+        raise ValueError(f"Invalid first element of this out-spec: {elm}")
+      path = elm
+  else:
+    raise ValueError(f"Invalid out-spec element: {elm}")
+  # we don't need to dive deeper. We'll just create a variable for Triton with whatever
+  # a corresponding element of out_shape has
+  return path
 
 
 def triton_call(
-    *args: jax.Array | bool | int | float | np.float32,
-    kernel: (
-        triton.JITFunction
-        | gl_runtime.GluonJITFunction
-        | triton.runtime.Heuristics
-        | triton.runtime.Autotuner
-    ),
-    out_shape: ShapeDtype | Sequence[ShapeDtype],
-    grid: GridOrLambda,
-    name: str = "",
-    num_warps: int | None = None,
-    num_stages: int | None = None,
-    num_ctas: int = 1,  # TODO(giorgioa): Add support for dimensions tuple.
-    compute_capability: int | None = None,
-    enable_fp_fusion: bool = True,
-    input_output_aliases: dict[int, int] | None = None,
-    zeroed_outputs: (
-        Sequence[int] | Callable[[dict[str, Any]], Sequence[int]]
-    ) = (),
-    debug: bool = False,
-    serialized_metadata: bytes = b"",
-    **metaparams: Any,
+  *args: jax.Array | bool | int | float | np.float32,
+  kernel: (
+    triton.JITFunction
+    | gl_runtime.GluonJITFunction
+    | triton.runtime.Heuristics
+    | triton.runtime.Autotuner
+  ),
+  grid: GridOrLambda,
+  out_shape: ShapeDtype | Sequence[ShapeDtype] | dict[str, ShapeDtype] = (),
+  out_names: None | str | tuple[str, ...] = None,
+  name: str = "",
+  num_warps: int | None = None,
+  num_stages: int | None = None,
+  num_ctas: int = 1,  # TODO(giorgioa): Add support for dimensions tuple.
+  compute_capability: int | None = None,
+  enable_fp_fusion: bool = True,
+  input_output_aliases: dict[int, int] | None = None,
+  zeroed_outputs: (
+    Sequence[InOutSpec] | Callable[[dict[str, Any]], Sequence[InOutSpec]]
+  ) = (),
+  debug: bool = False,
+  serialized_metadata: bytes = b"",
+  **kwargs: Any,
 ) -> Any:
   """Calls a Triton kernel with `jax.Array` arguments.
 
@@ -859,13 +1645,12 @@ def triton_call(
   import jax_triton as jt
 
   def add(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
-    out_shape = jax.ShapeDtypeStruct(shape=x.shape, dtype=x.dtype)
     block_size = 8
     return jt.triton_call(
         x,
         y,
         kernel=add_kernel,
-        out_shape=out_shape,
+        out_shape=x,
         grid=(x.size // block_size,),
         block_size=block_size)
 
@@ -875,81 +1660,279 @@ def triton_call(
   print(jax.jit(add)(x_val, y_val))
   ```
 
-  Args:
-    *args: Inputs for the Triton kernel.
-    kernel: A Triton kernel (e.g. a function decorated with `triton.jit`). All
-      static values should be annotated with `triton.language.constexpr` or
-      `triton.experimental.gluon.language.constexpr`.
-    out_shape: A `jax.ShapeDtypeStruct` (or something that has `.shape` and
-      `.dtype` attributes) or a sequence thereof that specify the output(s) of
-      the kernel. Pointers for each of the `jax.ShapeDtypeStruct`s in
-      `out_shape` will be passed into `kernel` following the input parameters.
+  You can find much more use examples in the tests directory.
+
+  Kernel outputs and aliasing specification is a mandatory complexity on top of Triton
+  to interoperate with JAX properly. To describe it, a concept of "Kernel's signature
+  coordinate system" is used - it's a hashable method of addressing an individual
+  array in a random (*args,**kwargs) position of kernel's arguments, no matter how
+  deeply nested it is. A "coordinate" refers to either a single array or all arrays
+  nested into the addressed tuple. It can be:
+    - an int: indexes a kernel signature parameter.
+    - a string - parameter name in the kernel's signature.
+    - a tuple, with [0] being a string, as above, identifies parameter name in the
+      kernel's signature; otherwise must be an int indexing a kernel signature
+      parameter. All other elements of the tuple must be ints indexing into the
+      compound argument corresponding to the parameter mentioned in the [0] tuple's
+      element.
+      For example: a tuple `("Ptrs", 0, 1)` refers to `Ptrs` parameter of the kernel,
+      and expects a corresponding argument to be a tuple, with its 0-th being another
+      tuple, whose 1-st element being an array, or a tuple of arrays/tuples.
+
+  `triton_call()` parameters:
+    *args: Positional inputs for the Triton kernel. In the kernel signature, purely
+      output parameters should go after the last input parameter to be passed as
+      a positional argument to `triton_call()`.
+
+    kernel: Triton (e.g. a function decorated with `triton.jit`) or a Gluon kernel.
+      All static values should be annotated with `triton.language.constexpr` or
+      `triton.experimental.gluon.language.constexpr`. All other Triton annotations are
+      also supported.
+
+    out_shape: Description of shapes and dtypes of output parameters of the kernel.
+      Could be one of the following:
+
+      (1) a single ShapeDtype-like object (something that has `.shape` and
+      `.dtype` attributes) describing a single output parameter of the kernel; or an
+      ordered, potentially nested, sequence of ShapeDtype-like objects corresponding to
+      a one or many output parameters, where each root-level element of the sequence
+      describes one kernel output parameter in its signature (the nesting defines a form
+      of the individual argument, for example, `out_shape=((a,b),c)` defines two output
+      arguments, the first is a tuple of arrays having shapes and dtypes of arrays a
+      and b, and the second is an array having shape and dtype of array c). Ordering of
+      elements in the sequence must correspond to the ordering of the output parameters
+      in the kernel's signature.
+
+      (2) a dictionary mapping kernel's output parameter names or indices to
+      one ShapeDtype-like object or an ordered, potentially nested, sequence of such
+      objects. The nested structure of elements in sequences of the dictionary values
+      defines the structure of the output argument. For example,
+      `out_shape={"a": (x,y), "b": z}` defines that the kernel has two output
+      parameters: param named as "a" is a tuple of 2 arrays, borrowing their shapes and
+      dtypes from arrays x and y, and "b" is a single `z`-like array.
+      If `out_names` is specified, the `out_shape` must have the same keys. Ordering
+      of the kernel signature parameters takes precedence over the ordering of the
+      dictionary keys.
+      If `input_output_aliases` is needed and a dictionary form of `out_shape` is used,
+      the `input_output_aliases` could only use a non-dictionary form, enumerating
+      input arrays only.
+
+      Contrary to the Triton itself, JAX/XLA must manage memory buffers and organize
+      data copying between host and device memory for all array parameters, so
+      `out_shape` helps it with providing the necessary information.
+      Also due to a JAX custom call API there's currently a restriction associated with
+      ordering of input/output parameters in the kernel signature: all purely output
+      parameters must reside after the last non-constexpr input parameter in a flattened
+      sequence of kernel's signature parameters. Interleaving input and output
+      parameters in the signature is not supported.
+
+      If `out_shape` uses a dictionary form, or if `out_names` is provided, then there
+      are no other restrictions. Other cases also require that all input arguments not
+      specialized as constexprs, are passed strictly as positional `args`. `out_names`
+      are inferred from an assumption that output parameters follow the positional
+      parameter values passed as `args` to `triton_call()`.
+
+      Note that no matter which form of `out_shape` is used, arguments corresponding to
+      strictly output parameters should never be passed to a `triton_call()` as a part
+      of `args` or `kwargs`, - these arguments are added implicitly by the launcher. If
+      an argument is going to be an input-output argument, set `input_output_aliases`
+      accordingly.
+
+    out_names: A sequence of output parameter names.
+      This is another way to specify the output parameter names of the kernel. This one
+      is useful to employ in conjunction with the `@kernel` decorator.
+      If `out_shape` is a dictionary, its keys must be in sync with `out_names`.
+
     grid: An integer, tuple of up to 3 integers, or a function that returns a
       tuple of up to 3 integers. When `grid` is an integer, `kernel` is
-      invocated in `grid`-many parallel executions. When `grid` is a sequence of
+      invoked in `grid`-many parallel executions. When `grid` is a sequence of
       integers, `kernel` is launched in a `prod(grid)`-many parallel execution.
-      When `grid` is a function, it is passed `**metaparams` and should return a
-      tuple of up to 3 integers.
-    input_output_aliases: A dictionary mapping input argument indices to output
-      indices. Providing a mapping will alias the corresponding buffers.
-    zeroed_outputs: A sequence of indices, or a function returning a sequence of
-      indices, for outputs that should be zeroed before the kernel is launched.
-      Note that this also supports zeroing input-output (i.e. aliased through
-      `input_output_aliases`) arguments that should be treated as outputs in this
-      argument.
+      When `grid` is a function, it is passed `kwargs` and should return a tuple of up
+      to 3 integers.
+
+    input_output_aliases: tells JAX/XLA backend which input arguments not only supply
+      input data to the kernel, but also serve as output buffers (hence requiring the
+      backend to arrange not only `host->device` data copying before kernel launch, but
+      also `device->host` data copying after kernel execution). Might take two forms:
+
+      (1 - deprecated): A dictionary mapping an input array coordinate in the kernel's
+      signature coordinate space to the `out_shape` sequence coordinate space.
+      Important note: if the kernel also has purely output arguments, they must go first
+      in the `out_shape` sequence, and aliased buffers must go last in the sequence.
+      Interleaving output with in/out argument shapes in `out_shape` isn't supported.
+      User is responsible for adhering to the requirement.
+
+      (2 - recommended): an ordered, potentially nested, sequence of input array
+      coordinates in the kernel's signature coordinate space. When this form is used
+      there should be no corresponding output arguments in the `out_shape`. Shapes and
+      dtypes are inferred from referenced input arguments automatically (JAX/XLA doesn't
+      support typecasting of aliased buffers anyway, so `out_shape` for aliased buffers
+      are always redundant). This could be specifically:
+      - a single int, or a string, or a tuple having an int or a string as a first
+        element: describes an input array in the kernel's signature coordinate space.
+      - a list: ordered, possibly nested, sequence of the above. The nested structure of
+        the sequence describes the structure of the corresponding output argument,
+        containing aliased buffers as it's returned by the `triton_call()`. For example,
+        `input_output_aliases=["out_ptr",[(2,0), "out_ptr2"]]` describes three aliased
+        (input-output) buffers: the first is an input array, passed to `out_ptr` kernel
+        parameter, the second is an array passed at index 0 of a tuple passed to the
+        third positional parameter, and the third is an input array passed for
+        `out_ptr2` kernel parameter. These three buffers (assuming all are single
+        arrays) are returned from the `triton_call()` as a tuple of two elements: [0] is
+        a new array wrapping around the same buffer as was used for `out_ptr` kernel
+        parameter, and [1] is a tuple of two new arrays wrapping the other two array
+        buffers. If some referenced input argument is not an array, but a possibly
+        nested tuple of arrays, all its internal arrays are considered to be aliased,
+        and are returned as a flat tuple of arrays by this call.
+        Note that tuples can also be used instead of lists, just remember that if a
+        tuple's first element is not another iterable, it's always treated as a
+        coordinate descriptor, which might be not what you want. For example,
+        `input_output_aliases=(0,1)` is always treated as a reference to an array at
+        the second position of a tuple passed to the first kernel parameter, but
+        `input_output_aliases=[0,1]` references two arrays passed to the first and the
+        second kernel parameters respectively. Hence for clarity it's recommended,
+        to use tuples only when describing a single input array coordinate.
+      Note that if a kernel needs to start working with an initially zeroed read-write
+      buffer that should be returned as an output (for example, for doing sparse
+      updates), you should designate a purely output argument for it with a proper
+      `out_shape` specification, and mention the buffer coordinate in `out_shape` in
+      `zeroed_outputs` parameter.
+
+    zeroed_outputs: A sequence of kernel signature coordinates of output arguments, or
+      a function taking a dict of metaparameters and returning a sequence of such
+      coordinates, for outputs that should be zeroed before the kernel is launched.
+
+      BREAKING: This argument does NOT support zeroing input-output (i.e. aliased
+      through `input_output_aliases`) arguments anymore since this breaks the semantic
+      of the input-output parameters - with that you can't pass an information in the
+      buffer from the host to the kernel, effectively turning an input-output argument
+      into a purely output argument. Mind a little of terminological mess here:
+      inputs-outputs are considered from the backend's perspective, whose job
+      is to manage memory buffers and arrange data copying between host and device
+      memory for all array parameters. A kernel could always read from what is called a
+      purely output argument above, so if you need the kernel to start working with a
+      buffer from a definite zeroed state, just declare the buffer as a purely output
+      argument in `out_shape` and mention the buffer's coordinate in `zeroed_outputs`.
+
+      Note that a callable form of `zeroed_outputs` is allowed to modify the
+      metaparameters dict passed to it if and only if the modification does not affect
+      kernel compilation (for example, through changing parameters affecting kernel
+      specialization variant), and that modification is propagated to the
+      kernel call. If the modification does affect kernel compilation, the behavior is
+      undefined.
+
     num_warps: The number of warps used to execute the Triton kernel.
     num_stages: The number of stages emitted by the Triton compiler.
     num_ctas: The size of thread blocks per cluster to be used on GPUs with
       compute capabilities >= 9.0. It must be less or equal to 8.
-    debug: Prints out intermediate IRs if True for debugging purposes.
+    enable_fp_fusion: Whether to enable floating-point operands fusion for the kernel.
+    debug: Prints out intermediate IRs if True for debugging purposes. Also used as a
+      the backend options argument.
     serialized_metadata: Arbitrary metadata that will be added into the
       serialized kernel call.
-    metaparams: A dictionary of arguments that will be provided to a `grid`
-      (if it is a function) and to the Triton kernel as `constexpr` arguments.
+
+    kwargs: Key-value pairs (num_warps, num_stages, num_ctas, debug and enable_fp_fusion
+      arguments are added there automatically) that will be provided to:
+      - a `grid` (if it is a function),
+      - backend options constructor (only recognized arguments are passed),
+      - the Triton kernel as `constexpr` arguments (constexprs must always be scalars)
+        or regular runtime arguments.
 
   Returns:
-    Outputs from the Triton kernel.
+    Outputs from the Triton kernel. First go all purely output arguments, then all
+    input-output arguments.
   """
-  if not CAN_USE_TRITON:
-    raise ValueError(
-        "`triton_call` is only available when `triton` is installed."
-    )
-  out_shape = tree_util.tree_map(
-      lambda a: jax.ShapeDtypeStruct(a.shape, a.dtype), out_shape
-  )
-  flat_args, _ = tree_util.tree_flatten(args)
-  # TODO(sharadmv): check in_tree is flat (no Pytrees allowed in triton_call)
-  flat_out_shapes, out_tree = tree_util.tree_flatten(out_shape)
+  # TODO(Arech) improve error reporting and check assumptions violation. We have a ton
+  # of assumptions, requiring a certain behavior from a user. For most if not all of the
+  # assumptions it's possible to verify them. We just don't do this b/c of performance
+  # or other reasons and that hurts user experience. We can have an extensive validation
+  # in at least two cases: (1) some kernel launching parameters aren't vary much between
+  # all possible call, b/c they reflect certain properties of the kernel, so processing
+  # of such parameters could be cached. In that case we can have a proper validation
+  # with the uncached run and all subsequent runs will be blazingly fast. (2) we already
+  # have a `debug` parameter that is meant precisely for that.
 
-  array_args = []
-  scalar_args = []
-  for i, arg in enumerate(flat_args):
-    if isinstance(arg, (bool, int, float)):
-      scalar_args.append((i, get_triton_type(arg), arg))
-    elif isinstance(arg, np.float32):
-      scalar_args.append((i, get_triton_type(arg), float(arg)))
-    else:
-      array_args.append(arg)
+  # Python guarantees the keys don't exist. The original Triton has a single namespace
+  # for both constexprs and backend options, and we're doing the same to unify processing
+  # We are setting defaults here early, since we use values early.
+  kwargs["num_warps"] = num_warps if num_warps is not None else 4
+  kwargs["num_stages"] = num_stages if num_stages is not None else 3
+  kwargs["num_ctas"] = num_ctas
+  kwargs["enable_fp_fusion"] = enable_fp_fusion
+  kwargs["debug"] = debug
 
   if input_output_aliases is None:
-    input_output_aliases = {}
+    input_output_aliases = []
+
+  jtfu = JTJITFunction(kernel)
+  pure_out_shapes, aliased_shapes = canonicalize_out_shape(
+    jtfu, out_shape, out_names, args, input_output_aliases
+  )
+  # now the structure of `pure_out_shapes` would let us reconstruct the output variables
+  # for Triton using ctx.avals_out instead of arrays, and the dict keys would let us
+  # place them correctly into args/kwargs. And also to properly structure returned
+  # outputs from the call
+
+  if input_output_aliases or input_output_aliases == 0:
+    aliased_shapes, aliases = make_aliased_shapes(
+      jtfu, input_output_aliases, pure_out_shapes, aliased_shapes, args, kwargs
+    )
+  else:  # quick shortcut
+    aliases = {}
+    if aliased_shapes:
+      raise ValueError("out_shape isn't coherent with input_output_aliases!")
+
+  # structure of `aliased_shapes` would help to return aliased arrays in a proper form,
+  # and flattened values are simply the shapes to pass to the .bind() method.
+  # `aliases` would help to generate properly array-only indexed
+  # `operand_output_aliases` property to use ffi interface
+  abs_args_kwargs, array_id2idx, args_kwargs_meta = serialize_args_kwargs(
+    jtfu, args, kwargs
+  )
+
+  pure_out_shapes_flat, pure_out_tree = tree_util.tree_flatten(pure_out_shapes)
+  num_pure_outputs = len(pure_out_shapes_flat)
+
+  aliased_shapes_flat, aliased_tree = tree_util.tree_flatten(aliased_shapes)
+  aliased_shape_id2idx = {  # shape id -> raw output array idx
+    id(s): i + num_pure_outputs for i, s in enumerate(aliased_shapes_flat)
+  }
+  operand_output_aliases = {
+    array_id2idx[arr_id]: aliased_shape_id2idx[shp_id]
+    for arr_id, shp_id in aliases.items()
+  }
+  num_aliased_outputs = len(aliased_shapes_flat)
+
+  if num_pure_outputs + num_aliased_outputs == 0:
+    raise ValueError(
+      "No outputs specified for the kernel, DCE will eliminate the call entirely"
+    )
 
   out_flat = triton_kernel_call_p.bind(
-      *array_args,
-      fn=kernel,
-      scalar_args=tuple(scalar_args),
-      name=name,
-      out_shapes=tuple(flat_out_shapes),
-      grid=grid,
-      num_warps=num_warps,
-      num_stages=num_stages,
-      num_ctas=num_ctas,
-      compute_capability=compute_capability,
-      enable_fp_fusion=enable_fp_fusion,
-      input_output_aliases=tuple(input_output_aliases.items()),
-      zeroed_outputs=zeroed_outputs,
-      debug=debug,
-      serialized_metadata=serialized_metadata,
-      metaparams=tuple(metaparams.items()),
+    *abs_args_kwargs,
+    fn=kernel,
+    kernel_call_name=name,
+    # out_shapes must be a flat sequence of shapes of ALL arrays whose result must be
+    # returned, i.e. output + input-output=aliased arrays.
+    out_shapes=(*pure_out_shapes_flat, *aliased_shapes_flat),
+    grid=grid,
+    compute_capability=compute_capability,
+    operand_output_aliases=tuple(operand_output_aliases.items()),
+    zeroed_outputs=zeroed_outputs,
+    serialized_metadata=serialized_metadata,
+    args_kwargs=args_kwargs_meta,
+    out_info=(num_pure_outputs, pure_out_tree),
   )
-  return tree_util.tree_unflatten(out_tree, out_flat)
+
+  pure_outs = (
+    tree_util.tree_unflatten(pure_out_tree, out_flat[:num_pure_outputs])
+    if num_pure_outputs > 0
+    else {}
+  )
+  aliased_outs = (
+    tree_util.tree_unflatten(aliased_tree, out_flat[num_pure_outputs:])
+    if num_aliased_outputs > 0
+    else ()
+  )
+  ret = tuple(pure_outs.values()) + aliased_outs
+  return ret[0] if len(ret) == 1 else ret

--- a/jax_triton/version.py
+++ b/jax_triton/version.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version_info__ = (0, 4, 0)
+__version_info__ = (0, 5, 0)
 __version__ = ".".join(str(v) for v in __version_info__)

--- a/tests/aliasing_test.py
+++ b/tests/aliasing_test.py
@@ -1,0 +1,404 @@
+# Copyright 2026 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Additional tests for input_output_aliases= parameter of triton_call().
+"""
+
+
+import os
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+from jax import config, random
+import jax.numpy as jnp
+import jax_triton as jt
+import jax_triton.triton_lib as jttl
+import numpy as np
+import triton
+import triton.language as tl
+
+config.parse_flags_with_absl()
+
+
+@triton.jit
+def inc_inplace_kernel(x_in_out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+  pid = tl.program_id(axis=0)
+  block_start = pid * BLOCK_SIZE
+  offsets = block_start + tl.arange(0, BLOCK_SIZE)
+  mask = offsets < n_elements
+  x = tl.load(x_in_out_ptr + offsets, mask=mask)
+  output = x + 1
+  tl.store(x_in_out_ptr + offsets, output, mask=mask)
+
+
+class TritonCallAliasingTest(parameterized.TestCase):
+  @parameterized.parameters(False, True)
+  def test_simple(self, with_donation):
+    size = 8
+    x = random.normal(random.key(0), [size])
+    expected = x + 1
+
+    launcher = lambda x: jt.triton_call(
+      x,
+      size,
+      kernel=inc_inplace_kernel,
+      out_shape=x,
+      grid=(8,),
+      BLOCK_SIZE=1,
+      input_output_aliases={0: 0},
+    )
+
+    if with_donation:
+      launcher = jax.jit(launcher, donate_argnums=(0,))
+      x_ptr = x.unsafe_buffer_pointer()
+
+    out = launcher(x)
+
+    if with_donation:
+      np.testing.assert_(x.is_deleted())
+      np.testing.assert_equal(x_ptr, out.unsafe_buffer_pointer())
+
+    np.testing.assert_allclose(out, expected)
+
+  @parameterized.product(with_donation=[False, True], first_is_inout=[False, True])
+  def test_2outputs(self, with_donation, first_is_inout):
+    # this tests aliasing correctness in case of 4 buffer parameters two of which
+    # (0 and 2, or 1 and 3) are in-out params. When first_is_inout=True, buffers 0 and 2
+    # are incremented in place using values from buffers 1 and 3, and otherwise buffers
+    # 1 and 3 are incremented in place with values from buffers 0 and 2.
+
+    @triton.jit
+    def weird_kernel(
+      ptr0,
+      ptr1,
+      ptr2,
+      ptr3,
+      n_elements,
+      BLOCK_SIZE: tl.constexpr,
+      FIRST_INOUT: tl.constexpr,
+    ):
+      """
+      For FIRST_INOUT=True  computes *ptr0[] += *ptr1[], *ptr2[] += *ptr3[],
+      for FIRST_INOUT=False computes *ptr1[] += *ptr0[], *ptr3[] += *ptr2[]
+      """
+      pid = tl.program_id(axis=0)
+      block_start = pid * BLOCK_SIZE
+      offsets = block_start + tl.arange(0, BLOCK_SIZE)
+      mask = offsets < n_elements
+      if FIRST_INOUT:
+        io0_ptr = ptr0
+        io1_ptr = ptr2
+        i0_ptr = ptr1
+        i1_ptr = ptr3
+      else:
+        io0_ptr = ptr1
+        io1_ptr = ptr3
+        i0_ptr = ptr0
+        i1_ptr = ptr2
+
+      x0 = tl.load(io0_ptr + offsets, mask=mask)
+      y0 = tl.load(i0_ptr + offsets, mask=mask)
+      x1 = tl.load(io1_ptr + offsets, mask=mask)
+      y1 = tl.load(i1_ptr + offsets, mask=mask)
+      output0 = x0 + y0
+      output1 = x1 + y1
+      tl.store(io0_ptr + offsets, output0, mask=mask)
+      tl.store(io1_ptr + offsets, output1, mask=mask)
+
+    size = 8
+    keys = random.split(random.key(0), 4)
+    args = [random.normal(key, [size]) for key in keys]
+    expect0 = args[0] + args[1]
+    expect1 = args[2] + args[3]
+
+    inout_aliases = {0: 0, 2: 1} if first_is_inout else {1: 0, 3: 1}
+    inout_indices = tuple(inout_aliases.keys())
+    in_indices = (1, 3) if first_is_inout else (0, 2)
+
+    launcher = lambda *a: jt.triton_call(
+      *a,
+      size,
+      kernel=weird_kernel,
+      out_shape=tuple(a[io] for io in inout_indices),
+      input_output_aliases=inout_aliases,
+      grid=(8,),
+      BLOCK_SIZE=1,
+      FIRST_INOUT=first_is_inout,
+    )
+    if with_donation:
+      launcher = jax.jit(launcher, donate_argnums=inout_indices)
+      io_ptrs = tuple(args[io].unsafe_buffer_pointer() for io in inout_indices)
+
+    outs = launcher(*args)
+
+    if with_donation:
+      for io in inout_indices:
+        np.testing.assert_(args[io].is_deleted())
+      for i in in_indices:
+        np.testing.assert_(not args[i].is_deleted())
+      np.testing.assert_array_equal(
+        io_ptrs, tuple(o.unsafe_buffer_pointer() for o in outs)
+      )
+
+    np.testing.assert_allclose(outs[0], expect0)
+    np.testing.assert_allclose(outs[1], expect1)
+
+  @parameterized.parameters(0, "x_in_out_ptr")
+  def test_raw_values(self, input_output_aliases):
+    """test raw values in input_output_aliases (without a container wrapping)."""
+    size = 8
+    x = random.normal(random.key(0), [size])
+    out = jt.triton_call(
+      x,
+      size,
+      kernel=inc_inplace_kernel,
+      grid=(8,),
+      BLOCK_SIZE=1,
+      input_output_aliases=input_output_aliases,
+    )
+    np.testing.assert_array_equal(out, x + 1)
+
+  @parameterized.parameters([("Ptrs", 1)], [(0, 1)], (("Ptrs", 1),), ((0, 1),))
+  def test_tuple_coordinate_into_compound(self, alias_spec):
+    """Tuple coordinate drilling into a specific element of a compound param.
+    Tests both ("name", idx) and (int, idx) forms."""
+
+    @jt.kernel
+    @triton.jit
+    def _k(Ptrs, val_ptr, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      v = tl.load(val_ptr + offs)
+      x = tl.load(Ptrs[1] + offs)
+      tl.store(Ptrs[1] + offs, x + v)
+
+    a = jnp.array([10.0], dtype=jnp.float32)
+    b = jnp.array([20.0], dtype=jnp.float32)
+    val = jnp.array([5.0], dtype=jnp.float32)
+    out = _k[(1,)]((a, b), val, 1, input_output_aliases=[alias_spec])
+    np.testing.assert_array_equal(out, jnp.array([25.0]))
+
+  def test_nested_list_structured_output(self):
+    """input_output_aliases=[0, [1, 2]] returns (flat, (nested, nested)) and
+    related tests"""
+
+    @jt.kernel
+    @triton.jit
+    def _k(ptr0, ptr1, ptr2, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      tl.store(ptr0 + offs, tl.load(ptr0 + offs) + 1)
+      tl.store(ptr1 + offs, tl.load(ptr1 + offs) + 2)
+      tl.store(ptr2 + offs, tl.load(ptr2 + offs) + 3)
+
+    a = jnp.array([10.0], dtype=jnp.float32)
+    b = jnp.array([20.0], dtype=jnp.float32)
+    c = jnp.array([30.0], dtype=jnp.float32)
+
+    result = _k[1](a, b, c, BLOCK=1, input_output_aliases=[0, [1, 2]])
+    self.assertIsInstance(result, tuple)
+    self.assertEqual(len(result), 2)
+    np.testing.assert_array_equal(result[0], jnp.array([11.0]))
+    self.assertIsInstance(result[1], tuple)
+    self.assertEqual(len(result[1]), 2)
+    np.testing.assert_array_equal(result[1][0], jnp.array([22.0]))
+    np.testing.assert_array_equal(result[1][1], jnp.array([33.0]))
+
+    result = _k[1](a, b, c, BLOCK=1, input_output_aliases=[2, [0, 1]])
+    self.assertIsInstance(result, tuple)
+    self.assertEqual(len(result), 2)
+    np.testing.assert_array_equal(result[0], jnp.array([33.0]))
+    self.assertIsInstance(result[1], tuple)
+    self.assertEqual(len(result[1]), 2)
+    np.testing.assert_array_equal(result[1][0], jnp.array([11.0]))
+    np.testing.assert_array_equal(result[1][1], jnp.array([22.0]))
+    assert jttl.JTJITFunction(_k).compiled_kernels_cache_size == 1
+
+    result = _k[1](a, b, c, BLOCK=1, input_output_aliases=[[1, 0], 2])
+    self.assertIsInstance(result, tuple)
+    self.assertEqual(len(result), 2)
+    np.testing.assert_array_equal(result[1], jnp.array([33.0]))
+    self.assertIsInstance(result[0], tuple)
+    self.assertEqual(len(result[0]), 2)
+    np.testing.assert_array_equal(result[0][0], jnp.array([22.0]))
+    np.testing.assert_array_equal(result[0][1], jnp.array([11.0]))
+    assert jttl.JTJITFunction(_k).compiled_kernels_cache_size == 1
+
+  @parameterized.parameters(
+    "inout_ptr",
+    ["inout_ptr"],
+    ("inout_ptr",),
+    (("inout_ptr",),),
+    [("inout_ptr",)],
+    1,
+    (1,),
+    [1],
+    [(1,)],
+    ((1,),),
+  )
+  def test_mixed_pure_and_aliased_outputs(self, input_output_aliases):
+    """Pure output + aliased output in a single call.
+    Exercises the return assembly: tuple(pure_outs.values()) + aliased_outs."""
+
+    @jt.kernel(out_names="out_ptr")
+    @triton.jit
+    def _k(in_ptr, inout_ptr, out_ptr, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      x = tl.load(in_ptr + offs)
+      y = tl.load(inout_ptr + offs)
+      tl.store(out_ptr + offs, x * 2)
+      tl.store(inout_ptr + offs, y + x)
+
+    x = jnp.array([5.0], dtype=jnp.float32)
+    y = jnp.array([10.0], dtype=jnp.float32)
+    pure_out, aliased_out = _k[(1,)](
+      x, y, BLOCK=1, out_shape=x, input_output_aliases=input_output_aliases
+    )
+    np.testing.assert_array_equal(pure_out, x * 2)
+    np.testing.assert_array_equal(aliased_out, y + x)
+
+  @parameterized.parameters(
+    "inout_ptr",
+    ["inout_ptr"],
+    ("inout_ptr",),
+    (("inout_ptr",),),
+    [("inout_ptr",)],
+    1,
+    (1,),
+    [1],
+    [(1,)],
+    ((1,),),
+  )
+  def test_mixed_multiple_pure_and_aliased_outputs(self, input_output_aliases):
+    """2 pure outputs + 1 aliased output, verifying ordering."""
+
+    @jt.kernel(out_names=("out1_ptr", "out2_ptr"))
+    @triton.jit
+    def _k(in_ptr, inout_ptr, out1_ptr, out2_ptr, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      x = tl.load(in_ptr + offs)
+      y = tl.load(inout_ptr + offs)
+      tl.store(out1_ptr + offs, x * 2)
+      tl.store(out2_ptr + offs, x * 3)
+      tl.store(inout_ptr + offs, y + x)
+
+    x = jnp.array([5.0], dtype=jnp.float32)
+    y = jnp.array([10.0], dtype=jnp.float32)
+    out1, out2, aliased_out = _k[(1,)](
+      x, y, BLOCK=1, out_shape=(x, x), input_output_aliases=input_output_aliases
+    )
+    np.testing.assert_array_equal(out1, x * 2)
+    np.testing.assert_array_equal(out2, x * 3)
+    np.testing.assert_array_equal(aliased_out, y + x)
+
+  @parameterized.product(
+    out_shape_key=["out_ptr", 2, ("out_ptr",), (2,)],
+    input_output_aliases=[
+      "inout_ptr",
+      ["inout_ptr"],
+      ("inout_ptr",),
+      (("inout_ptr",),),
+      [("inout_ptr",)],
+      1,
+      (1,),
+      [1],
+      [(1,)],
+      ((1,),),
+    ],
+  )
+  def test_with_dict_out_shape(self, out_shape_key, input_output_aliases):
+    """Dict out_shape combined with sequence-form input_output_aliases.
+    The dict provides pure output shapes; aliased shapes are inferred from inputs."""
+
+    @jt.kernel
+    @triton.jit
+    def _k(in_ptr, inout_ptr, out_ptr, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      x = tl.load(in_ptr + offs)
+      y = tl.load(inout_ptr + offs)
+      tl.store(out_ptr + offs, x * 2)
+      tl.store(inout_ptr + offs, y + x)
+
+    x = jnp.array([5.0], dtype=jnp.float32)
+    y = jnp.array([10.0], dtype=jnp.float32)
+    pure_out, aliased_out = _k[(1,)](
+      x,
+      y,
+      BLOCK=1,
+      out_shape={out_shape_key: x},
+      input_output_aliases=input_output_aliases,
+    )
+    np.testing.assert_array_equal(pure_out, x * 2)
+    np.testing.assert_array_equal(aliased_out, y + x)
+
+  @parameterized.parameters(
+    "inout_ptr",
+    ("inout_ptr",),
+    (("inout_ptr",),),
+    1,
+    (1,),
+    ((1,),),
+  )
+  def test_dict_form_with_pure_and_aliased_out_shape(self, aliasing_key):
+    """Deprecated dict-form aliases where out_shape carries both pure and
+    aliased shapes, split by out_names count."""
+
+    @jt.kernel(out_names="out_ptr")
+    @triton.jit
+    def _k(in_ptr, inout_ptr, out_ptr, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      x = tl.load(in_ptr + offs)
+      y = tl.load(inout_ptr + offs)
+      tl.store(out_ptr + offs, x * 2)
+      tl.store(inout_ptr + offs, y + x)
+
+    x = jnp.array([5.0], dtype=jnp.float32)
+    y = jnp.array([10.0], dtype=jnp.float32)
+    pure_out, aliased_out = _k[1](
+      x,
+      y,
+      out_shape=(x, y),  # the first is pure output, the second is aliased
+      BLOCK=1,
+      input_output_aliases={aliasing_key: 1},
+    )
+    np.testing.assert_array_equal(pure_out, x * 2)
+    np.testing.assert_array_equal(aliased_out, y + x)
+
+  def test_compound_with_mixed_dtypes(self):
+    """String aliasing a compound param whose arrays have different dtypes.
+    Verifies functools.reduce(_unpack_arg, ...) creates correct per-dtype shapes."""
+
+    @jt.kernel
+    @triton.jit
+    def _k(Ptrs, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      x = tl.load(Ptrs[0] + offs)
+      y = tl.load(Ptrs[1] + offs)
+      tl.store(Ptrs[0] + offs, x + 1)
+      tl.store(Ptrs[1] + offs, y + 10)
+
+    f = jnp.array([5.0], dtype=jnp.float32)
+    i = jnp.array([100], dtype=jnp.int32)
+    out = _k[(1,)]((f, i), 1, input_output_aliases="Ptrs")
+    self.assertIsInstance(out, tuple)
+    self.assertEqual(len(out), 2)
+    np.testing.assert_array_equal(out[0], jnp.array([6.0], dtype=jnp.float32))
+    self.assertEqual(out[0].dtype, jnp.float32)
+    np.testing.assert_array_equal(out[1], jnp.array([110], dtype=jnp.int32))
+    self.assertEqual(out[1].dtype, jnp.int32)
+
+
+if __name__ == "__main__":
+  os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+  absltest.main()

--- a/tests/cluster_test.py
+++ b/tests/cluster_test.py
@@ -50,8 +50,8 @@ class ClusterTest(parameterized.TestCase):
         _dummy_fn(jnp.empty((16,)))
 
   def test_cluster_not_available(self):
-    if 'h100' in jax.devices()[0].device_kind.lower():
-      self.skipTest('Clusters available only on H100s.')
+    if "h100" in jax.devices()[0].device_kind.lower():
+      self.skipTest("This test expects clusters being not available, but it's an H100.")
 
     my_triton_call = functools.partial(jt.triton_call, num_ctas=2)
 

--- a/tests/gluon_test.py
+++ b/tests/gluon_test.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Gluon specific tests.
+"""
+
 from absl.testing import absltest
 from absl.testing import parameterized
 
@@ -23,10 +27,8 @@ import jax_triton as jt
 import numpy as np
 import triton
 
-# import triton.language as tl
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
-# from triton.language.extra import libdevice
 
 
 config.parse_flags_with_absl()

--- a/tests/outshape_test.py
+++ b/tests/outshape_test.py
@@ -1,0 +1,347 @@
+# Copyright 2026 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Additional tests for out_shape= parameter of triton_call().
+"""
+
+import os
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from jax import config
+import jax.numpy as jnp
+import jax_triton as jt
+import jax_triton.triton_lib as jttl
+import numpy as np
+import triton
+import triton.language as tl
+
+config.parse_flags_with_absl()
+
+
+class TritonCallOutShapeTest(parameterized.TestCase):
+  def test_single_output(self):
+    """All forms of out_shape for a single output parameter."""
+
+    @jt.kernel
+    @triton.jit
+    def copy_k(in_ptr, n_elements, out_ptr, BLOCK_SIZE: tl.constexpr):
+      pid = tl.program_id(axis=0)
+      offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+      mask = offs < n_elements
+      tl.store(out_ptr + offs, tl.load(in_ptr + offs, mask=mask), mask=mask)
+
+    def assert_expected(out):
+      np.testing.assert_array_equal(out, x)
+      assert jttl.JTJITFunction(copy_k).compiled_kernels_cache_size == 1
+
+    x = jnp.arange(16, dtype=jnp.float32)
+
+    for out_shape in [{"out_ptr": x}, {2: x}, x, [x], (x,)]:
+      for out_names in [["out_ptr"], ("out_ptr",), "out_ptr", 2, [2], (2,), None]:
+        if (
+          isinstance(out_shape, dict)
+          and out_names is not None
+          and frozenset(out_shape.keys())
+          != frozenset(
+            out_names if isinstance(out_names, (tuple, list)) else (out_names,)
+          )
+        ):
+          out_names = None
+        out = copy_k[(2,)](
+          x, x.size, BLOCK_SIZE=8, out_shape=out_shape, out_names=out_names
+        )
+        assert_expected(out)
+
+  def test_multiple_outputs(self):
+    """All forms of out_shape for multiple output parameters."""
+
+    @jt.kernel
+    @triton.jit
+    def twin_k(in_ptr, n, out1_ptr, out2_ptr, BLOCK_SIZE: tl.constexpr):
+      pid = tl.program_id(axis=0)
+      offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+      mask = offs < n
+      x = tl.load(in_ptr + offs, mask=mask)
+      tl.store(out1_ptr + offs, x, mask=mask)
+      tl.store(out2_ptr + offs, x + 1, mask=mask)
+
+    def assert_expected(o1, o2):
+      np.testing.assert_array_equal(o1, x)
+      np.testing.assert_array_equal(o2, x + 1)
+      assert jttl.JTJITFunction(twin_k).compiled_kernels_cache_size == 1
+
+    x = jnp.arange(8, dtype=jnp.float32)
+
+    for out_shape in [
+      {"out1_ptr": x, "out2_ptr": x},
+      {"out2_ptr": x, "out1_ptr": x},
+      {2: x, "out2_ptr": x},
+      {3: x, "out1_ptr": x},
+      {"out1_ptr": x, 3: x},
+      {"out2_ptr": x, 2: x},
+      {2: x, 3: x},
+      {3: x, 2: x},
+      (x, x),
+      [x, x],
+    ]:
+      for out_names in [
+        None,
+        ("out1_ptr", "out2_ptr"),
+        ("out2_ptr", "out1_ptr"),
+        [2, 3],
+        [3, 2],
+        [2, "out2_ptr"],
+        [3, "out1_ptr"],
+        (2, 3),
+        (3, 2),
+        ("out1_ptr", 3),
+        (2, "out2_ptr"),
+      ]:
+        if (
+          isinstance(out_shape, dict)
+          and out_names is not None
+          and frozenset(out_shape.keys())
+          != frozenset(
+            out_names if isinstance(out_names, (tuple, list)) else (out_names,)
+          )
+        ):
+          out_names = None
+        o1, o2 = twin_k[(1,)](
+          x, x.size, BLOCK_SIZE=8, out_shape=out_shape, out_names=out_names
+        )
+        assert_expected(o1, o2)
+
+  def test_different_shapes(self):
+    """Multiple outputs with different shapes via sequence form."""
+
+    @jt.kernel
+    @triton.jit
+    def split_k(in_ptr, out1_ptr, out2_ptr, BLOCK_SIZE: tl.constexpr):
+      pid = tl.program_id(axis=0)
+      offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+      mask8 = offs < 8
+      mask7 = offs < 7
+      tl.store(out1_ptr + offs, tl.load(in_ptr + offs, mask=mask8), mask=mask8)
+      tl.store(out2_ptr + offs, tl.load(in_ptr + 8 + offs, mask=mask7), mask=mask7)
+
+    x = jnp.arange(15, dtype=jnp.float32)
+    o1, o2 = split_k[(1,)](x, BLOCK_SIZE=8, out_shape=[x[:8], x[8:]])
+    np.testing.assert_array_equal(o1, x[:8])
+    np.testing.assert_array_equal(o2, x[8:])
+
+  def test_different_dtypes(self):
+    """Multiple outputs with different dtypes."""
+
+    @jt.kernel
+    @triton.jit
+    def cast_k(in_ptr, out_f32_ptr, out_i32_ptr):
+      x = tl.load(in_ptr)
+      tl.store(out_f32_ptr, x)
+      tl.store(out_i32_ptr, x.to(tl.int32))
+
+    x = jnp.array([42.25], dtype=jnp.float32)
+    o_f, o_i = cast_k[(1,)](x, out_shape=[x, x.astype(jnp.int32)])
+    np.testing.assert_array_equal(o_f, x)
+    self.assertEqual(o_f.dtype, jnp.float32)
+    np.testing.assert_array_equal(o_i, jnp.array([42], dtype=jnp.int32))
+    self.assertEqual(o_i.dtype, jnp.int32)
+
+  def test_dict_ordering(self):
+    """Dict out_shape + explicit out_names: ordering doesn't matter and is always
+    governed by the kernel signature."""
+
+    @jt.kernel
+    @triton.jit
+    def twin_k(in_ptr, out_a_ptr, out_b_ptr):
+      x = tl.load(in_ptr)
+      tl.store(out_a_ptr, x.to(tl.int32))
+      tl.store(out_b_ptr, x + 10)
+
+    x = jnp.array([5.25], dtype=jnp.float32)
+
+    def assert_expected(o1, o2):
+      np.testing.assert_array_equal(o1, x.astype(jnp.int32))
+      self.assertEqual(o1.dtype, jnp.int32)
+      np.testing.assert_array_equal(o2, x + 10)
+      self.assertEqual(o2.dtype, jnp.float32)
+      assert jttl.JTJITFunction(twin_k).compiled_kernels_cache_size == 1
+
+    for out_shape in [
+      {"out_b_ptr": x, "out_a_ptr": x.astype(jnp.int32)},
+      {"out_a_ptr": x.astype(jnp.int32), "out_b_ptr": x},
+    ]:
+      for out_names in [
+        ("out_b_ptr", "out_a_ptr"),
+        ("out_a_ptr", "out_b_ptr"),
+        None,
+      ]:
+        o1, o2 = twin_k[(1,)](x, out_shape=out_shape, out_names=out_names)
+        assert_expected(o1, o2)
+
+  def test_compound_first(self):
+    """out_shape=((a,(b,c)),d) — first output param is a compound tuple of arrays."""
+
+    @jt.kernel
+    @triton.jit
+    def compound_k(in_ptr, Ptrs, single_out):
+      x = tl.load(in_ptr)
+      tl.static_assert(len(Ptrs) == 2, "Ptrs must be a tuple of 2 elements")
+      tl.store(Ptrs[0], x)
+      tl.static_assert(len(Ptrs[1]) == 2, "Ptrs[1] must be a tuple of 2 arrays")
+      tl.store(Ptrs[1][0], x.to(tl.int32) + 1)
+      tl.store(Ptrs[1][1], x.to(tl.int16) + 2)
+      tl.store(single_out, x * 2)
+
+    x = jnp.array([5.25])
+    z = jnp.zeros((1,), dtype=jnp.float32)
+
+    compound_out, scalar_out = compound_k[(1,)](
+      x, out_shape=((z, (z.astype(jnp.int32), z.astype(jnp.int16))), z)
+    )
+    self.assertIsInstance(compound_out, tuple)
+    self.assertEqual(len(compound_out), 2)
+    np.testing.assert_array_equal(compound_out[0], x)
+    self.assertEqual(compound_out[0].dtype, jnp.float32)
+
+    self.assertIsInstance(compound_out[1], tuple)
+    self.assertEqual(len(compound_out[1]), 2)
+    np.testing.assert_array_equal(compound_out[1][0], (x + 1).astype(jnp.int32))
+    self.assertEqual(compound_out[1][0].dtype, jnp.int32)
+    np.testing.assert_array_equal(compound_out[1][1], (x + 2).astype(jnp.int16))
+    self.assertEqual(compound_out[1][1].dtype, jnp.int16)
+
+    np.testing.assert_array_equal(scalar_out, x * 2)
+    self.assertEqual(scalar_out.dtype, jnp.float32)
+
+  def test_compound_second(self):
+    """out_shape=(a, (b,(c,d),e)) — second output param is a compound tuple of arrays."""
+
+    @jt.kernel
+    @triton.jit
+    def compound_k(in_ptr, single_out, Ptrs):
+      x = tl.load(in_ptr)
+      tl.store(single_out, x * 2)
+      tl.static_assert(len(Ptrs) == 3, "Ptrs must be a tuple of 3 elements")
+      tl.static_assert(len(Ptrs[1]) == 2, "Ptrs[1] must be a tuple of 2 arrays")
+      tl.store(Ptrs[0], x)
+      tl.store(Ptrs[1][0], x.to(tl.int32) + 1)
+      tl.store(Ptrs[1][1], x.to(tl.int16) + 2)
+      tl.store(Ptrs[2], x.to(tl.int8) + 3)
+
+    x = jnp.array([5.25])
+    z = jnp.zeros((1,), dtype=jnp.float32)
+    scalar_out, compound_out = compound_k[(1,)](
+      x,
+      out_shape=(
+        z,
+        (z, (z.astype(jnp.int32), z.astype(jnp.int16)), z.astype(jnp.int8)),
+      ),
+    )
+    np.testing.assert_array_equal(scalar_out, x * 2)
+    self.assertEqual(scalar_out.dtype, jnp.float32)
+
+    self.assertIsInstance(compound_out, tuple)
+    self.assertEqual(len(compound_out), 3)
+    self.assertIsInstance(compound_out[1], tuple)
+    self.assertEqual(len(compound_out[1]), 2)
+
+    np.testing.assert_array_equal(compound_out[0], x)
+    self.assertEqual(compound_out[0].dtype, jnp.float32)
+
+    np.testing.assert_array_equal(compound_out[1][0], (x + 1).astype(jnp.int32))
+    self.assertEqual(compound_out[1][0].dtype, jnp.int32)
+    np.testing.assert_array_equal(compound_out[1][1], (x + 2).astype(jnp.int16))
+    self.assertEqual(compound_out[1][1].dtype, jnp.int16)
+
+    np.testing.assert_array_equal(compound_out[2], (x + 3).astype(jnp.int8))
+    self.assertEqual(compound_out[2].dtype, jnp.int8)
+
+  def test_dict_compound(self):
+    """Dict form: out_shape={"Ptrs": ((a,b),c), "single_out": d} — compound dict value."""
+
+    @jt.kernel
+    @triton.jit
+    def compound_k(in_ptr, Ptrs, single_out):
+      x = tl.load(in_ptr)
+      tl.static_assert(len(Ptrs) == 2, "Ptrs must be a tuple of 2 elements")
+      tl.static_assert(len(Ptrs[0]) == 2, "Ptrs[0] must be a tuple of 2 arrays")
+      tl.store(Ptrs[0][0], x)
+      tl.store(Ptrs[0][1], x.to(tl.int32) + 1)
+      tl.store(Ptrs[1], x.to(tl.int16) + 2)
+      tl.store(single_out, x * 2)
+
+    x = jnp.array([5.25])
+    z = jnp.zeros((1,), dtype=jnp.float32)
+
+    def assert_expected(compound_out, scalar_out):
+      self.assertIsInstance(compound_out, tuple)
+      self.assertEqual(len(compound_out), 2)
+      self.assertIsInstance(compound_out[0], tuple)
+      self.assertEqual(len(compound_out[0]), 2)
+
+      np.testing.assert_array_equal(compound_out[0][0], x)
+      self.assertEqual(compound_out[0][0].dtype, jnp.float32)
+      np.testing.assert_array_equal(compound_out[0][1], (x + 1).astype(jnp.int32))
+      self.assertEqual(compound_out[0][1].dtype, jnp.int32)
+
+      np.testing.assert_array_equal(compound_out[1], (x + 2).astype(jnp.int16))
+      self.assertEqual(compound_out[1].dtype, jnp.int16)
+
+      np.testing.assert_array_equal(scalar_out, x * 2)
+      self.assertEqual(scalar_out.dtype, jnp.float32)
+
+      assert jttl.JTJITFunction(compound_k).compiled_kernels_cache_size == 1
+
+    compound_out, scalar_out = compound_k[(1,)](
+      x,
+      out_shape={
+        "Ptrs": ((z, z.astype(jnp.int32)), z.astype(jnp.int16)),
+        "single_out": z,
+      },
+    )
+    assert_expected(compound_out, scalar_out)
+
+    # Reversed dict key ordering — result must be identical (kernel signature order wins)
+    compound_out2, scalar_out2 = compound_k[(1,)](
+      x,
+      out_shape={
+        "single_out": z,
+        "Ptrs": ((z, z.astype(jnp.int32)), z.astype(jnp.int16)),
+      },
+    )
+    assert_expected(compound_out2, scalar_out2)
+
+  def test_integer_interleaved(self):
+    """Integer out_names for output params interleaved with a kwarg-only scalar input."""
+
+    @jt.kernel
+    @triton.jit
+    def interleaved_k(in_ptr, out1_ptr, scale, out2_ptr):
+      x = tl.load(in_ptr)
+      tl.store(out1_ptr, x)
+      tl.store(out2_ptr, x * scale)
+
+    x = jnp.array([5.25])
+    z = jnp.zeros((1,), dtype=jnp.float32)
+
+    o1, o2 = interleaved_k[(1,)](x, out_shape=[z, z], out_names=(1, 3), scale=3.0)
+    np.testing.assert_array_equal(o1, x)
+    np.testing.assert_array_equal(o2, x * 3)
+
+
+if __name__ == "__main__":
+  os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+  absltest.main()

--- a/tests/triton_call_test.py
+++ b/tests/triton_call_test.py
@@ -12,19 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Main tests for triton_call()
+"""
+
 import os
 from unittest import mock
 
 from absl.testing import absltest
 from absl.testing import parameterized
+from copy import deepcopy
 import jax
-from jax import config
-from jax import random
+from jax import config, random, tree_util
 import jax.numpy as jnp
 import jax_triton as jt
+import jax_triton.triton_lib as jttl
 import numpy as np
 import triton
 import triton.language as tl
+import types
 
 config.parse_flags_with_absl()
 
@@ -35,6 +41,116 @@ def setUpModule():
 
 def tearDownModule():
   config.update("jax_enable_x64", False)
+
+
+class ArgsKwargsTest(parameterized.TestCase):
+  def test_serialize_deserialize(self):
+    """Test that serialize_args_kwargs() and deserialize_args_kwargs() are inverses of
+    each other, caring about the order of kwargs and args."""
+    args = [
+      1,
+      3.14,
+      jnp.array([1, 2, 3], dtype=jnp.int8),
+      (3, 4),
+      "string",
+      (jnp.array([5, 6], dtype=jnp.int16),),
+      (9, jnp.array([7, 8], dtype=jnp.int32), jnp.array([70, 80], dtype=jnp.float32)),
+      (10, (jnp.array([7, 8], dtype=jnp.int64), 11)),
+    ]
+    kwargs = {  # keys aren't in the order of declaration in the signature
+      "b": 3.14,
+      "g": (
+        9,
+        jnp.array([7, 8], dtype=jnp.uint32),
+        jnp.array([70, 80], dtype=jnp.float16),
+      ),
+      "h": (10, (jnp.array([7, 8], dtype=jnp.uint64), 11)),
+      "a": 1,
+      "e": "string",
+      "c": jnp.array([1, 2, 3], dtype=jnp.uint8),
+      "d": (3, 4),
+      "f": (jnp.array([5, 6], dtype=jnp.uint16),),
+    }
+
+    # kwargs are expected to be sorted
+    @triton.jit
+    def kernel(int_, fl, a1, t1, st, t2, t3, t4, *, a, b, c, d, e, f, g, h):
+      pass
+
+    class FakeAvals:
+      def __init__(self):
+        # extracting only arrays from args sequence in kernel's signature order.
+        # This ensures that during ser/des, arrays are ordered in signature's
+        # order too, so no further reshuffling to match signature order to call the
+        # kernel is needed.
+        self.flat = [
+          v
+          for v in tree_util.tree_flatten((
+            args,
+            {k: kwargs[k] for k in sorted(kwargs.keys())},  # restore signature order
+          ))[0]
+          if isinstance(v, jax.Array)
+        ]
+
+        # check the core test assumption that types in args are unique and get_type_id()
+        # is a bijection.
+        unique_types = frozenset(jttl.get_type_id(v) for v in self.flat)
+        assert len(unique_types) == len(self.flat), (
+          "Duplicate types in the args sequence"
+        )
+
+      def __getitem__(self, i):
+        return self.flat[i]
+
+      def __len__(self):
+        return len(self.flat)
+
+    def _make_expected_array_id2idx(args, kwargs):
+      array_id2idx = {}
+      for coll in [args, kwargs]:
+        flat, _ = tree_util.tree_flatten(coll)
+        arrays = [v for v in flat if isinstance(v, jax.Array)]
+        l = len(array_id2idx)
+        array_id2idx.update({id(v): idx + l for idx, v in enumerate(arrays)})
+      return array_id2idx
+
+    kwargs_copy = deepcopy(kwargs)
+    expected_array_id2idx = _make_expected_array_id2idx(args, kwargs_copy)
+
+    abs_args, abs_kwargs, array_id2idx, args_kwargs_meta = jttl.serialize_args_kwargs(
+      jttl.JTJITFunction(kernel),
+      args,
+      kwargs_copy,
+      # kwargs could be modified, hence must copy
+    )
+
+    assert array_id2idx == expected_array_id2idx
+
+    ctx = types.SimpleNamespace(avals_in=FakeAvals())
+    dargs, dkwargs = jttl.deserialize_args_kwargs(
+      ctx, [*abs_args, *abs_kwargs], args_kwargs_meta
+    )
+
+    def assert_correct(a, b):
+      if isinstance(a, jax.Array):
+        assert jttl.get_type_id(a) == b.dtype
+        # can't test actual values here, they were abstracted away
+      elif isinstance(a, tuple):
+        assert isinstance(b, tuple)
+        assert len(a) == len(b)
+        for ai, bi in zip(a, b):
+          assert_correct(ai, bi)
+      else:
+        assert isinstance(a, type(b))
+        assert a == b
+
+    assert len(args) == len(dargs)
+    for ai in range(len(args)):
+      assert_correct(args[ai], dargs[ai])
+
+    assert len(kwargs) == len(dkwargs)
+    for k in kwargs.keys():
+      assert_correct(kwargs[k], dkwargs[k])
 
 
 @triton.jit
@@ -50,7 +166,9 @@ def add_kernel(x_ptr, y_ptr, n_elements, output_ptr, BLOCK_SIZE: tl.constexpr):
 
 
 @triton.jit
-def add_inplace_kernel(x_ptr, y_ptr, n_elements, BLOCK_SIZE: tl.constexpr, INPLACE_Y: tl.constexpr):
+def add_inplace_kernel(
+  x_ptr, y_ptr, n_elements, BLOCK_SIZE: tl.constexpr, INPLACE_Y: tl.constexpr
+):
   pid = tl.program_id(axis=0)
   block_start = pid * BLOCK_SIZE
   offsets = block_start + tl.arange(0, BLOCK_SIZE)
@@ -74,46 +192,35 @@ def add(x, y, *, kernel=add_kernel, **kwargs):
 
   default_grid = lambda meta: triton.cdiv(x.size, meta["BLOCK_SIZE"])
   return jt.triton_call(
-      x,
-      y,
-      x.size,
-      kernel=kernel,
-      out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype),
-      grid=kwargs.pop("grid", default_grid),
-      **kwargs,
+    x,
+    y,
+    x.size,
+    kernel=kernel,
+    out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype),
+    grid=kwargs.pop("grid", default_grid),
+    **kwargs,
   )
 
 
 @triton.jit
-def inc_inplace_kernel(x_in_out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
-  pid = tl.program_id(axis=0)
-  block_start = pid * BLOCK_SIZE
-  offsets = block_start + tl.arange(0, BLOCK_SIZE)
-  mask = offsets < n_elements
-  x = tl.load(x_in_out_ptr + offsets, mask=mask)
-  output = x + 1
-  tl.store(x_in_out_ptr + offsets, output, mask=mask)
-
-
-@triton.jit
 def matmul_kernel(
-    a_ptr,
-    b_ptr,
-    M,
-    N,
-    K,
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
-    stride_cm,
-    stride_cn,
-    c_ptr,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-    K_EXACTLY_DIVISIBLE_BY_BLOCK: tl.constexpr,
+  a_ptr,
+  b_ptr,
+  M,
+  N,
+  K,
+  stride_am,
+  stride_ak,
+  stride_bk,
+  stride_bn,
+  stride_cm,
+  stride_cn,
+  c_ptr,
+  BLOCK_SIZE_M: tl.constexpr,
+  BLOCK_SIZE_N: tl.constexpr,
+  BLOCK_SIZE_K: tl.constexpr,
+  GROUP_SIZE_M: tl.constexpr,
+  K_EXACTLY_DIVISIBLE_BY_BLOCK: tl.constexpr,
 ):
   pid = tl.program_id(axis=0)
   num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
@@ -160,22 +267,22 @@ def matmul(x, y, *, kernel=matmul_kernel, **kwargs):
     return cdiv(m, meta["BLOCK_SIZE_M"]) * cdiv(n, meta["BLOCK_SIZE_N"])
 
   return jt.triton_call(
-      x,
-      y,
-      m,
-      n,
-      k,
-      k,  # stride_am
-      1,  # stride_ak
-      n,  # stride_bk
-      1,  # stride_bn
-      n,  # stride_cm
-      1,  # stride_cn
-      kernel=kernel,
-      out_shape=jax.ShapeDtypeStruct((m, n), dtype=x.dtype),
-      grid=grid,
-      GROUP_SIZE_M=8,
-      **kwargs,
+    x,
+    y,
+    m,
+    n,
+    k,
+    k,  # stride_am
+    1,  # stride_ak
+    n,  # stride_bk
+    1,  # stride_bn
+    n,  # stride_cm
+    1,  # stride_cn
+    kernel=kernel,
+    out_shape=jax.ShapeDtypeStruct((m, n), dtype=x.dtype),
+    grid=grid,
+    GROUP_SIZE_M=8,
+    **kwargs,
   )
 
 
@@ -193,12 +300,14 @@ def create_random_inputs(shape1, shape2=None, *, dtype="float32"):
   return x, y
 
 
-class TritonKernelCallTest(parameterized.TestCase):
+GLOBAL_DEFAULT_ARG = 1
 
+
+class TritonKernelCallTest(parameterized.TestCase):
   @parameterized.product(
-      size=[1, 5, 100, 1024],
-      dtype=["int32", "float32", "float16", "int64", "float64"],
-      block_size=[1, 32, 256],
+    size=[1, 5, 100, 1024],
+    dtype=["int32", "float32", "float16", "int64", "float64"],
+    block_size=[1, 32, 256],
   )
   def test_add(self, size, dtype, block_size):
     x, y = create_random_inputs([size], dtype=dtype)
@@ -207,43 +316,43 @@ class TritonKernelCallTest(parameterized.TestCase):
     np.testing.assert_allclose(out, expected)
 
   @parameterized.product(
-      m=[512, 1024],
-      k=[512],
-      n=[512],
-      dtype=["float32", "float16"],
-      block_size_m=[64, 128],
-      block_size_n=[128, 256],
-      block_size_k=[32],
+    m=[512, 1024],
+    k=[512],
+    n=[512],
+    dtype=["float32", "float16"],
+    block_size_m=[64, 128],
+    block_size_n=[128, 256],
+    block_size_k=[32],
   )
   def test_matmul(
-      self,
-      m,
-      n,
-      k,
-      dtype,
-      block_size_m,
-      block_size_n,
-      block_size_k,
+    self,
+    m,
+    n,
+    k,
+    dtype,
+    block_size_m,
+    block_size_n,
+    block_size_k,
   ):
     if jt.get_compute_capability(0) < 70:
       self.skipTest("Matmul only works on GPUs with capability >= sm70")
 
     x, y = create_random_inputs([m, k], [k, n], dtype=dtype)
     out = matmul(
-        x,
-        y,
-        BLOCK_SIZE_M=block_size_m,
-        BLOCK_SIZE_N=block_size_n,
-        BLOCK_SIZE_K=block_size_k,
-        K_EXACTLY_DIVISIBLE_BY_BLOCK=k % block_size_k == 0,
+      x,
+      y,
+      BLOCK_SIZE_M=block_size_m,
+      BLOCK_SIZE_N=block_size_n,
+      BLOCK_SIZE_K=block_size_k,
+      K_EXACTLY_DIVISIBLE_BY_BLOCK=k % block_size_k == 0,
     )
     expected = jnp.matmul(x, y)
     np.testing.assert_allclose(out, expected, atol=0.05, rtol=0.05)
 
   @parameterized.product(
-      size=[1, 5, 100, 1024],
-      dtype=["int32", "float32", "float16", "int64", "float64"],
-      block_size=[1, 32, 256],
+    size=[1, 5, 100, 1024],
+    dtype=["int32", "float32", "float16", "int64", "float64"],
+    block_size=[1, 32, 256],
   )
   def test_pmap(self, size, dtype, block_size):
     n_devices = jax.local_device_count()
@@ -276,182 +385,199 @@ class TritonKernelCallTest(parameterized.TestCase):
 
   @parameterized.parameters(42.0, np.float32(42.0))
   def test_add_float_scalar(self, scalar):
+    @jt.kernel
     @triton.jit
     def add_scalar_kernel(x_ptr, y, output_ptr):
       tl.store(output_ptr, tl.load(x_ptr) + y)
 
-    def add_scalar(x, y):
+    x = jnp.array([1.0])
+    np.testing.assert_allclose(add_scalar_kernel[1](x, scalar, out_shape=x), x + scalar)
+
+  @parameterized.product(
+    mul=[None, 1, 1.0, 3.14],
+    ofs=[None, 1, 1.0, 2.71],
+    numel=[1, 5, 257],
+    block_size=[1, 32],
+  )
+  def test_scalar_ordering_1None(self, mul, ofs, numel, block_size):
+    """Test that the order of passing scalars doesn't not matter, as well as that
+    special values of 1 and None for runtime arguments are handled correctly.
+    Since most kernels in tests follow `inputs first, then scalars` scheme, this test
+    only needs to check the reverse order of that."""
+
+    @triton.jit
+    def affine_kernel(mul, ofs, in_ptr, in_numel, out_ptr, BLOCK_SIZE: tl.constexpr):
+      pid = tl.program_id(0)
+      start = pid * BLOCK_SIZE
+      end = min(start + BLOCK_SIZE, in_numel)
+      for i in range(start, end):
+        x = tl.load(in_ptr + i)
+        if mul is not None:
+          x *= mul
+        if ofs is not None:
+          x += ofs
+        tl.store(out_ptr + i, x)
+
+    def affine(mul, ofs, x, BLOCK_SIZE):
       return jt.triton_call(
-          x,
-          y,
-          kernel=add_scalar_kernel,
-          out_shape=jax.ShapeDtypeStruct((), x.dtype),
-          grid=1,
+        mul,
+        ofs,
+        x,
+        x.size,
+        kernel=affine_kernel,
+        out_shape=x,
+        grid=(triton.cdiv(x.size, BLOCK_SIZE),),
+        BLOCK_SIZE=BLOCK_SIZE,
       )
 
-    x = jnp.array([1.0])
-    np.testing.assert_allclose(add_scalar(x, scalar), x + scalar)
+    x = jnp.arange(numel, dtype=jnp.float32)
+    y = affine(mul, ofs, x, block_size)
+    expected = x
+    if mul is not None:
+      expected *= mul
+    if ofs is not None:
+      expected += ofs
+    np.testing.assert_allclose(y, expected, rtol=2e-07)
+
+  def test_function_arguments(self):
+    # mostly taken from Triton with necessary changes and a test without tl.constexpr
+    @triton.jit
+    def func1():
+      return 1
+
+    @triton.jit
+    def func2():
+      return 2
+
+    @triton.jit
+    def func3(x):
+      return x
+
+    @triton.jit
+    def func4(x, y):
+      return x + y
+
+    @triton.jit  # callables are explicitly constexpr
+    def kernel(fn_args, Y, fn: tl.constexpr):
+      tl.store(Y, fn(*fn_args))
+
+    @triton.jit  # callables aren't annotated (made constexpr automatically)
+    def kernel2(fn_args, Y, fn):
+      tl.store(Y, fn(*fn_args))
+
+    def launch_kernel(fn, fn_args, kernel=kernel):
+      return jt.triton_call(
+        fn_args,
+        fn=fn,
+        kernel=kernel,
+        out_shape=jax.ShapeDtypeStruct((), jnp.int32),
+        grid=1,
+      )
+
+    rets = [None] * 5
+    rets[0] = launch_kernel(func1, tuple())
+    rets[1] = launch_kernel(func2, tuple())
+    rets[2] = launch_kernel(func3, (3,))
+    rets[3] = launch_kernel(func4, (3, 4))
+    rets[4] = launch_kernel(func1, tuple())
+    self.assertEqual(jttl.JTJITFunction(kernel).compiled_kernels_cache_size, 4)
+    np.testing.assert_array_equal(rets, [1, 2, 3, 7, 1])
+
+    rets = [None] * 5
+    rets[0] = launch_kernel(func1, tuple(), kernel=kernel2)
+    rets[1] = launch_kernel(func2, tuple(), kernel=kernel2)
+    rets[2] = launch_kernel(func3, (3,), kernel=kernel2)
+    rets[3] = launch_kernel(func4, (3, 4), kernel=kernel2)
+    rets[4] = launch_kernel(func1, tuple(), kernel=kernel2)
+    self.assertEqual(jttl.JTJITFunction(kernel2).compiled_kernels_cache_size, 4)
+    np.testing.assert_array_equal(rets, [1, 2, 3, 7, 1])
+
+  def test_jit_function_arg(self):
+    @triton.jit
+    def mul_jit_function(x, y):
+      return x * y
+
+    @triton.jit
+    def apply_binary_op(x, combine_op):
+      return combine_op(x, x)
+
+    @jt.kernel
+    @triton.jit
+    def square_kernel_jit_function(in_ptr, out_ptr, BLOCK_SIZE: tl.constexpr):
+      offsets = tl.arange(0, BLOCK_SIZE)
+      in_data = tl.load(in_ptr + offsets)
+      # pass a JITFunction into another JITFunction
+      out_data = apply_binary_op(in_data, mul_jit_function)
+      tl.store(out_ptr + offsets, out_data)
+
+    BLOCK_SIZE = 16
+    x = jnp.full((BLOCK_SIZE,), 3.0)
+    expect = jnp.full((BLOCK_SIZE,), 9.0, dtype=x.dtype)
+
+    out = square_kernel_jit_function[(1,)](x, BLOCK_SIZE=BLOCK_SIZE, out_shape=x)
+    np.testing.assert_allclose(out, expect)
 
   def test_explicit_compute_capability(self):
     scalar = np.float32(8)
 
+    @jt.kernel(compute_capability=jt.get_compute_capability(0))
     @triton.jit
     def add_scalar_kernel(x_ptr, y, output_ptr):
       tl.store(output_ptr, tl.load(x_ptr) + y)
 
-    def add_scalar(x, y):
-      return jt.triton_call(
-          x,
-          y,
-          kernel=add_scalar_kernel,
-          compute_capability=jt.get_compute_capability(0),
-          out_shape=jax.ShapeDtypeStruct((), x.dtype),
-          grid=1,
-      )
-
     x = jnp.array([1.0])
-    np.testing.assert_allclose(add_scalar(x, scalar), x + scalar)
+    np.testing.assert_allclose(add_scalar_kernel[1](x, scalar, out_shape=x), x + scalar)
 
-  @parameterized.parameters(False, True)
-  def test_input_output_aliasing_simple(self, with_donation):
-    size = 8
-    x = random.normal(random.PRNGKey(0), [size])
-    expected = x + 1
-
-    launcher = lambda x: jt.triton_call(
-      x,
-      size,
-      kernel=inc_inplace_kernel,
-      out_shape=x,
-      grid=(8,),
-      BLOCK_SIZE=1,
-      input_output_aliases={0: 0},
-    )
-
-    if with_donation:
-      launcher = jax.jit(launcher, donate_argnums=(0,))
-      x_ptr = x.unsafe_buffer_pointer()
-
-    out = launcher(x)
-
-    if with_donation:
-      np.testing.assert_(x.is_deleted())
-      np.testing.assert_equal(x_ptr, out.unsafe_buffer_pointer())
-
-    np.testing.assert_allclose(out, expected)
-
-  @parameterized.product(with_donation=[False, True], first_is_inout=[False, True])
-  def test_input_output_aliasing_2outputs(self, with_donation, first_is_inout):
-    # this tests aliasing correctness in case of 4 buffer parameters two of which
-    # (0 and 2, or 1 and 3) are in-out params. When first_is_inout=True, buffers 0 and 2
-    # are incremented in place using values from buffers 1 and 3, and otherwise buffers
-    # 1 and 3 are incremented in place with values from buffers 0 and 2.
+  def test_single_namespace_for_constexprs_and_backend_options(self):
+    """Checks that metaparams of triton_call() are passed to the kernel and to backend
+    options. Validates that non-hashable backend options work too."""
 
     @triton.jit
-    def weird_kernel(
-      ptr0,
-      ptr1,
-      ptr2,
-      ptr3,
-      n_elements,
-      BLOCK_SIZE: tl.constexpr,
-      FIRST_INOUT: tl.constexpr,
-    ):
-      """For FIRST_INOUT=True  computes *ptr0[] += *ptr1[], *ptr2[] += *ptr3[],
-      for FIRST_INOUT=False computes *ptr1[] += *ptr0[], *ptr3[] += *ptr2[]"""
-      pid = tl.program_id(axis=0)
-      block_start = pid * BLOCK_SIZE
-      offsets = block_start + tl.arange(0, BLOCK_SIZE)
-      mask = offsets < n_elements
-      if FIRST_INOUT:
-        io0_ptr = ptr0
-        io1_ptr = ptr2
-        i0_ptr = ptr1
-        i1_ptr = ptr3
-      else:
-        io0_ptr = ptr1
-        io1_ptr = ptr3
-        i0_ptr = ptr0
-        i1_ptr = ptr2
+    def kernel(in_ptr, out_ptr, num_warps: tl.constexpr):
+      tl.store(out_ptr, tl.load(in_ptr) * num_warps)
 
-      x0 = tl.load(io0_ptr + offsets, mask=mask)
-      y0 = tl.load(i0_ptr + offsets, mask=mask)
-      x1 = tl.load(io1_ptr + offsets, mask=mask)
-      y1 = tl.load(i1_ptr + offsets, mask=mask)
-      output0 = x0 + y0
-      output1 = x1 + y1
-      tl.store(io0_ptr + offsets, output0, mask=mask)
-      tl.store(io1_ptr + offsets, output1, mask=mask)
+    extern_libs = {"some wild lib": "/path/not/exists/trust_me"}
 
-    size = 8
-    keys = random.split(random.key(0), 4)
-    args = [random.normal(key, [size]) for key in keys]
-    expect0 = args[0] + args[1]
-    expect1 = args[2] + args[3]
-
-    inout_aliases = {0: 0, 2: 1} if first_is_inout else {1: 0, 3: 1}
-    inout_indices = tuple(inout_aliases.keys())
-    in_indices = (1, 3) if first_is_inout else (0, 2)
-
-    launcher = lambda *a: jt.triton_call(
-      *a,
-      size,
-      kernel=weird_kernel,
-      out_shape=tuple(a[io] for io in inout_indices),
-      input_output_aliases=inout_aliases,
-      grid=(8,),
-      BLOCK_SIZE=1,
-      FIRST_INOUT=first_is_inout,
-    )
-    if with_donation:
-      launcher = jax.jit(launcher, donate_argnums=inout_indices)
-      io_ptrs = tuple(args[io].unsafe_buffer_pointer() for io in inout_indices)
-
-    outs = launcher(*args)
-
-    if with_donation:
-      for io in inout_indices:
-        np.testing.assert_(args[io].is_deleted())
-      for i in in_indices:
-        np.testing.assert_(not args[i].is_deleted())
-      np.testing.assert_array_equal(
-        io_ptrs, tuple(o.unsafe_buffer_pointer() for o in outs)
+    def call_kernel(x, mul):
+      return jt.triton_call(
+        x,
+        kernel=kernel,
+        out_shape=x,
+        grid=1,
+        num_warps=mul,
+        extern_libs=extern_libs,
       )
 
-    np.testing.assert_allclose(outs[0], expect0)
-    np.testing.assert_allclose(outs[1], expect1)
+    import triton.backends.nvidia.compiler as cb
+    import triton.backends.amd.compiler as hb
 
-  @parameterized.parameters(False, True)
-  def test_zeroed_outputs(self, use_function):
-    x, y = create_random_inputs([1000000])
-    # We alias `y` with the output, so are performing the add in-place.
-    # If we zero the output before the kernel, the result is `x + 0`.
-    out = add(
-        x,
-        y,
-        input_output_aliases={1: 0},
-        kernel=add_inplace_kernel,
-        INPLACE_Y=True,
-        zeroed_outputs=(lambda _: (0,)) if use_function else (0,),
-    )
-    np.testing.assert_allclose(out, x)
+    # now we need the platform ID, and I didn't find a better way than this ugliness
+    backends = jax.extend.backend.backends()
+    default = jax.extend.backend.get_backend()
+    name = next((n for n, c in backends.items() if c is default))
+    # getting relevant backend options object for hooking its initialization method
+    OptionsObj = {"cuda": cb.CUDAOptions, "rocm": hb.HIPOptions}[name]
 
-  def test_multiple_outputs(self):
-    @triton.jit
-    def copy_twice_kernel(a_ptr, x_ptr, y_ptr):
-      a = tl.load(a_ptr)
-      tl.store(x_ptr, a)
-      tl.store(y_ptr, a)
+    orig_opts_init = OptionsObj.__post_init__
 
-    a = jnp.array([42])
-    x, y = jt.triton_call(
-        a,
-        kernel=copy_twice_kernel,
-        out_shape=[a, a],
-        grid=(1,),
-    )
-    np.testing.assert_array_equal(a, x)
-    np.testing.assert_array_equal(a, y)
+    my_num_warps = 1
+
+    def my_opts_init(self):
+      assert self.num_warps == my_num_warps
+      assert self.extern_libs == extern_libs
+      # cleaning it up to prevent unexpected effects of error handling
+      object.__setattr__(self, "extern_libs", None)
+      orig_opts_init(self)
+
+    x = jnp.array([2.5])
+
+    with mock.patch.object(OptionsObj, "__post_init__", new=my_opts_init):
+      my_num_warps = 1
+      np.testing.assert_allclose(call_kernel(x, my_num_warps), x * my_num_warps)
+      my_num_warps = 2
+      np.testing.assert_allclose(call_kernel(x, my_num_warps), x * my_num_warps)
+      my_num_warps = 4
+      np.testing.assert_allclose(call_kernel(x, my_num_warps), x * my_num_warps)
 
   def test_kernel_cache_equivalent_kernels(self):
     # Create unique JITFunction to avoid conflicts with other tests.
@@ -460,10 +586,14 @@ class TritonKernelCallTest(parameterized.TestCase):
     fn2 = jax.jit(lambda x, y: add(x, y, BLOCK_SIZE=32, kernel=my_add_kernel))
     fn3 = jax.jit(lambda x, y: add(x, y, BLOCK_SIZE=64, kernel=my_add_kernel))
 
+    jt_kernel = jttl.JTJITFunction(my_add_kernel)
+    jt_cache_size = lambda: jt_kernel.compiled_kernels_cache_size
+    self.assertEqual(jt_cache_size(), 0)
+
     x1, y1 = create_random_inputs([42])
     x2, y2 = create_random_inputs([43])
 
-    compile_ttir_inplace = jt.triton_lib.compile_ttir_inplace
+    compile_ttir_inplace = jttl.compile_ttir_inplace
 
     call_count = [0]
 
@@ -471,33 +601,35 @@ class TritonKernelCallTest(parameterized.TestCase):
       call_count[0] += 1
       return compile_ttir_inplace(*args, **kwargs)
 
-    with mock.patch.object(
-        jt.triton_lib, "compile_ttir_inplace", new=my_compile
-    ):
+    with mock.patch.object(jttl, "compile_ttir_inplace", new=my_compile):
       _ = fn1(x1, y1)
       self.assertEqual(call_count[0], 1)
+      self.assertEqual(jt_cache_size(), 1)
+
       _ = fn2(x2, y2)
       self.assertEqual(call_count[0], 1)  # Second call hits the cache.
+      self.assertEqual(jt_cache_size(), 1)
+
       _ = fn3(x1, y1)
       self.assertEqual(call_count[0], 2)  # Third call misses (block size).
+      self.assertEqual(jt_cache_size(), 2)
 
   def test_kernel_cache_same_kernel_different_params(self):
+    @jt.kernel(out_names="output_ptr")
     @triton.jit
     def silly_add_kernel(x_ptr, y_ptr, output_ptr):
       pid = tl.program_id(axis=0)
       tl.store(output_ptr + pid, tl.load(x_ptr + pid) + tl.load(y_ptr + pid))
 
-    def silly_add(n):
-      x, y = create_random_inputs([n])
-      return jt.triton_call(
-          x,
-          y,
-          kernel=silly_add_kernel,
-          out_shape=x,
-          grid=x.size,
-      )
+    def silly_add(n, dtype="float32"):
+      x, y = create_random_inputs([n], dtype=dtype)
+      return silly_add_kernel[x.size](x, y, out_shape=x), x, y
 
-    get_or_create_triton_kernel = jt.triton_lib.get_or_create_triton_kernel
+    jt_kernel = jttl.JTJITFunction(silly_add_kernel)
+    jt_cache_size = lambda: jt_kernel.compiled_kernels_cache_size
+    self.assertEqual(jt_cache_size(), 0)
+
+    get_or_create_triton_kernel = jttl.JTJITFunction.get_or_create_triton_kernel
 
     call_count = [0]
 
@@ -506,22 +638,37 @@ class TritonKernelCallTest(parameterized.TestCase):
       return get_or_create_triton_kernel(*args, **kwargs)
 
     with mock.patch.object(
-        jt.triton_lib,
-        "get_or_create_triton_kernel",
-        new=my_get_or_create_triton_kernel,
+      jttl.JTJITFunction,
+      "get_or_create_triton_kernel",
+      new=my_get_or_create_triton_kernel,
     ):
-      _ = silly_add(42)
+      ret, x, y = silly_add(42)
+      np.testing.assert_array_equal(ret, x + y)
       self.assertEqual(call_count[0], 1)
-      _ = silly_add(42)
-      self.assertEqual(call_count[0], 1)  # Second call hits the cache.
-      _ = silly_add(43)
-      self.assertEqual(call_count[0], 2)  # Third call misses (grid size).
+      self.assertEqual(jt_cache_size(), 1)
+
+      ret, x, y = silly_add(42)
+      np.testing.assert_array_equal(ret, x + y)
+      self.assertEqual(call_count[0], 1)  # Second call hits the Primitive cache.
+      self.assertEqual(jt_cache_size(), 1)  # and the lowering doesn't even run
+
+      ret, x, y = silly_add(43)
+      np.testing.assert_array_equal(ret, x + y)
+      # Third call differs in grid size and misses the Primitive's cache, but hits
+      # the internal kernel cache
+      self.assertEqual(call_count[0], 2)
+      self.assertEqual(jt_cache_size(), 1)
+
+      ret, x, y = silly_add(42, "int32")
+      np.testing.assert_array_equal(ret, x + y)
+      self.assertEqual(call_count[0], 3)  # Misses both caches due to a different dtype
+      self.assertEqual(jt_cache_size(), 2)
 
   def test_autotune(self):
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
-        triton.Config({"BLOCK_SIZE": 64}, num_warps=1),
-        triton.Config({"BLOCK_SIZE": 64}, num_warps=2),
+      triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 64}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 64}, num_warps=2),
     ]
     kernel = triton.autotune(autotune_configs, key=("n_elements",))(add_kernel)
 
@@ -532,8 +679,8 @@ class TritonKernelCallTest(parameterized.TestCase):
 
   def test_regression_issue_128(self):
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE": 1024}, num_warps=1),
-        triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 1024}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
     ]
     kernel = triton.autotune(autotune_configs, key=("n_elements",))(add_kernel)
 
@@ -548,7 +695,7 @@ class TritonKernelCallTest(parameterized.TestCase):
 
   def test_autotune_pre_hook_error(self):
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE": 32}, num_warps=1, pre_hook=lambda _: None),
+      triton.Config({"BLOCK_SIZE": 32}, num_warps=1, pre_hook=lambda _: None),
     ]
     kernel = triton.autotune(autotune_configs, key=("n_elements",))(add_kernel)
 
@@ -569,12 +716,12 @@ class TritonKernelCallTest(parameterized.TestCase):
     def do_matmul(m, n, k):
       x, y = create_random_inputs([m, k], [k, n])
       return matmul(
-          x,
-          y,
-          kernel=kernel,
-          BLOCK_SIZE_M=32,
-          BLOCK_SIZE_N=32,
-          BLOCK_SIZE_K=32,
+        x,
+        y,
+        kernel=kernel,
+        BLOCK_SIZE_M=32,
+        BLOCK_SIZE_N=32,
+        BLOCK_SIZE_K=32,
       )
 
     _ = do_matmul(m=128, n=128, k=128)
@@ -590,21 +737,21 @@ class TritonKernelCallTest(parameterized.TestCase):
 
     heuristics = {"K_EXACTLY_DIVISIBLE_BY_BLOCK": heuristic_fn}
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE_K": 32}, num_warps=1),
-        triton.Config({"BLOCK_SIZE_K": 64}, num_warps=1),
+      triton.Config({"BLOCK_SIZE_K": 32}, num_warps=1),
+      triton.Config({"BLOCK_SIZE_K": 64}, num_warps=1),
     ]
     kernel = triton.autotune(autotune_configs, key=("M", "N", "K"))(
-        triton.heuristics(heuristics)(matmul_kernel)
+      triton.heuristics(heuristics)(matmul_kernel)
     )
 
     def do_matmul(m, n, k):
       x, y = create_random_inputs([m, k], [k, n])
       return matmul(
-          x,
-          y,
-          kernel=kernel,
-          BLOCK_SIZE_M=32,
-          BLOCK_SIZE_N=32,
+        x,
+        y,
+        kernel=kernel,
+        BLOCK_SIZE_M=32,
+        BLOCK_SIZE_N=32,
       )
 
     _ = do_matmul(m=128, n=128, k=128)
@@ -618,17 +765,17 @@ class TritonKernelCallTest(parameterized.TestCase):
     heuristics = {"K_EXACTLY_DIVISIBLE_BY_BLOCK": heuristic_fn}
     autotune_config = triton.Config({"BLOCK_SIZE_K": 32}, num_warps=1)
     kernel = triton.autotune([autotune_config], key=("M", "N", "K"))(
-        triton.heuristics(heuristics)(matmul_kernel)
+      triton.heuristics(heuristics)(matmul_kernel)
     )
 
     def do_matmul(m, n, k):
       x, y = create_random_inputs([m, k], [k, n])
       return matmul(
-          x,
-          y,
-          kernel=kernel,
-          BLOCK_SIZE_M=32,
-          BLOCK_SIZE_N=32,
+        x,
+        y,
+        kernel=kernel,
+        BLOCK_SIZE_M=32,
+        BLOCK_SIZE_N=32,
       )
 
     _ = do_matmul(m=128, n=128, k=128)
@@ -636,8 +783,8 @@ class TritonKernelCallTest(parameterized.TestCase):
 
   def test_autotune_with_input_output_aliasing(self):
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
-        triton.Config({"BLOCK_SIZE": 64}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 64}, num_warps=1),
     ]
     kernel = triton.autotune(autotune_configs, key=("n_elements",))(add_inplace_kernel)
 
@@ -646,23 +793,231 @@ class TritonKernelCallTest(parameterized.TestCase):
     out = add(x, y, kernel=kernel, input_output_aliases={0: 0})
     np.testing.assert_allclose(out, expected)
 
+  def test_kernel_in_thread(self):
+    # inspired by Triton's test
+
+    # Test calling in a new thread sets a valid device context
+    buf = jnp.zeros((38016 * 1024,), dtype=jnp.float32)
+
+    @jt.kernel(out_names="out")
+    @triton.jit
+    def _kernel(P, BLOCK: tl.constexpr, out):
+      pid = tl.program_id(0).to(tl.int64)
+      offset = pid * BLOCK + tl.arange(0, BLOCK)
+
+      p = tl.load(P + offset)
+      tl.store(out + offset, p + 1)
+
+    def call_triton():
+      nonlocal buf
+      N = buf.size
+      grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]),)
+      out = _kernel[grid](buf, BLOCK=1024, out_shape=buf)
+      np.testing.assert_array_equal(buf + 1, out)
+
+    from concurrent.futures import ThreadPoolExecutor
+
+    call_triton()
+    with ThreadPoolExecutor(1) as pool:
+      future = pool.submit(call_triton)
+      future.result()
+
   def test_autodiff_exception(self):
     x, y = create_random_inputs([10, 100], dtype="float32")
     with self.assertRaisesRegex(
-        NotImplementedError,
-        r"jax_triton.triton_call does not support automatic differentiation.*"
-        r"jax\.custom_jvp or jax\.custom_vjp.*",
+      NotImplementedError,
+      r"jax_triton.triton_call does not support automatic differentiation.*"
+      r"jax\.custom_jvp or jax\.custom_vjp.*",
     ):
       jax.grad(lambda x, y: jnp.sum(add(x, y, BLOCK_SIZE=32)))(x, y)
 
   def test_batching_exception(self):
     x, y = create_random_inputs([10, 100], dtype="float32")
     with self.assertRaisesRegex(
-        NotImplementedError,
-        r"jax_triton.triton_call does not support batching.*"
-        r"jax\.custom_batching\.custom_vmap.*",
+      NotImplementedError,
+      r"jax_triton.triton_call does not support batching.*"
+      r"jax\.custom_batching\.custom_vmap.*",
     ):
       jax.vmap(lambda x, y: add(x, y, BLOCK_SIZE=32))(x, y)
+
+  def test_memory_leak(self):
+    # inspired by Triton's test
+
+    @jt.kernel(out_names="out_ptr0")
+    @triton.jit
+    def kernel(in_ptr0, xnumel, XBLOCK: tl.constexpr, out_ptr0):
+      xnumel = 10
+      xoffset = tl.program_id(0) * XBLOCK
+      xindex = xoffset + tl.arange(0, XBLOCK)[:]
+      xmask = xindex < xnumel
+      x0 = xindex
+      tmp0 = tl.load(in_ptr0 + (x0), xmask)
+      tl.store(out_ptr0 + (x0 + tl.zeros([XBLOCK], tl.int32)), tmp0, xmask)
+
+    import gc
+    import tracemalloc
+
+    tracemalloc.start()
+    try:
+      inp = random.normal(random.key(0), (10,))
+      out = kernel[(10,)](inp, 10, XBLOCK=16, out_shape=inp)
+      gc.collect()
+      begin, _ = tracemalloc.get_traced_memory()
+      for _ in range(200):  # originally was 100
+        out = kernel[(10,)](inp, 10, XBLOCK=16, out_shape=inp)
+      del out
+      gc.collect()
+      end, _ = tracemalloc.get_traced_memory()
+      assert end - begin < 71000  # originally this was 30000, but we add a bunch
+      # of data into a kernel object and there's JAX's internal caching in the Primitive
+      # system on top of that, so +41k seem reasonable (it was estimated with the
+      # original 100 reps in the loop above, then the range was set to 200).
+      # Note that the margin is just about 100 bytes on my system, so it's ok if on the
+      # other system it's slightly different (i.e. a bit bigger and causes a failure,
+      # - then just update the threshold above).
+    finally:
+      tracemalloc.stop()
+
+  @parameterized.product(
+    signed=[False, True],
+    width=[8, 16, 32, 64, 1],
+  )
+  def test_int_annotation(self, signed, width):
+    # Inspired by an original Triton test.
+    # We could have similar for float, but it seem redundant as now we let the original
+    # Triton code do the job and if ints work - all other should work too.
+    if width == 1 and signed:
+      return
+
+    def annotated_function(return_type=None, **arg_types):
+      """A decorator to add annotations to a function."""
+
+      def decorator(func):
+        func.__annotations__ = {**arg_types, "return": return_type}
+        return func
+
+      return decorator
+
+    @jt.kernel
+    @triton.jit
+    @annotated_function(v=f"tl.{'' if signed else 'u'}int{width}")
+    def _kernel(v, X):
+      tl.store(X + v, v)
+
+    _kernel[(1,)](3, out_shape=jnp.zeros(1), _store_asm=True)
+
+    asm = jttl.JTJITFunction(_kernel).asm
+    assert len(asm) == 1
+    ttir = next(iter(asm.values())).get("ttir")
+
+    pfx = "si" if signed else "ui"
+    if not signed and width < 64:
+      assert "arith.extui %v" in ttir
+    assert f"%v: i{width}" in ttir
+    assert f"arith.{pfx}tofp" in ttir
+
+  def test_err_constexpr_and_do_not_specialize(self):
+    # again inspired by the original test; essentially verifies that our code doesn't
+    # break `do_not_specialize` functionality. It's somewhat related to the previous,
+    # as for this we just rely on the original Triton processing and this tests that
+    # this isn't broken.
+    @jt.kernel
+    @triton.jit(do_not_specialize=["N"])
+    def kernel(out_ptr, N: tl.constexpr):
+      pass
+
+    with self.assertRaisesRegex(
+      triton.compiler.errors.CompilationError,
+      r"N marked as constexpr and listed in do_not_specialize",
+    ):
+      kernel[(1,)](5, out_shape=jnp.zeros(1))  # out_shape is needed to prevent DCE
+
+  def test_kernel_default_arg(self):
+    # inspired by an original Triton test
+    global GLOBAL_DEFAULT_ARG
+
+    @jt.kernel
+    @triton.jit
+    def kernel(X, i: tl.constexpr = GLOBAL_DEFAULT_ARG):
+      tl.store(X, i)
+
+    x = kernel[(1,)](out_shape=jnp.zeros(1))
+    assert x == jnp.ones_like(x)
+
+    # Changing the global variable should not change the default argument in
+    # `kernel`.  That value gets set at the time the function is declared.
+    GLOBAL_DEFAULT_ARG = 2
+    x = kernel[(1,)](out_shape=jnp.zeros(1))
+    assert x == jnp.ones_like(x)
+
+    assert jttl.JTJITFunction(kernel).compiled_kernels_cache_size == 1
+
+  def test_readme(self):
+    """Code for readme example, basically an integration test of many features at once,
+    including not otherwise tested passing of strings and precise partial aliasing +
+    pure outputs"""
+    from triton.language.extra import libdevice
+    from typing import NamedTuple
+    import time
+
+    class Function(NamedTuple):
+      fn: tl.constexpr
+      captured: tuple
+
+    @triton.jit
+    def func1(x_ptr, y_ptr: tl.const, SIZE: tl.constexpr):
+      off = tl.arange(0, SIZE)
+      x = tl.load(x_ptr + off)
+      y = tl.load(y_ptr + off)
+      x1 = libdevice.sin(x)
+      x2 = libdevice.cos(x)
+      z = x1 * x1 + x2 * x2
+      tl.store(x_ptr + off, z)
+      y = libdevice.asin(y) + libdevice.acos(y)
+      return z, libdevice.floor(2 * y)
+
+    @triton.jit
+    def floor_of_func(values, SIZE: tl.constexpr, FUNC_NAME: tl.constexpr):
+      off = tl.arange(0, SIZE)
+      return libdevice.floor(getattr(libdevice, FUNC_NAME)(values))
+
+    @triton.jit
+    def aggregate(Ptrs):
+      z = tl.zeros([], tl.float32)
+      for i in tl.static_range(len(Ptrs)):
+        z += Ptrs[i]
+      return z
+
+    @jt.kernel
+    @triton.jit
+    def kernel(capture, out_ptr, SIZE: tl.constexpr, FUNC_NAME: tl.constexpr):
+      off = tl.arange(0, SIZE)
+      t1, t2 = capture.fn(*capture.captured, SIZE=SIZE)
+      t3 = floor_of_func(t1, SIZE=SIZE, FUNC_NAME=FUNC_NAME)
+      t4 = t2 * t3
+      result = aggregate((t4, t4 * t4)).to(tl.int32)
+      tl.store(out_ptr + off, result)
+
+    size = 8
+    k1, k2 = random.split(random.key(time.perf_counter_ns()), 2)
+    x = random.uniform(k1, (size,), dtype=jnp.float32)
+    y = random.uniform(k2, (size,), dtype=jnp.float32)
+
+    fn = Function(func1, (x, y))
+    out, x = kernel[(1,)](
+      fn,  # essentially a tuple of (func_name, (2 arrays in a subtuple))
+      SIZE=size,
+      FUNC_NAME="exp",
+      out_shape=jnp.zeros(size, dtype=jnp.int32),
+      input_output_aliases=("capture", 1, 0),  # a path inside `capture` argument, 0th
+      # element of 1st subtuple, i.e. `x`. Note that since this is a tuple, it
+      # references just a single element (or all its embedded arrays if it's a tuple,
+      # but in this invocation it references array `x`)
+    )
+    np.testing.assert_array_equal(out, jnp.full((size,), 42, dtype=jnp.int32))
+    assert out.dtype == jnp.int32
+    np.testing.assert_allclose(x, jnp.full((size,), 1.0, dtype=jnp.float32), rtol=5e-7)
+    assert x.dtype == jnp.float32
 
 
 if __name__ == "__main__":

--- a/tests/triton_call_test.py
+++ b/tests/triton_call_test.py
@@ -12,19 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Main tests for triton_call()
+"""
+
 import os
 from unittest import mock
 
 from absl.testing import absltest
 from absl.testing import parameterized
+from copy import deepcopy
 import jax
-from jax import config
-from jax import random
+from jax import config, random, tree_util
 import jax.numpy as jnp
 import jax_triton as jt
+import jax_triton.triton_lib as jttl
 import numpy as np
 import triton
 import triton.language as tl
+import types
 
 config.parse_flags_with_absl()
 
@@ -35,6 +41,116 @@ def setUpModule():
 
 def tearDownModule():
   config.update("jax_enable_x64", False)
+
+
+class ArgsKwargsTest(parameterized.TestCase):
+  def test_serialize_deserialize(self):
+    """Test that serialize_args_kwargs() and deserialize_args_kwargs() are inverses of
+    each other, caring about the order of kwargs and args."""
+    args = [
+      1,
+      3.14,
+      jnp.array([1, 2, 3], dtype=jnp.int8),
+      (3, 4),
+      "string",
+      (jnp.array([5, 6], dtype=jnp.int16),),
+      (9, jnp.array([7, 8], dtype=jnp.int32), jnp.array([70, 80], dtype=jnp.float32)),
+      (10, (jnp.array([7, 8], dtype=jnp.int64), 11)),
+    ]
+    kwargs = {  # keys aren't in the order of declaration in the signature
+      "b": 3.14,
+      "g": (
+        9,
+        jnp.array([7, 8], dtype=jnp.uint32),
+        jnp.array([70, 80], dtype=jnp.float16),
+      ),
+      "h": (10, (jnp.array([7, 8], dtype=jnp.uint64), 11)),
+      "a": 1,
+      "e": "string",
+      "c": jnp.array([1, 2, 3], dtype=jnp.uint8),
+      "d": (3, 4),
+      "f": (jnp.array([5, 6], dtype=jnp.uint16),),
+    }
+
+    # kwargs are expected to be sorted
+    @triton.jit
+    def kernel(int_, fl, a1, t1, st, t2, t3, t4, *, a, b, c, d, e, f, g, h):
+      pass
+
+    class FakeAvals:
+      def __init__(self):
+        # extracting only arrays from args sequence in kernel's signature order.
+        # This ensures that during ser/des, arrays are ordered in signature's
+        # order too, so no further reshuffling to match signature order to call the
+        # kernel is needed.
+        self.flat = [
+          v
+          for v in tree_util.tree_flatten((
+            args,
+            {k: kwargs[k] for k in sorted(kwargs.keys())},  # restore signature order
+          ))[0]
+          if isinstance(v, jax.Array)
+        ]
+
+        # check the core test assumption that types in args are unique and get_type_id()
+        # is a bijection.
+        unique_types = frozenset(jttl.get_type_id(v) for v in self.flat)
+        assert len(unique_types) == len(self.flat), (
+          "Duplicate types in the args sequence"
+        )
+
+      def __getitem__(self, i):
+        return self.flat[i]
+
+      def __len__(self):
+        return len(self.flat)
+
+    def _make_expected_array_id2idx(args, kwargs):
+      array_id2idx = {}
+      for coll in [args, kwargs]:
+        flat, _ = tree_util.tree_flatten(coll)
+        arrays = [v for v in flat if isinstance(v, jax.Array)]
+        l = len(array_id2idx)
+        array_id2idx.update({id(v): idx + l for idx, v in enumerate(arrays)})
+      return array_id2idx
+
+    kwargs_copy = deepcopy(kwargs)
+    expected_array_id2idx = _make_expected_array_id2idx(args, kwargs_copy)
+
+    abs_args_kwargs, array_id2idx, args_kwargs_meta = jttl.serialize_args_kwargs(
+      jttl.JTJITFunction(kernel),
+      args,
+      kwargs_copy,
+      # kwargs could be modified, hence must copy
+    )
+
+    assert array_id2idx == expected_array_id2idx
+
+    ctx = types.SimpleNamespace(avals_in=FakeAvals())
+    dargs, dkwargs, _ = jttl.deserialize_args_kwargs(
+      ctx, [*abs_args_kwargs], args_kwargs_meta
+    )
+
+    def assert_correct(a, b):
+      if isinstance(a, jax.Array):
+        assert jttl.get_type_id(a) == b.dtype
+        # can't test actual values here, they were abstracted away
+      elif isinstance(a, tuple):
+        assert isinstance(b, tuple)
+        assert len(a) == len(b)
+        for ai, bi in zip(a, b):
+          assert_correct(ai, bi)
+      else:
+        assert isinstance(a, type(b))
+        assert a == b
+
+    assert len(args) == len(dargs)
+    for ai in range(len(args)):
+      assert_correct(args[ai], dargs[ai])
+
+    assert len(kwargs) == len(dkwargs)
+    for k in kwargs.keys():
+      assert_correct(kwargs[k], dkwargs[k])
 
 
 @triton.jit
@@ -50,7 +166,9 @@ def add_kernel(x_ptr, y_ptr, n_elements, output_ptr, BLOCK_SIZE: tl.constexpr):
 
 
 @triton.jit
-def add_inplace_kernel(x_ptr, y_ptr, n_elements, BLOCK_SIZE: tl.constexpr, INPLACE_Y: tl.constexpr):
+def add_inplace_kernel(
+  x_ptr, y_ptr, n_elements, BLOCK_SIZE: tl.constexpr, INPLACE_Y: tl.constexpr
+):
   pid = tl.program_id(axis=0)
   block_start = pid * BLOCK_SIZE
   offsets = block_start + tl.arange(0, BLOCK_SIZE)
@@ -74,46 +192,35 @@ def add(x, y, *, kernel=add_kernel, **kwargs):
 
   default_grid = lambda meta: triton.cdiv(x.size, meta["BLOCK_SIZE"])
   return jt.triton_call(
-      x,
-      y,
-      x.size,
-      kernel=kernel,
-      out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype),
-      grid=kwargs.pop("grid", default_grid),
-      **kwargs,
+    x,
+    y,
+    x.size,
+    kernel=kernel,
+    out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype),
+    grid=kwargs.pop("grid", default_grid),
+    **kwargs,
   )
 
 
 @triton.jit
-def inc_inplace_kernel(x_in_out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
-  pid = tl.program_id(axis=0)
-  block_start = pid * BLOCK_SIZE
-  offsets = block_start + tl.arange(0, BLOCK_SIZE)
-  mask = offsets < n_elements
-  x = tl.load(x_in_out_ptr + offsets, mask=mask)
-  output = x + 1
-  tl.store(x_in_out_ptr + offsets, output, mask=mask)
-
-
-@triton.jit
 def matmul_kernel(
-    a_ptr,
-    b_ptr,
-    M,
-    N,
-    K,
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
-    stride_cm,
-    stride_cn,
-    c_ptr,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-    K_EXACTLY_DIVISIBLE_BY_BLOCK: tl.constexpr,
+  a_ptr,
+  b_ptr,
+  M,
+  N,
+  K,
+  stride_am,
+  stride_ak,
+  stride_bk,
+  stride_bn,
+  stride_cm,
+  stride_cn,
+  c_ptr,
+  BLOCK_SIZE_M: tl.constexpr,
+  BLOCK_SIZE_N: tl.constexpr,
+  BLOCK_SIZE_K: tl.constexpr,
+  GROUP_SIZE_M: tl.constexpr,
+  K_EXACTLY_DIVISIBLE_BY_BLOCK: tl.constexpr,
 ):
   pid = tl.program_id(axis=0)
   num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
@@ -160,22 +267,22 @@ def matmul(x, y, *, kernel=matmul_kernel, **kwargs):
     return cdiv(m, meta["BLOCK_SIZE_M"]) * cdiv(n, meta["BLOCK_SIZE_N"])
 
   return jt.triton_call(
-      x,
-      y,
-      m,
-      n,
-      k,
-      k,  # stride_am
-      1,  # stride_ak
-      n,  # stride_bk
-      1,  # stride_bn
-      n,  # stride_cm
-      1,  # stride_cn
-      kernel=kernel,
-      out_shape=jax.ShapeDtypeStruct((m, n), dtype=x.dtype),
-      grid=grid,
-      GROUP_SIZE_M=8,
-      **kwargs,
+    x,
+    y,
+    m,
+    n,
+    k,
+    k,  # stride_am
+    1,  # stride_ak
+    n,  # stride_bk
+    1,  # stride_bn
+    n,  # stride_cm
+    1,  # stride_cn
+    kernel=kernel,
+    out_shape=jax.ShapeDtypeStruct((m, n), dtype=x.dtype),
+    grid=grid,
+    GROUP_SIZE_M=8,
+    **kwargs,
   )
 
 
@@ -193,12 +300,14 @@ def create_random_inputs(shape1, shape2=None, *, dtype="float32"):
   return x, y
 
 
-class TritonKernelCallTest(parameterized.TestCase):
+GLOBAL_DEFAULT_ARG = 1
 
+
+class TritonKernelCallTest(parameterized.TestCase):
   @parameterized.product(
-      size=[1, 5, 100, 1024],
-      dtype=["int32", "float32", "float16", "int64", "float64"],
-      block_size=[1, 32, 256],
+    size=[1, 5, 100, 1024],
+    dtype=["int32", "float32", "float16", "int64", "float64"],
+    block_size=[1, 32, 256],
   )
   def test_add(self, size, dtype, block_size):
     x, y = create_random_inputs([size], dtype=dtype)
@@ -207,43 +316,43 @@ class TritonKernelCallTest(parameterized.TestCase):
     np.testing.assert_allclose(out, expected)
 
   @parameterized.product(
-      m=[512, 1024],
-      k=[512],
-      n=[512],
-      dtype=["float32", "float16"],
-      block_size_m=[64, 128],
-      block_size_n=[128, 256],
-      block_size_k=[32],
+    m=[512, 1024],
+    k=[512],
+    n=[512],
+    dtype=["float32", "float16"],
+    block_size_m=[64, 128],
+    block_size_n=[128, 256],
+    block_size_k=[32],
   )
   def test_matmul(
-      self,
-      m,
-      n,
-      k,
-      dtype,
-      block_size_m,
-      block_size_n,
-      block_size_k,
+    self,
+    m,
+    n,
+    k,
+    dtype,
+    block_size_m,
+    block_size_n,
+    block_size_k,
   ):
     if jt.get_compute_capability(0) < 70:
       self.skipTest("Matmul only works on GPUs with capability >= sm70")
 
     x, y = create_random_inputs([m, k], [k, n], dtype=dtype)
     out = matmul(
-        x,
-        y,
-        BLOCK_SIZE_M=block_size_m,
-        BLOCK_SIZE_N=block_size_n,
-        BLOCK_SIZE_K=block_size_k,
-        K_EXACTLY_DIVISIBLE_BY_BLOCK=k % block_size_k == 0,
+      x,
+      y,
+      BLOCK_SIZE_M=block_size_m,
+      BLOCK_SIZE_N=block_size_n,
+      BLOCK_SIZE_K=block_size_k,
+      K_EXACTLY_DIVISIBLE_BY_BLOCK=k % block_size_k == 0,
     )
     expected = jnp.matmul(x, y)
     np.testing.assert_allclose(out, expected, atol=0.05, rtol=0.05)
 
   @parameterized.product(
-      size=[1, 5, 100, 1024],
-      dtype=["int32", "float32", "float16", "int64", "float64"],
-      block_size=[1, 32, 256],
+    size=[1, 5, 100, 1024],
+    dtype=["int32", "float32", "float16", "int64", "float64"],
+    block_size=[1, 32, 256],
   )
   def test_pmap(self, size, dtype, block_size):
     n_devices = jax.local_device_count()
@@ -276,182 +385,199 @@ class TritonKernelCallTest(parameterized.TestCase):
 
   @parameterized.parameters(42.0, np.float32(42.0))
   def test_add_float_scalar(self, scalar):
+    @jt.kernel
     @triton.jit
     def add_scalar_kernel(x_ptr, y, output_ptr):
       tl.store(output_ptr, tl.load(x_ptr) + y)
 
-    def add_scalar(x, y):
+    x = jnp.array([1.0])
+    np.testing.assert_allclose(add_scalar_kernel[1](x, scalar, out_shape=x), x + scalar)
+
+  @parameterized.product(
+    mul=[None, 1, 1.0, 3.14],
+    ofs=[None, 1, 1.0, 2.71],
+    numel=[1, 5, 257],
+    block_size=[1, 32],
+  )
+  def test_scalar_ordering_1None(self, mul, ofs, numel, block_size):
+    """Test that the order of passing scalars doesn't not matter, as well as that
+    special values of 1 and None for runtime arguments are handled correctly.
+    Since most kernels in tests follow `inputs first, then scalars` scheme, this test
+    only needs to check the reverse order of that."""
+
+    @triton.jit
+    def affine_kernel(mul, ofs, in_ptr, in_numel, out_ptr, BLOCK_SIZE: tl.constexpr):
+      pid = tl.program_id(0)
+      start = pid * BLOCK_SIZE
+      end = min(start + BLOCK_SIZE, in_numel)
+      for i in range(start, end):
+        x = tl.load(in_ptr + i)
+        if mul is not None:
+          x *= mul
+        if ofs is not None:
+          x += ofs
+        tl.store(out_ptr + i, x)
+
+    def affine(mul, ofs, x, BLOCK_SIZE):
       return jt.triton_call(
-          x,
-          y,
-          kernel=add_scalar_kernel,
-          out_shape=jax.ShapeDtypeStruct((), x.dtype),
-          grid=1,
+        mul,
+        ofs,
+        x,
+        x.size,
+        kernel=affine_kernel,
+        out_shape=x,
+        grid=(triton.cdiv(x.size, BLOCK_SIZE),),
+        BLOCK_SIZE=BLOCK_SIZE,
       )
 
-    x = jnp.array([1.0])
-    np.testing.assert_allclose(add_scalar(x, scalar), x + scalar)
+    x = jnp.arange(numel, dtype=jnp.float32)
+    y = affine(mul, ofs, x, block_size)
+    expected = x
+    if mul is not None:
+      expected *= mul
+    if ofs is not None:
+      expected += ofs
+    np.testing.assert_allclose(y, expected, rtol=2e-07)
+
+  def test_function_arguments(self):
+    # mostly taken from Triton with necessary changes and a test without tl.constexpr
+    @triton.jit
+    def func1():
+      return 1
+
+    @triton.jit
+    def func2():
+      return 2
+
+    @triton.jit
+    def func3(x):
+      return x
+
+    @triton.jit
+    def func4(x, y):
+      return x + y
+
+    @triton.jit  # callables are explicitly constexpr
+    def kernel(fn_args, Y, fn: tl.constexpr):
+      tl.store(Y, fn(*fn_args))
+
+    @triton.jit  # callables aren't annotated (made constexpr automatically)
+    def kernel2(fn_args, Y, fn):
+      tl.store(Y, fn(*fn_args))
+
+    def launch_kernel(fn, fn_args, kernel=kernel):
+      return jt.triton_call(
+        fn_args,
+        fn=fn,
+        kernel=kernel,
+        out_shape=jax.ShapeDtypeStruct((), jnp.int32),
+        grid=1,
+      )
+
+    rets = [None] * 5
+    rets[0] = launch_kernel(func1, tuple())
+    rets[1] = launch_kernel(func2, tuple())
+    rets[2] = launch_kernel(func3, (3,))
+    rets[3] = launch_kernel(func4, (3, 4))
+    rets[4] = launch_kernel(func1, tuple())
+    self.assertEqual(jttl.JTJITFunction(kernel).compiled_kernels_cache_size, 4)
+    np.testing.assert_array_equal(rets, [1, 2, 3, 7, 1])
+
+    rets = [None] * 5
+    rets[0] = launch_kernel(func1, tuple(), kernel=kernel2)
+    rets[1] = launch_kernel(func2, tuple(), kernel=kernel2)
+    rets[2] = launch_kernel(func3, (3,), kernel=kernel2)
+    rets[3] = launch_kernel(func4, (3, 4), kernel=kernel2)
+    rets[4] = launch_kernel(func1, tuple(), kernel=kernel2)
+    self.assertEqual(jttl.JTJITFunction(kernel2).compiled_kernels_cache_size, 4)
+    np.testing.assert_array_equal(rets, [1, 2, 3, 7, 1])
+
+  def test_jit_function_arg(self):
+    @triton.jit
+    def mul_jit_function(x, y):
+      return x * y
+
+    @triton.jit
+    def apply_binary_op(x, combine_op):
+      return combine_op(x, x)
+
+    @jt.kernel
+    @triton.jit
+    def square_kernel_jit_function(in_ptr, out_ptr, BLOCK_SIZE: tl.constexpr):
+      offsets = tl.arange(0, BLOCK_SIZE)
+      in_data = tl.load(in_ptr + offsets)
+      # pass a JITFunction into another JITFunction
+      out_data = apply_binary_op(in_data, mul_jit_function)
+      tl.store(out_ptr + offsets, out_data)
+
+    BLOCK_SIZE = 16
+    x = jnp.full((BLOCK_SIZE,), 3.0)
+    expect = jnp.full((BLOCK_SIZE,), 9.0, dtype=x.dtype)
+
+    out = square_kernel_jit_function[(1,)](x, BLOCK_SIZE=BLOCK_SIZE, out_shape=x)
+    np.testing.assert_allclose(out, expect)
 
   def test_explicit_compute_capability(self):
     scalar = np.float32(8)
 
+    @jt.kernel(compute_capability=jt.get_compute_capability(0))
     @triton.jit
     def add_scalar_kernel(x_ptr, y, output_ptr):
       tl.store(output_ptr, tl.load(x_ptr) + y)
 
-    def add_scalar(x, y):
-      return jt.triton_call(
-          x,
-          y,
-          kernel=add_scalar_kernel,
-          compute_capability=jt.get_compute_capability(0),
-          out_shape=jax.ShapeDtypeStruct((), x.dtype),
-          grid=1,
-      )
-
     x = jnp.array([1.0])
-    np.testing.assert_allclose(add_scalar(x, scalar), x + scalar)
+    np.testing.assert_allclose(add_scalar_kernel[1](x, scalar, out_shape=x), x + scalar)
 
-  @parameterized.parameters(False, True)
-  def test_input_output_aliasing_simple(self, with_donation):
-    size = 8
-    x = random.normal(random.PRNGKey(0), [size])
-    expected = x + 1
-
-    launcher = lambda x: jt.triton_call(
-      x,
-      size,
-      kernel=inc_inplace_kernel,
-      out_shape=x,
-      grid=(8,),
-      BLOCK_SIZE=1,
-      input_output_aliases={0: 0},
-    )
-
-    if with_donation:
-      launcher = jax.jit(launcher, donate_argnums=(0,))
-      x_ptr = x.unsafe_buffer_pointer()
-
-    out = launcher(x)
-
-    if with_donation:
-      np.testing.assert_(x.is_deleted())
-      np.testing.assert_equal(x_ptr, out.unsafe_buffer_pointer())
-
-    np.testing.assert_allclose(out, expected)
-
-  @parameterized.product(with_donation=[False, True], first_is_inout=[False, True])
-  def test_input_output_aliasing_2outputs(self, with_donation, first_is_inout):
-    # this tests aliasing correctness in case of 4 buffer parameters two of which
-    # (0 and 2, or 1 and 3) are in-out params. When first_is_inout=True, buffers 0 and 2
-    # are incremented in place using values from buffers 1 and 3, and otherwise buffers
-    # 1 and 3 are incremented in place with values from buffers 0 and 2.
+  def test_single_namespace_for_constexprs_and_backend_options(self):
+    """Checks that metaparams of triton_call() are passed to the kernel and to backend
+    options. Validates that non-hashable backend options work too."""
 
     @triton.jit
-    def weird_kernel(
-      ptr0,
-      ptr1,
-      ptr2,
-      ptr3,
-      n_elements,
-      BLOCK_SIZE: tl.constexpr,
-      FIRST_INOUT: tl.constexpr,
-    ):
-      """For FIRST_INOUT=True  computes *ptr0[] += *ptr1[], *ptr2[] += *ptr3[],
-      for FIRST_INOUT=False computes *ptr1[] += *ptr0[], *ptr3[] += *ptr2[]"""
-      pid = tl.program_id(axis=0)
-      block_start = pid * BLOCK_SIZE
-      offsets = block_start + tl.arange(0, BLOCK_SIZE)
-      mask = offsets < n_elements
-      if FIRST_INOUT:
-        io0_ptr = ptr0
-        io1_ptr = ptr2
-        i0_ptr = ptr1
-        i1_ptr = ptr3
-      else:
-        io0_ptr = ptr1
-        io1_ptr = ptr3
-        i0_ptr = ptr0
-        i1_ptr = ptr2
+    def kernel(in_ptr, out_ptr, num_warps: tl.constexpr):
+      tl.store(out_ptr, tl.load(in_ptr) * num_warps)
 
-      x0 = tl.load(io0_ptr + offsets, mask=mask)
-      y0 = tl.load(i0_ptr + offsets, mask=mask)
-      x1 = tl.load(io1_ptr + offsets, mask=mask)
-      y1 = tl.load(i1_ptr + offsets, mask=mask)
-      output0 = x0 + y0
-      output1 = x1 + y1
-      tl.store(io0_ptr + offsets, output0, mask=mask)
-      tl.store(io1_ptr + offsets, output1, mask=mask)
+    extern_libs = {"some wild lib": "/path/not/exists/trust_me"}
 
-    size = 8
-    keys = random.split(random.key(0), 4)
-    args = [random.normal(key, [size]) for key in keys]
-    expect0 = args[0] + args[1]
-    expect1 = args[2] + args[3]
-
-    inout_aliases = {0: 0, 2: 1} if first_is_inout else {1: 0, 3: 1}
-    inout_indices = tuple(inout_aliases.keys())
-    in_indices = (1, 3) if first_is_inout else (0, 2)
-
-    launcher = lambda *a: jt.triton_call(
-      *a,
-      size,
-      kernel=weird_kernel,
-      out_shape=tuple(a[io] for io in inout_indices),
-      input_output_aliases=inout_aliases,
-      grid=(8,),
-      BLOCK_SIZE=1,
-      FIRST_INOUT=first_is_inout,
-    )
-    if with_donation:
-      launcher = jax.jit(launcher, donate_argnums=inout_indices)
-      io_ptrs = tuple(args[io].unsafe_buffer_pointer() for io in inout_indices)
-
-    outs = launcher(*args)
-
-    if with_donation:
-      for io in inout_indices:
-        np.testing.assert_(args[io].is_deleted())
-      for i in in_indices:
-        np.testing.assert_(not args[i].is_deleted())
-      np.testing.assert_array_equal(
-        io_ptrs, tuple(o.unsafe_buffer_pointer() for o in outs)
+    def call_kernel(x, mul):
+      return jt.triton_call(
+        x,
+        kernel=kernel,
+        out_shape=x,
+        grid=1,
+        num_warps=mul,
+        extern_libs=extern_libs,
       )
 
-    np.testing.assert_allclose(outs[0], expect0)
-    np.testing.assert_allclose(outs[1], expect1)
+    import triton.backends.nvidia.compiler as cb
+    import triton.backends.amd.compiler as hb
 
-  @parameterized.parameters(False, True)
-  def test_zeroed_outputs(self, use_function):
-    x, y = create_random_inputs([1000000])
-    # We alias `y` with the output, so are performing the add in-place.
-    # If we zero the output before the kernel, the result is `x + 0`.
-    out = add(
-        x,
-        y,
-        input_output_aliases={1: 0},
-        kernel=add_inplace_kernel,
-        INPLACE_Y=True,
-        zeroed_outputs=(lambda _: (0,)) if use_function else (0,),
-    )
-    np.testing.assert_allclose(out, x)
+    # now we need the platform ID, and I didn't find a better way than this ugliness
+    backends = jax.extend.backend.backends()
+    default = jax.extend.backend.get_backend()
+    name = next((n for n, c in backends.items() if c is default))
+    # getting relevant backend options object for hooking its initialization method
+    OptionsObj = {"cuda": cb.CUDAOptions, "rocm": hb.HIPOptions}[name]
 
-  def test_multiple_outputs(self):
-    @triton.jit
-    def copy_twice_kernel(a_ptr, x_ptr, y_ptr):
-      a = tl.load(a_ptr)
-      tl.store(x_ptr, a)
-      tl.store(y_ptr, a)
+    orig_opts_init = OptionsObj.__post_init__
 
-    a = jnp.array([42])
-    x, y = jt.triton_call(
-        a,
-        kernel=copy_twice_kernel,
-        out_shape=[a, a],
-        grid=(1,),
-    )
-    np.testing.assert_array_equal(a, x)
-    np.testing.assert_array_equal(a, y)
+    my_num_warps = 1
+
+    def my_opts_init(self):
+      assert self.num_warps == my_num_warps
+      assert self.extern_libs == extern_libs
+      # cleaning it up to prevent unexpected effects of error handling
+      object.__setattr__(self, "extern_libs", None)
+      orig_opts_init(self)
+
+    x = jnp.array([2.5])
+
+    with mock.patch.object(OptionsObj, "__post_init__", new=my_opts_init):
+      my_num_warps = 1
+      np.testing.assert_allclose(call_kernel(x, my_num_warps), x * my_num_warps)
+      my_num_warps = 2
+      np.testing.assert_allclose(call_kernel(x, my_num_warps), x * my_num_warps)
+      my_num_warps = 4
+      np.testing.assert_allclose(call_kernel(x, my_num_warps), x * my_num_warps)
 
   def test_kernel_cache_equivalent_kernels(self):
     # Create unique JITFunction to avoid conflicts with other tests.
@@ -460,10 +586,14 @@ class TritonKernelCallTest(parameterized.TestCase):
     fn2 = jax.jit(lambda x, y: add(x, y, BLOCK_SIZE=32, kernel=my_add_kernel))
     fn3 = jax.jit(lambda x, y: add(x, y, BLOCK_SIZE=64, kernel=my_add_kernel))
 
+    jt_kernel = jttl.JTJITFunction(my_add_kernel)
+    jt_cache_size = lambda: jt_kernel.compiled_kernels_cache_size
+    self.assertEqual(jt_cache_size(), 0)
+
     x1, y1 = create_random_inputs([42])
     x2, y2 = create_random_inputs([43])
 
-    compile_ttir_inplace = jt.triton_lib.compile_ttir_inplace
+    compile_ttir_inplace = jttl.compile_ttir_inplace
 
     call_count = [0]
 
@@ -471,33 +601,35 @@ class TritonKernelCallTest(parameterized.TestCase):
       call_count[0] += 1
       return compile_ttir_inplace(*args, **kwargs)
 
-    with mock.patch.object(
-        jt.triton_lib, "compile_ttir_inplace", new=my_compile
-    ):
+    with mock.patch.object(jttl, "compile_ttir_inplace", new=my_compile):
       _ = fn1(x1, y1)
       self.assertEqual(call_count[0], 1)
+      self.assertEqual(jt_cache_size(), 1)
+
       _ = fn2(x2, y2)
       self.assertEqual(call_count[0], 1)  # Second call hits the cache.
+      self.assertEqual(jt_cache_size(), 1)
+
       _ = fn3(x1, y1)
       self.assertEqual(call_count[0], 2)  # Third call misses (block size).
+      self.assertEqual(jt_cache_size(), 2)
 
   def test_kernel_cache_same_kernel_different_params(self):
+    @jt.kernel(out_names="output_ptr")
     @triton.jit
     def silly_add_kernel(x_ptr, y_ptr, output_ptr):
       pid = tl.program_id(axis=0)
       tl.store(output_ptr + pid, tl.load(x_ptr + pid) + tl.load(y_ptr + pid))
 
-    def silly_add(n):
-      x, y = create_random_inputs([n])
-      return jt.triton_call(
-          x,
-          y,
-          kernel=silly_add_kernel,
-          out_shape=x,
-          grid=x.size,
-      )
+    def silly_add(n, dtype="float32"):
+      x, y = create_random_inputs([n], dtype=dtype)
+      return silly_add_kernel[x.size](x, y, out_shape=x), x, y
 
-    get_or_create_triton_kernel = jt.triton_lib.get_or_create_triton_kernel
+    jt_kernel = jttl.JTJITFunction(silly_add_kernel)
+    jt_cache_size = lambda: jt_kernel.compiled_kernels_cache_size
+    self.assertEqual(jt_cache_size(), 0)
+
+    get_or_create_triton_kernel = jttl.JTJITFunction.get_or_create_triton_kernel
 
     call_count = [0]
 
@@ -506,22 +638,37 @@ class TritonKernelCallTest(parameterized.TestCase):
       return get_or_create_triton_kernel(*args, **kwargs)
 
     with mock.patch.object(
-        jt.triton_lib,
-        "get_or_create_triton_kernel",
-        new=my_get_or_create_triton_kernel,
+      jttl.JTJITFunction,
+      "get_or_create_triton_kernel",
+      new=my_get_or_create_triton_kernel,
     ):
-      _ = silly_add(42)
+      ret, x, y = silly_add(42)
+      np.testing.assert_array_equal(ret, x + y)
       self.assertEqual(call_count[0], 1)
-      _ = silly_add(42)
-      self.assertEqual(call_count[0], 1)  # Second call hits the cache.
-      _ = silly_add(43)
-      self.assertEqual(call_count[0], 2)  # Third call misses (grid size).
+      self.assertEqual(jt_cache_size(), 1)
+
+      ret, x, y = silly_add(42)
+      np.testing.assert_array_equal(ret, x + y)
+      self.assertEqual(call_count[0], 1)  # Second call hits the Primitive cache.
+      self.assertEqual(jt_cache_size(), 1)  # and the lowering doesn't even run
+
+      ret, x, y = silly_add(43)
+      np.testing.assert_array_equal(ret, x + y)
+      # Third call differs in grid size and misses the Primitive's cache, but hits
+      # the internal kernel cache
+      self.assertEqual(call_count[0], 2)
+      self.assertEqual(jt_cache_size(), 1)
+
+      ret, x, y = silly_add(42, "int32")
+      np.testing.assert_array_equal(ret, x + y)
+      self.assertEqual(call_count[0], 3)  # Misses both caches due to a different dtype
+      self.assertEqual(jt_cache_size(), 2)
 
   def test_autotune(self):
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
-        triton.Config({"BLOCK_SIZE": 64}, num_warps=1),
-        triton.Config({"BLOCK_SIZE": 64}, num_warps=2),
+      triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 64}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 64}, num_warps=2),
     ]
     kernel = triton.autotune(autotune_configs, key=("n_elements",))(add_kernel)
 
@@ -532,8 +679,8 @@ class TritonKernelCallTest(parameterized.TestCase):
 
   def test_regression_issue_128(self):
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE": 1024}, num_warps=1),
-        triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 1024}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
     ]
     kernel = triton.autotune(autotune_configs, key=("n_elements",))(add_kernel)
 
@@ -548,7 +695,7 @@ class TritonKernelCallTest(parameterized.TestCase):
 
   def test_autotune_pre_hook_error(self):
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE": 32}, num_warps=1, pre_hook=lambda _: None),
+      triton.Config({"BLOCK_SIZE": 32}, num_warps=1, pre_hook=lambda _: None),
     ]
     kernel = triton.autotune(autotune_configs, key=("n_elements",))(add_kernel)
 
@@ -569,12 +716,12 @@ class TritonKernelCallTest(parameterized.TestCase):
     def do_matmul(m, n, k):
       x, y = create_random_inputs([m, k], [k, n])
       return matmul(
-          x,
-          y,
-          kernel=kernel,
-          BLOCK_SIZE_M=32,
-          BLOCK_SIZE_N=32,
-          BLOCK_SIZE_K=32,
+        x,
+        y,
+        kernel=kernel,
+        BLOCK_SIZE_M=32,
+        BLOCK_SIZE_N=32,
+        BLOCK_SIZE_K=32,
       )
 
     _ = do_matmul(m=128, n=128, k=128)
@@ -590,21 +737,21 @@ class TritonKernelCallTest(parameterized.TestCase):
 
     heuristics = {"K_EXACTLY_DIVISIBLE_BY_BLOCK": heuristic_fn}
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE_K": 32}, num_warps=1),
-        triton.Config({"BLOCK_SIZE_K": 64}, num_warps=1),
+      triton.Config({"BLOCK_SIZE_K": 32}, num_warps=1),
+      triton.Config({"BLOCK_SIZE_K": 64}, num_warps=1),
     ]
     kernel = triton.autotune(autotune_configs, key=("M", "N", "K"))(
-        triton.heuristics(heuristics)(matmul_kernel)
+      triton.heuristics(heuristics)(matmul_kernel)
     )
 
     def do_matmul(m, n, k):
       x, y = create_random_inputs([m, k], [k, n])
       return matmul(
-          x,
-          y,
-          kernel=kernel,
-          BLOCK_SIZE_M=32,
-          BLOCK_SIZE_N=32,
+        x,
+        y,
+        kernel=kernel,
+        BLOCK_SIZE_M=32,
+        BLOCK_SIZE_N=32,
       )
 
     _ = do_matmul(m=128, n=128, k=128)
@@ -618,17 +765,17 @@ class TritonKernelCallTest(parameterized.TestCase):
     heuristics = {"K_EXACTLY_DIVISIBLE_BY_BLOCK": heuristic_fn}
     autotune_config = triton.Config({"BLOCK_SIZE_K": 32}, num_warps=1)
     kernel = triton.autotune([autotune_config], key=("M", "N", "K"))(
-        triton.heuristics(heuristics)(matmul_kernel)
+      triton.heuristics(heuristics)(matmul_kernel)
     )
 
     def do_matmul(m, n, k):
       x, y = create_random_inputs([m, k], [k, n])
       return matmul(
-          x,
-          y,
-          kernel=kernel,
-          BLOCK_SIZE_M=32,
-          BLOCK_SIZE_N=32,
+        x,
+        y,
+        kernel=kernel,
+        BLOCK_SIZE_M=32,
+        BLOCK_SIZE_N=32,
       )
 
     _ = do_matmul(m=128, n=128, k=128)
@@ -636,8 +783,8 @@ class TritonKernelCallTest(parameterized.TestCase):
 
   def test_autotune_with_input_output_aliasing(self):
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
-        triton.Config({"BLOCK_SIZE": 64}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 64}, num_warps=1),
     ]
     kernel = triton.autotune(autotune_configs, key=("n_elements",))(add_inplace_kernel)
 
@@ -646,23 +793,231 @@ class TritonKernelCallTest(parameterized.TestCase):
     out = add(x, y, kernel=kernel, input_output_aliases={0: 0})
     np.testing.assert_allclose(out, expected)
 
+  def test_kernel_in_thread(self):
+    # inspired by Triton's test
+
+    # Test calling in a new thread sets a valid device context
+    buf = jnp.zeros((38016 * 1024,), dtype=jnp.float32)
+
+    @jt.kernel(out_names="out")
+    @triton.jit
+    def _kernel(P, BLOCK: tl.constexpr, out):
+      pid = tl.program_id(0).to(tl.int64)
+      offset = pid * BLOCK + tl.arange(0, BLOCK)
+
+      p = tl.load(P + offset)
+      tl.store(out + offset, p + 1)
+
+    def call_triton():
+      nonlocal buf
+      N = buf.size
+      grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]),)
+      out = _kernel[grid](buf, BLOCK=1024, out_shape=buf)
+      np.testing.assert_array_equal(buf + 1, out)
+
+    from concurrent.futures import ThreadPoolExecutor
+
+    call_triton()
+    with ThreadPoolExecutor(1) as pool:
+      future = pool.submit(call_triton)
+      future.result()
+
   def test_autodiff_exception(self):
     x, y = create_random_inputs([10, 100], dtype="float32")
     with self.assertRaisesRegex(
-        NotImplementedError,
-        r"jax_triton.triton_call does not support automatic differentiation.*"
-        r"jax\.custom_jvp or jax\.custom_vjp.*",
+      NotImplementedError,
+      r"jax_triton.triton_call does not support automatic differentiation.*"
+      r"jax\.custom_jvp or jax\.custom_vjp.*",
     ):
       jax.grad(lambda x, y: jnp.sum(add(x, y, BLOCK_SIZE=32)))(x, y)
 
   def test_batching_exception(self):
     x, y = create_random_inputs([10, 100], dtype="float32")
     with self.assertRaisesRegex(
-        NotImplementedError,
-        r"jax_triton.triton_call does not support batching.*"
-        r"jax\.custom_batching\.custom_vmap.*",
+      NotImplementedError,
+      r"jax_triton.triton_call does not support batching.*"
+      r"jax\.custom_batching\.custom_vmap.*",
     ):
       jax.vmap(lambda x, y: add(x, y, BLOCK_SIZE=32))(x, y)
+
+  def test_memory_leak(self):
+    # inspired by Triton's test
+
+    @jt.kernel(out_names="out_ptr0")
+    @triton.jit
+    def kernel(in_ptr0, xnumel, XBLOCK: tl.constexpr, out_ptr0):
+      xnumel = 10
+      xoffset = tl.program_id(0) * XBLOCK
+      xindex = xoffset + tl.arange(0, XBLOCK)[:]
+      xmask = xindex < xnumel
+      x0 = xindex
+      tmp0 = tl.load(in_ptr0 + (x0), xmask)
+      tl.store(out_ptr0 + (x0 + tl.zeros([XBLOCK], tl.int32)), tmp0, xmask)
+
+    import gc
+    import tracemalloc
+
+    tracemalloc.start()
+    try:
+      inp = random.normal(random.key(0), (10,))
+      out = kernel[(10,)](inp, 10, XBLOCK=16, out_shape=inp)
+      gc.collect()
+      begin, _ = tracemalloc.get_traced_memory()
+      for _ in range(200):  # originally was 100
+        out = kernel[(10,)](inp, 10, XBLOCK=16, out_shape=inp)
+      del out
+      gc.collect()
+      end, _ = tracemalloc.get_traced_memory()
+      assert end - begin < 71000  # originally this was 30000, but we add a bunch
+      # of data into a kernel object and there's JAX's internal caching in the Primitive
+      # system on top of that, so +41k seem reasonable (it was estimated with the
+      # original 100 reps in the loop above, then the range was set to 200).
+      # Note that the margin is just about 100 bytes on my system, so it's ok if on the
+      # other system it's slightly different (i.e. a bit bigger and causes a failure,
+      # - then just update the threshold above).
+    finally:
+      tracemalloc.stop()
+
+  @parameterized.product(
+    signed=[False, True],
+    width=[8, 16, 32, 64, 1],
+  )
+  def test_int_annotation(self, signed, width):
+    # Inspired by an original Triton test.
+    # We could have similar for float, but it seem redundant as now we let the original
+    # Triton code do the job and if ints work - all other should work too.
+    if width == 1 and signed:
+      return
+
+    def annotated_function(return_type=None, **arg_types):
+      """A decorator to add annotations to a function."""
+
+      def decorator(func):
+        func.__annotations__ = {**arg_types, "return": return_type}
+        return func
+
+      return decorator
+
+    @jt.kernel
+    @triton.jit
+    @annotated_function(v=f"tl.{'' if signed else 'u'}int{width}")
+    def _kernel(v, X):
+      tl.store(X + v, v)
+
+    _kernel[(1,)](3, out_shape=jnp.zeros(1), _store_asm=True)
+
+    asm = jttl.JTJITFunction(_kernel).asm
+    assert len(asm) == 1
+    ttir = next(iter(asm.values())).get("ttir")
+
+    pfx = "si" if signed else "ui"
+    if not signed and width < 64:
+      assert "arith.extui %v" in ttir
+    assert f"%v: i{width}" in ttir
+    assert f"arith.{pfx}tofp" in ttir
+
+  def test_err_constexpr_and_do_not_specialize(self):
+    # again inspired by the original test; essentially verifies that our code doesn't
+    # break `do_not_specialize` functionality. It's somewhat related to the previous,
+    # as for this we just rely on the original Triton processing and this tests that
+    # this isn't broken.
+    @jt.kernel
+    @triton.jit(do_not_specialize=["N"])
+    def kernel(out_ptr, N: tl.constexpr):
+      pass
+
+    with self.assertRaisesRegex(
+      triton.compiler.errors.CompilationError,
+      r"N marked as constexpr and listed in do_not_specialize",
+    ):
+      kernel[(1,)](5, out_shape=jnp.zeros(1))  # out_shape is needed to prevent DCE
+
+  def test_kernel_default_arg(self):
+    # inspired by an original Triton test
+    global GLOBAL_DEFAULT_ARG
+
+    @jt.kernel
+    @triton.jit
+    def kernel(X, i: tl.constexpr = GLOBAL_DEFAULT_ARG):
+      tl.store(X, i)
+
+    x = kernel[(1,)](out_shape=jnp.zeros(1))
+    assert x == jnp.ones_like(x)
+
+    # Changing the global variable should not change the default argument in
+    # `kernel`.  That value gets set at the time the function is declared.
+    GLOBAL_DEFAULT_ARG = 2
+    x = kernel[(1,)](out_shape=jnp.zeros(1))
+    assert x == jnp.ones_like(x)
+
+    assert jttl.JTJITFunction(kernel).compiled_kernels_cache_size == 1
+
+  def test_readme(self):
+    """Code for readme example, basically an integration test of many features at once,
+    including not otherwise tested passing of strings and precise partial aliasing +
+    pure outputs"""
+    from triton.language.extra import libdevice
+    from typing import NamedTuple
+    import time
+
+    class Function(NamedTuple):
+      fn: tl.constexpr
+      captured: tuple
+
+    @triton.jit
+    def func1(x_ptr, y_ptr: tl.const, SIZE: tl.constexpr):
+      off = tl.arange(0, SIZE)
+      x = tl.load(x_ptr + off)
+      y = tl.load(y_ptr + off)
+      x1 = libdevice.sin(x)
+      x2 = libdevice.cos(x)
+      z = x1 * x1 + x2 * x2
+      tl.store(x_ptr + off, z)
+      y = libdevice.asin(y) + libdevice.acos(y)
+      return z, libdevice.floor(2 * y)
+
+    @triton.jit
+    def floor_of_func(values, SIZE: tl.constexpr, FUNC_NAME: tl.constexpr):
+      off = tl.arange(0, SIZE)
+      return libdevice.floor(getattr(libdevice, FUNC_NAME)(values))
+
+    @triton.jit
+    def aggregate(Ptrs):
+      z = tl.zeros([], tl.float32)
+      for i in tl.static_range(len(Ptrs)):
+        z += Ptrs[i]
+      return z
+
+    @jt.kernel
+    @triton.jit
+    def kernel(capture, out_ptr, SIZE: tl.constexpr, FUNC_NAME: tl.constexpr):
+      off = tl.arange(0, SIZE)
+      t1, t2 = capture.fn(*capture.captured, SIZE=SIZE)
+      t3 = floor_of_func(t1, SIZE=SIZE, FUNC_NAME=FUNC_NAME)
+      t4 = t2 * t3
+      result = aggregate((t4, t4 * t4)).to(tl.int32)
+      tl.store(out_ptr + off, result)
+
+    size = 8
+    k1, k2 = random.split(random.key(time.perf_counter_ns()), 2)
+    x = random.uniform(k1, (size,), dtype=jnp.float32)
+    y = random.uniform(k2, (size,), dtype=jnp.float32)
+
+    fn = Function(func1, (x, y))
+    out, x = kernel[(1,)](
+      fn,  # essentially a tuple of (func_name, (2 arrays in a subtuple))
+      SIZE=size,
+      FUNC_NAME="exp",
+      out_shape=jnp.zeros(size, dtype=jnp.int32),
+      input_output_aliases=("capture", 1, 0),  # a path inside `capture` argument, 0th
+      # element of 1st subtuple, i.e. `x`. Note that since this is a tuple, it
+      # references just a single element (or all its embedded arrays if it's a tuple,
+      # but in this invocation it references array `x`)
+    )
+    np.testing.assert_array_equal(out, jnp.full((size,), 42, dtype=jnp.int32))
+    assert out.dtype == jnp.int32
+    np.testing.assert_allclose(x, jnp.full((size,), 1.0, dtype=jnp.float32), rtol=5e-7)
+    assert x.dtype == jnp.float32
 
 
 if __name__ == "__main__":

--- a/tests/triton_test.py
+++ b/tests/triton_test.py
@@ -13,14 +13,27 @@
 # limitations under the License.
 
 from absl.testing import absltest
+from absl.testing import parameterized
 
 import jax
+from jax import config, random
 import jax.numpy as jnp
 import jax_triton as jt
 import numpy as np
+import scipy
 import triton
 import triton.language as tl
 from triton.language.extra import libdevice
+
+config.parse_flags_with_absl()
+
+
+def setUpModule():
+  config.update("jax_enable_x64", True)
+
+
+def tearDownModule():
+  config.update("jax_enable_x64", False)
 
 
 @triton.jit
@@ -77,7 +90,7 @@ def tanh_kernel(
   tl.store(output_ptr + offsets, output, mask=mask)
 
 
-class TritonTest(absltest.TestCase):
+class TritonTest(parameterized.TestCase):
 
   def test_add_kernel(self):
 
@@ -115,6 +128,44 @@ class TritonTest(absltest.TestCase):
     x = jnp.arange(8, dtype=jnp.float32)
     np.testing.assert_allclose(tanh(x), np.tanh(x))
 
+  @parameterized.product(
+    dtype_str=["float32", "float64"],
+    funcs=[
+      # ("j0", lambda x: jax.scipy.special.bessel_jn(x, v=0)[0]),
+      # much surprisingly, the above produces nans and according to Opus this might
+      # be due to an inherent instability of the implemented Miller backward recurrence
+      # algorithm. Don't know the truth, but for tests scipy use is acceptable.
+      ("j0", lambda x: jnp.array(scipy.special.j0(np.asarray(x)))),
+      ("j1", lambda x: jnp.array(scipy.special.j1(np.asarray(x)))),
+      ("y0", lambda x: jnp.array(scipy.special.y0(np.asarray(x)))),
+      ("y1", lambda x: jnp.array(scipy.special.y1(np.asarray(x)))),
+      ("cyl_bessel_i0", lambda x: jnp.array(scipy.special.i0(np.asarray(x)))),
+      ("cyl_bessel_i1", lambda x: jnp.array(scipy.special.i1(np.asarray(x)))),
+    ],
+  )
+  def test_bessel(self, dtype_str, funcs):
+    # inspired by the original Triton test
+    libdevice_fn, jax_special_fn = funcs
+    SIZE = 128
+    dtype = getattr(jnp, dtype_str)
 
-if __name__ == '__main__':
+    x = random.normal(random.key(42), (SIZE,), dtype=dtype)
+    y_ref = jax_special_fn(x)
+
+    @jt.kernel
+    @triton.jit
+    def kernel(in_p, out_p, fn: tl.constexpr, SIZE: tl.constexpr):
+      off = tl.arange(0, SIZE)
+      x = tl.load(in_p + off)
+      res = getattr(libdevice, fn)(x)
+      tl.store(out_p + off, res)
+
+    y_exp = kernel[(1,)](
+      x, fn=libdevice_fn, SIZE=SIZE, num_warps=4, num_ctas=1, out_shape=x
+    )
+
+    np.testing.assert_allclose(y_exp, y_ref, equal_nan=True, rtol=1e-6)
+
+
+if __name__ == "__main__":
   absltest.main()

--- a/tests/tuple_test.py
+++ b/tests/tuple_test.py
@@ -1,0 +1,269 @@
+# Copyright 2026 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Additional tests for tuple passing and returning.
+"""
+
+import os
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+from jax import config, random
+import jax.numpy as jnp
+import jax_triton as jt
+import numpy as np
+import triton
+import triton.language as tl
+from typing import NamedTuple
+
+config.parse_flags_with_absl()
+
+
+def jax_strides(x):
+  assert isinstance(x, jax.Array) and x.ndim == 2
+  return (x.shape[1], 1)
+
+
+# many tests here are inspired by the original Triton's test suite
+
+
+class TupleTest(parameterized.TestCase):
+  @parameterized.parameters(1, 2, 3, 4)
+  # the original test also tested size=0, however, this leads to an invocation of the
+  # kernel with no outputs, which triggers JAX's DCE. DCE could be disabled for a
+  # kernel call if needed, but the utility of that isn't exactly clear, so until
+  # clarified, size=0 is excluded.
+  def test_index(self, size):
+    @triton.jit
+    def _tuple_increment(values):
+      return tl.tuple([v + 1 for v in values])
+
+    @triton.jit
+    def _tuple_index_func(Ptrs, values):
+      for i in tl.static_range(len(values)):
+        tl.store(Ptrs[i], values[i])
+
+    @jt.kernel(out_names="Ptrs")
+    @triton.jit
+    def _tuple_index(_0, _1: tl.constexpr, values, _2, _3: tl.constexpr, _4, Ptrs):
+      values = _tuple_increment(values)
+      _tuple_index_func(Ptrs, values)
+
+    vals = tuple(i + 1 for i in range(size))
+    rets = tuple(jnp.zeros((1,), dtype=jnp.float32) for _ in vals)
+    rets = _tuple_index[(1,)](0, 0, vals, 0, 0, 0, out_shape=[rets])
+    assert vals == tuple(x - 1 for x in rets)
+
+  def test_assign(self):
+    @jt.kernel
+    @triton.jit
+    def _tuple_assign(XPtrs, YPtrs, values):
+      # assign from tuple
+      X0, X1 = XPtrs
+      x0, x1, _ = values
+      tl.store(X0, x0)
+      tl.store(X1, x1)
+      # assign to tuple
+      Y0, Y1, Y2 = YPtrs
+      Y = Y0, Y1, Y2
+      y = x0, 10, x1
+      tl.store(Y[0], y[0])
+      tl.store(Y[1], y[1])
+      tl.store(Y[2], y[2])
+
+    vals = (2.0, 3.0, None)
+    x = tuple(jnp.zeros((1,), dtype=jnp.float32) for _ in range(2))
+    y = tuple(jnp.zeros((1,), dtype=jnp.float32) for _ in range(3))
+    x, y = _tuple_assign[(1,)](x, y, vals, input_output_aliases=["XPtrs", "YPtrs"])
+    assert x[0] == vals[0]
+    assert x[1] == vals[1]
+    assert y[0] == vals[0]
+    assert y[1] == 10
+    assert y[2] == vals[1]
+
+  def test_assign_return(self):
+    @triton.jit
+    def _tuple_ret(a, b):
+      return a + b, a - b, a * b
+
+    @jt.kernel
+    @triton.jit
+    def with_fn(X, Y, A, B, C):
+      x = tl.load(X)
+      y = tl.load(Y)
+      a, b, c = _tuple_ret(x, y)
+      tl.store(A, a)
+      tl.store(B, b)
+      tl.store(C, c)
+
+    @jt.kernel
+    @triton.jit
+    def without_fn(X, Y, A, B, C):
+      x = tl.load(X)
+      y = tl.load(Y)
+      a, b, c = x + y, x - y, x * y
+      tl.store(A, a)
+      tl.store(B, b)
+      tl.store(C, c)
+
+    x = jnp.array([1.3], dtype=jnp.float32)
+    y = jnp.array([1.9], dtype=jnp.float32)
+    for kernel in [with_fn, without_fn]:
+      a_tri, b_tri, c_tri = kernel[(1,)](x, y, num_warps=1, out_shape=(x, x, x))
+      a_ref, b_ref, c_ref = x + y, x - y, x * y
+      assert a_tri == a_ref
+      assert b_tri == b_ref
+      assert c_tri == c_ref
+
+  def test_serialize(self):
+    @triton.jit
+    def _tuple_fn0(Ptr, cst2: tl.constexpr, tuple1):
+      tl.static_assert(tuple1[1] is None)
+      tl.store(Ptr + 5, cst2)
+      tl.store(Ptr + 6, tuple1[0])
+      tl.store(Ptr + 7, tl.load(tuple1[2][0]))
+      tl.store(Ptr + 8, tuple1[2][1][0])
+      tl.store(Ptr + 9, tl.load(tuple1[2][1][2]))
+
+    @jt.kernel(out_names="Ptr")
+    @triton.jit
+    def _tuple_serialize(N1, tuple1, cst1: tl.constexpr, val1, tuple2, Ptr):
+      tl.static_assert(N1 is None)
+      tl.static_assert(tuple1[1][1] is None)
+      tl.static_assert(tuple1[1][3] == 4)
+      tl.store(Ptr + 0, tl.load(tuple1[0]))
+      tl.store(Ptr + 1, tuple1[1][0])
+      tl.store(Ptr + 2, tl.load(tuple1[1][2]))
+      tl.store(Ptr + 3, cst1 + val1)
+      tl.store(Ptr + 4, tl.load(tuple2[0]))
+      _tuple_fn0(Ptr, 15, (-1, None, tuple1))
+
+    x0 = jnp.array([8], dtype=jnp.int32)
+    x1 = jnp.array([12], dtype=jnp.int32)
+    y0 = jnp.array([10], dtype=jnp.int32)
+
+    z = _tuple_serialize[(1,)](
+      None,
+      (x0, (1, None, x1, tl.constexpr(4))),
+      20,
+      1,
+      (y0,),
+      out_shape=jnp.empty((10,), dtype=jnp.int32),
+    )
+    ref = jnp.array([8, 1, 12, 21, 10, 15, -1, 8, 1, 12], dtype=jnp.int32)
+    np.testing.assert_array_equal(z, ref)
+
+  def test_namedtuple(self):
+    class Function(NamedTuple):
+      fn: tl.constexpr
+      captured: tuple
+
+    class Tensor(NamedTuple):
+      ptr: any
+      shape: tuple
+      stride: tuple
+
+    @triton.jit
+    def _namedtuple_create_func0(shape, ptr, stride):
+      return Tensor(shape=shape, ptr=ptr, stride=stride)
+
+    @triton.jit
+    def _namedtuple_create_func1(shape, ptr, stride):
+      tensor = Tensor(shape=shape, ptr=ptr, stride=stride)
+      return tensor
+
+    @triton.jit
+    def _namedtuple_mask_func(Tensor, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+      offs_m = tl.arange(0, BLOCK_M)
+      offs_n = tl.arange(0, BLOCK_N)
+      mask = (offs_m[:, None] < Tensor.shape[0]) & (offs_n[None, :] < Tensor.shape[1])
+      return mask
+
+    @jt.kernel
+    @triton.jit
+    def _namedtuple_kernel(
+      closure, _X, Y, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr
+    ):
+      offs_m = tl.arange(0, BLOCK_M)
+      offs_n = tl.arange(0, BLOCK_N)
+      X = _namedtuple_create_func0(_X.shape, _X.ptr, _X.stride)
+      Y = _namedtuple_create_func1(Y.shape, Y.ptr, Y.stride)
+      Xs = X.ptr + offs_m[:, None] * X.stride[0] + offs_n[None, :] * X.stride[1]
+      Ys = Y.ptr + offs_m[:, None] * Y.stride[0] + offs_n[None, :] * Y.stride[1]
+      x = tl.load(Xs, mask=_namedtuple_mask_func(X, BLOCK_M, BLOCK_N), other=0)
+      y = closure.fn(x, *closure.captured)
+      tl.store(Ys, y, mask=_namedtuple_mask_func(Y, BLOCK_M, BLOCK_N))
+
+    x = random.normal(random.key(0), (32, 32), dtype=jnp.float32)
+    y = jnp.empty((16, 16), dtype=jnp.float32)
+    a = jnp.array([5.2], dtype=jnp.float32)
+
+    @triton.jit
+    def mul(x, a):
+      return x * tl.load(a)
+
+    function = Function(mul, (a,))
+    tx = Tensor(x, x.shape, jax_strides(x))
+    ty = Tensor(y, y.shape, jax_strides(y))
+    y = _namedtuple_kernel[(1,)](function, tx, ty, 64, 64, input_output_aliases="Y")
+    np.testing.assert_allclose(y, x[:16, :16] * a)
+
+  def test_passing_nested_tuple_with_constexpr(self):
+    @jt.kernel
+    @triton.jit
+    def _nested_tuple_kernel(x, out_ptr):
+      # This creates a new scope, which will force a copy of liveins. It's
+      # important for this to happen as it forces IR flattening/unflattening,
+      # which relies on the types being correct for the roundtrip to succeed.
+      for _ in range(1):
+        tl.static_assert(x[1][0] == 2)
+        tl.static_assert(len(x[2]) == 0)  # to tests JT specific empty tuple passing
+
+    _nested_tuple_kernel[(1,)](  # out_shape is needed to prevent DCE
+      ((1,), (tl.constexpr(2),), tuple()), out_shape=jnp.zeros(1)
+    )
+
+  def test_passing_tuple_to_make_tensor_descriptor(self):
+    @jt.kernel
+    @triton.jit
+    def m_to_the_n(X_base, shape, strides, m_n, BLOCK_DIM: tl.constexpr):
+      tl.static_assert(isinstance(strides[1].type, tl.constexpr_type))
+      X = tl.make_tensor_descriptor(
+        X_base,
+        shape=shape,
+        strides=strides,
+        block_shape=[BLOCK_DIM, BLOCK_DIM],
+      )
+      # Make sure tl.make_tensor_descriptor didn't modify strides (i.e. didn't unwrap the constexpr)
+      tl.static_assert(isinstance(strides[1].type, tl.constexpr_type))
+      data = X.load([0, 0])
+      # Include a for loop to ensure strides[1] is lifted into a constexpr
+      # (otherwise cloning the local scope will fail).
+      for i in tl.range(0, m_n[1]):
+        data = m_n[0] * data
+      X.store([0, 0], data)
+
+    x = jnp.arange(0, 16).reshape(4, 4)
+    expected_x = 8 * x.copy()
+    x = m_to_the_n[(1,)](
+      x, x.shape, jax_strides(x), (2, 3), x.shape[0], input_output_aliases="X_base"
+    )
+    np.testing.assert_array_equal(x, expected_x)
+
+
+if __name__ == "__main__":
+  os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+  absltest.main()

--- a/tests/zeroed_outputs_test.py
+++ b/tests/zeroed_outputs_test.py
@@ -1,0 +1,263 @@
+# Copyright 2026 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Additional tests for zeroed_outputs= parameter of triton_call().
+
+Note that all these tests have an inherent weakness that could render them potentially
+useless should the backend behavior change: zeroing of purely output arguments is
+tricky, since when the backend initially allocates memory on a device, the memory comes
+from a driver always already zeroed due to security concerns. The test are based on an
+observed backend behavior that if the same kernel is launched 2 times while the outputs
+of the first run are discarded, then on the next run kernel's purely output argument
+will retain its old "dirty" values. If this behavior changes, the tests will become
+flaky.
+
+Previously the only test for zeroed_outputs= was based on zeroing an in-out argument.
+The problem with that is that zeroing in-out arguments doesn't seem to have any
+real-world use, since it just turns an in-out argument back into purely output argument,
+all while likely still requiring the backend to copy the argument content from the host
+to a device before clearing it. This prevents any information from passing into the
+kernel via the aliased argument. Implementing that feature with a proper support for
+tuples is cumbersome and does not worth the effort considering it has no real-world use
+beyond testing.
+
+Unfortunately, I don't have better ideas at this time how to test this in a more robust
+fashion.
+"""
+
+import os
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+from jax import config, random
+import jax_triton as jt
+import numpy as np
+import triton
+import triton.language as tl
+
+config.parse_flags_with_absl()
+
+
+ERR_MSG = (
+  "This test's assumption that subsequent calls use dirty buffers is "
+  "violated (likely because of the backend behavior change). This makes the test "
+  "either flaky or useless. Anyway, the test needs to be fixed and until that the "
+  "best possible solution is to disable/skip this test."
+)
+
+# large array is likely to be reallocated to the same memory
+ARRAY_SIZE = 100000
+
+
+@jt.kernel
+@triton.jit
+def zeroing_kernel(
+  x_ptr: tl.const,
+  n_elements,
+  out_ptr,
+  BLOCK_SIZE: tl.constexpr,
+  CLEANUP: tl.constexpr = False,  # this also implicitly test defaults
+):
+  pid = tl.program_id(axis=0)
+  block_start = pid * BLOCK_SIZE
+  offsets = block_start + tl.arange(0, BLOCK_SIZE)
+  mask = offsets < n_elements
+  # explicit cleanup is needed to isolate the kernel from previous tests run history
+  if CLEANUP:
+    tl.store(out_ptr + offsets, 0, mask=mask)
+  x = tl.load(x_ptr + offsets, mask=mask)
+  y = tl.load(out_ptr + offsets, mask=mask)
+  output = x + y
+  tl.store(out_ptr + offsets, output, mask=mask)
+
+
+class TritonCallZeroedOutputsTest(parameterized.TestCase):
+  @parameterized.product(
+    use_function=[False, True], arg_form=[("out_ptr",), (2,), (("out_ptr",),), ((2,),)]
+  )
+  def test_arg_form_raw(self, use_function, arg_form):
+    x = random.normal(random.key(0), shape=ARRAY_SIZE)
+    BLOCK_SIZE = 8
+    grid = triton.cdiv(x.size, BLOCK_SIZE)
+
+    # first test the backend behavior, that sequential calls use dirty outputs.
+    out = zeroing_kernel[grid](
+      x, x.size, BLOCK_SIZE=BLOCK_SIZE, CLEANUP=True, out_shape=x
+    )
+    np.testing.assert_allclose(out, x)
+    del out
+
+    # and verify the core test assumption that second call uses a dirty buffer
+    out = zeroing_kernel[grid](x, x.size, BLOCK_SIZE=BLOCK_SIZE, out_shape=x)
+    np.testing.assert_allclose(out, 2 * x, err_msg=ERR_MSG)
+    del out
+
+    # finally test zeroed_outputs
+    zeroed_arg = (lambda x: arg_form) if use_function else arg_form
+    out = zeroing_kernel[grid](
+      x, x.size, BLOCK_SIZE=BLOCK_SIZE, out_shape=x, zeroed_outputs=zeroed_arg
+    )
+    np.testing.assert_allclose(out, x)
+
+  @parameterized.product(
+    use_function=[False, True],
+    zeroed_which=[
+      # (zeroed_spec, which_zeroed) — which_zeroed tells us which tuple elements to expect zeroed
+      (("out_ptrs", 0), {0}),  # string + sub-index, zero first only
+      (("out_ptrs", 1), {1}),  # string + sub-index, zero second only
+      ((2, 0), {0}),  # int + sub-index, zero first only
+      ((2, 1), {1}),  # int + sub-index, zero second only
+      ("out_ptrs", {0, 1}),  # string, zero both
+      ((("out_ptrs", 0), ("out_ptrs", 1)), {0, 1}),  # tuples, zero both
+      ((("out_ptrs", 1), ("out_ptrs", 0)), {0, 1}),  # tuples, zero both
+      (2, {0, 1}),  # int, zero both
+      (((2, 0), (2, 1)), {0, 1}),  # tuples, zero both
+      (((2, 1), (2, 0)), {0, 1}),  # tuples, zero both
+      (((2, 1), ("out_ptrs", 0)), {0, 1}),  # tuples, zero both
+      ((("out_ptrs", 1), (2, 0)), {0, 1}),  # tuples, zero both
+    ],
+  )
+  def test_tuple(self, use_function, zeroed_which):
+    """zeroed_outputs uses a tuple path to address a single array inside a
+    compound (tuple) output parameter."""
+    zeroed_spec, which_zeroed = zeroed_which
+
+    @jt.kernel(out_names="out_ptrs")
+    @triton.jit
+    def kernel_tuple_path(
+      x_ptr: tl.const,
+      n_elements,
+      out_ptrs,
+      BLOCK_SIZE: tl.constexpr,
+      CLEANUP: tl.constexpr = False,
+    ):
+      pid = tl.program_id(axis=0)
+      block_start = pid * BLOCK_SIZE
+      offsets = block_start + tl.arange(0, BLOCK_SIZE)
+      mask = offsets < n_elements
+      for i in tl.static_range(len(out_ptrs)):
+        if CLEANUP:
+          tl.store(out_ptrs[i] + offsets, 0, mask=mask)
+        x = tl.load(x_ptr + offsets, mask=mask)
+        y = tl.load(out_ptrs[i] + offsets, mask=mask)
+        tl.store(out_ptrs[i] + offsets, x + y, mask=mask)
+
+    x = random.normal(random.key(20), shape=(ARRAY_SIZE,))
+    BLOCK_SIZE = 8
+    grid = triton.cdiv(x.size, BLOCK_SIZE)
+    z = jax.ShapeDtypeStruct(x.shape, x.dtype)
+    shape_pair = (z, z)
+
+    args = [x, x.size]
+    kwargs = dict(BLOCK_SIZE=BLOCK_SIZE, out_shape=[shape_pair])
+
+    # prime
+    o0, o1 = kernel_tuple_path[grid](*args, **kwargs, CLEANUP=True)
+    np.testing.assert_allclose(o0, x)
+    np.testing.assert_allclose(o1, x)
+    del o0, o1
+    # confirm dirty
+    o0, o1 = kernel_tuple_path[grid](*args, **kwargs)
+    np.testing.assert_allclose(o0, 2 * x, err_msg=ERR_MSG)
+    np.testing.assert_allclose(o1, 2 * x, err_msg=ERR_MSG)
+    del o0, o1
+
+    # selective zeroing via tuple path
+    zeroed_outputs = (
+      (zeroed_spec,)
+      if not isinstance(zeroed_spec, tuple) or not isinstance(zeroed_spec[0], tuple)
+      else zeroed_spec
+    )
+    o0, o1 = kernel_tuple_path[grid](
+      *args,
+      **kwargs,
+      zeroed_outputs=(lambda x: zeroed_outputs) if use_function else zeroed_outputs,
+    )
+    for i, out in enumerate((o0, o1)):
+      if i in which_zeroed:
+        np.testing.assert_allclose(out, x, err_msg=f"out_ptrs[{i}] should be zeroed")
+      else:
+        np.testing.assert_allclose(
+          out, 3 * x, err_msg=f"out_ptrs[{i}] should NOT be zeroed"
+        )
+
+  @parameterized.parameters(True, False)
+  def test_config_dependent_callable(self, zero_first):
+    """Callable that inspects a constexpr metaparam to decide which output to zero.
+    Also tests that modification of kwargs in callable is propagated."""
+
+    @jt.kernel(out_names=("out0_ptr", "out1_ptr"))
+    @triton.jit
+    def kernel_configurable(
+      x_ptr: tl.const,
+      n_elements,
+      out0_ptr,
+      out1_ptr,
+      BLOCK_SIZE: tl.constexpr,
+      CLEANUP: tl.constexpr = False,
+    ):
+      pid = tl.program_id(axis=0)
+      block_start = pid * BLOCK_SIZE
+      offsets = block_start + tl.arange(0, BLOCK_SIZE)
+      mask = offsets < n_elements
+      if CLEANUP:
+        tl.store(out0_ptr + offsets, 0, mask=mask)
+        tl.store(out1_ptr + offsets, 0, mask=mask)
+      x = tl.load(x_ptr + offsets, mask=mask)
+      o0 = tl.load(out0_ptr + offsets, mask=mask)
+      o1 = tl.load(out1_ptr + offsets, mask=mask)
+      tl.store(out0_ptr + offsets, x + o0, mask=mask)
+      tl.store(out1_ptr + offsets, x + o1, mask=mask)
+
+    x = random.normal(random.key(50), shape=(ARRAY_SIZE,))
+    BLOCK_SIZE = 8
+    grid = triton.cdiv(x.size, BLOCK_SIZE)
+    args = [x, x.size]
+    kwargs = dict(BLOCK_SIZE=BLOCK_SIZE, out_shape=(x, x))
+
+    # The callable inspects the WHICH constexpr from metaparams
+    def zeroed_fn(meta):
+      which_val = meta["WHICH"]
+      del meta["WHICH"]  # also tests that modification of kwargs is propagated
+      return ("out0_ptr",) if which_val == 0 else ("out1_ptr",)
+
+    # prime both outputs to a dirty state
+    o0, o1 = kernel_configurable[grid](*args, **kwargs, CLEANUP=True)
+    np.testing.assert_allclose(o0, x)
+    np.testing.assert_allclose(o1, x)
+    del o0, o1
+    o0, o1 = kernel_configurable[grid](*args, **kwargs)
+    np.testing.assert_allclose(o0, 2 * x, err_msg=ERR_MSG)
+    np.testing.assert_allclose(o1, 2 * x, err_msg=ERR_MSG)
+    del o0, o1
+
+    # WHICH=0 - callable zeros out0_ptr; WHICH=1 - callable zeros out1_ptr
+    which_val = 0 if zero_first else 1
+    o0, o1 = kernel_configurable[grid](
+      *args, **kwargs, WHICH=which_val, zeroed_outputs=zeroed_fn
+    )
+
+    if zero_first:
+      np.testing.assert_allclose(o0, x, err_msg="out0 should be zeroed (WHICH=1)")
+      np.testing.assert_allclose(o1, 3 * x, err_msg="out1 should be dirty (WHICH=1)")
+    else:
+      np.testing.assert_allclose(o0, 3 * x, err_msg="out0 should be dirty (WHICH=0)")
+      np.testing.assert_allclose(o1, x, err_msg="out1 should be zeroed (WHICH=0)")
+
+
+if __name__ == "__main__":
+  os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+  absltest.main()


### PR DESCRIPTION
I'll squash all commits once reviewed before the merge.


# 0.5.0
## Breaking changes
- `float` now follows upstream convention and is represented as `fp32`, instead of old
`fp64`
- `zeroed_outputs=` parameter of `triton_call()` no longer supports zeroing of aliased
input-output arguments.

## New features / bugfixing
- all possible backend initialization options is now fully supported and is handled
similarly to the upstream (via single `kwargs` dictionary).
- support for `@jt.kernel` decorator and a concise Triton-native form of launching a
kernel with `kernel[grid](*args, **kwargs)` syntax.
- arrays and other run-time values can now also be passed as a key-value pair to the
launcher when `out_names=` is set or if a new dictionary form of `out_shape=` is used.
- handling of kernel arguments specialization and defaults values now is fully delegate
to the upstream Triton code, which enables full support for default values, kernel
parameter annotations, related `@triton.jit()` arguments such as `do_not_specialize`,
and also using tuples (including deeply nested), callables or strings as kernel
arguments.
- `out_shape`, `input_output_aliases` and `zeroed_outputs` handling is fully reworked
to support nested tuples and now is based on a kernel signature coordinate system,
instead of flat array indices, leading to a much clearer launcher syntax.
- dictionary form of `input_output_aliases=` is deprecated, but is still fully supported
- `CAN_USE_TRITON` guard is dropped due to obsolescence
- tests grew 187 to 438 test cases

## Performance

Non-jitted launchers are roughly 19% slower for comparable features (I have a changeset to lower this number to ~10% at most, but it makes code less simple and straightforward, so I'll publish it after this one is merged). Jitted launchers show roughly similar numbers, depending on situation. Typical current numbers for launching the following kernel
```python
@triton.jit
def copy_scalar_triton(in_ptr, out_ptr):
    value = tl.load(in_ptr)
    tl.store(out_ptr, value)
```
on a scalar or 4G array are:
```
                                             Benchmark comparison results (Brunner Munzel test, alpha=0.00100)
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃                                       ┃ mean (means),                        ┃ median (means),                    ┃ min (means),                         ┃
┃ Benchmark                             ┃ [0%, 50%, 100%]                      ┃ [0%, 50%, 100%]                    ┃ [0%, 50%, 100%]                      ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ startup(1) | new vs old               │ 102.5us > 83.12us {-18.9%}           │ 99.73us > 81.32us {-18.5%}         │ 89.62us > 72.71us {-18.9%}           │
│                                       │ [89.57u,99.59u,361.3u] >             │ [84.65u,98.91u,113.9u] >           │ [77.94u,88.97u,106.7u] >             │
│                                       │ [71.73u,81.59u,324.1u]               │ [69.96u,80.84u,103.4u]             │ [64.17u,72.07u,90.45u]               │
│                                       │ {-19.9%,-18.1%,-10.3%}               │ {-17.4%,-18.3%,-9.2%}              │ {-17.7%,-19.0%,-15.2%}               │
│                                       │ p=0.00000+(200 vs 200)               │ p=0.00000+(200 vs 200)             │ p=0.00000+(200 vs 200)               │
│                                       │ pvs(1001) >:100.0%(1001)             │ pvs(1001) >:100.0%(1001)           │ pvs(1001) >:100.0%(1001)             │
│ startup(1) jcall | new vs old         │ 57.72us > 55.52us {-3.8%}            │ 55.72us > 54.71us {-1.8%}          │ 52.04us > 51.11us {-1.8%}            │
│                                       │ [49.87u,56.05u,283.4u] >             │ [49.43u,54.96u,65.95u] >           │ [47.16u,51.44u,63.17u] >             │
│                                       │ [50.25u,54.70u,66.21u]               │ [48.76u,53.86u,66.62u]             │ [47.15u,50.32u,63.06u]               │
│                                       │ {+0.8%,-2.4%,-76.6%}                 │ {-1.4%,-2.0%,+1.0%}                │ {-0.0%,-2.2%,-0.2%}                  │
│                                       │ p=0.00015 (200 vs 200)               │ p=0.00004 (200 vs 200)             │ p=0.00001 (200 vs 200)               │
│                                       │ pvs(1001) >:100.0%(1001)             │ pvs(1001) >:97.7%(978), ~:2.3%(23) │ pvs(1001) >:100.0%(1001)             │
│ startup(4G) jcall | new vs old        │ 65.46us ~ 65.32us {-0.2%}            │ 64.15us ~ 62.30us {-2.9%}          │ 54.17us ~ 53.43us {-1.4%}            │
│                                       │ [53.75u,64.28u,294.6u] ~             │ [51.58u,63.46u,81.01u] ~           │ [48.67u,52.92u,72.77u] ~             │
│                                       │ [52.51u,62.81u,293.0u]               │ [50.79u,60.67u,80.22u]             │ [47.23u,51.92u,71.40u]               │
│                                       │ {-2.3%,-2.3%,-0.5%}                  │ {-1.5%,-4.4%,-1.0%}                │ {-3.0%,-1.9%,-1.9%}                  │
│                                       │           (200 vs 200)               │           (200 vs 200)             │           (200 vs 200)               │
│                                       │ pvs(1001) >:0.4%(4), ~:99.6%(997)    │ pvs(1001) >:1.3%(13), ~:98.7%(988) │ pvs(1001) >:19.7%(197), ~:80.3%(804) │
│ startup(4G) out jcall | new vs old    │ 7.364ms ~ 7.358ms {-0.1%}            │ 7.361ms ~ 7.355ms {-0.1%}          │ 7.310ms ~ 7.307ms {-0.0%}            │
│                                       │ [7.305m,7.361m,7.629m] ~             │ [7.300m,7.360m,7.415m] ~           │ [7.190m,7.320m,7.368m] ~             │
│                                       │ [7.292m,7.355m,7.570m]               │ [7.298m,7.356m,7.419m]             │ [7.167m,7.313m,7.369m]               │
│                                       │ {-0.2%,-0.1%,-0.8%}                  │ {-0.0%,-0.1%,+0.1%}                │ {-0.3%,-0.1%,+0.0%}                  │
│                                       │           (200 vs 200)               │           (200 vs 200)             │           (200 vs 200)               │
│                                       │ pvs(1001) >:10.5%(105), ~:89.5%(896) │ pvs(1001) >:6.8%(68), ~:93.2%(933) │ pvs(1001) ~:100.0%(1001)             │
│ startup(4G) donate jcall | new vs old │ 72.86us ~ 73.90us {+1.4%}            │ 72.19us ~ 71.17us {-1.4%}          │ 62.78us > 61.75us {-1.6%}            │
│                                       │ [60.72u,72.50u,87.88u] ~             │ [59.71u,71.68u,87.81u] ~           │ [55.89u,61.53u,81.86u] >             │
│                                       │ [58.71u,71.58u,290.1u]               │ [58.18u,72.14u,87.02u]             │ [52.53u,60.26u,81.60u]               │
│                                       │ {-3.3%,-1.3%,+230.1%}                │ {-2.6%,+0.6%,-0.9%}                │ {-6.0%,-2.1%,-0.3%}                  │
│                                       │           (200 vs 200)               │           (200 vs 200)             │ p=0.00002 (200 vs 200)               │
│                                       │ pvs(1001) >:0.1%(1), ~:99.9%(1000)   │ pvs(1001) >:0.1%(1), ~:99.9%(1000) │ pvs(1001) >:100.0%(1001)             │
└───────────────────────────────────────┴──────────────────────────────────────┴────────────────────────────────────┴──────────────────────────────────────┘
```

To reproduce put the following preparation script in a sibling directory to the checkout and run it:
```bash
#!/usr/bin/bash

THIS_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
#echo "THIS_DIR: $THIS_DIR"

cd $THIS_DIR/../jax-triton
git worktree add ../jax-triton-old upstream/main

cd $THIS_DIR/../jax-triton-old
sed -i 's/name = "jax-triton"/name = "jax-triton-old"/' ./pyproject.toml
sed -i 's/packages = \["jax_triton"\]/packages = \["jax_triton_old"\]/' ./pyproject.toml
sed -i 's/version = {attr = "jax_triton.version.__version__"}/version = {attr = "jax_triton_old.version.__version__"}/' ./pyproject.toml
find ./jax_triton -name '*.py' -exec sed -i 's/\bjax_triton\b/jax_triton_old/g' {} +
mv ./jax_triton ./jax_triton_old

pip install .
pip install benchstats  # benchmarks runner + statistical testing package used

echo "Run as $ python ./comparative_bm.py --iters=5 --reps=200 --warmup=5"
```

The `comparative_bm.py` script is:
```python
import argparse
import os
import time

from benchstats import qbench as qb
from benchstats.common import LoggingConsole
from benchstats.render import makeReadable
import jax
import jax.numpy as jnp
import jax_triton as jt
import jax_triton_old as jt_old
import numpy as np
import triton
import triton.language as tl
from triton.experimental import gluon
from triton.experimental.gluon import language as gl


@qb.registerBenchmark
def make_startup_benchmark():
  NGigs = 4

  @triton.jit
  def copy_scalar_triton(in_ptr, out_ptr):
    value = tl.load(in_ptr)
    tl.store(out_ptr, value)

  def startup(module, input: jnp.ndarray, kernel) -> jnp.ndarray:
    return module.triton_call(
      input,
      kernel=kernel,
      out_shape=jax.ShapeDtypeStruct(shape=input.shape, dtype=input.dtype),
      grid=1,
    )

  def startup_out(module, input: jnp.ndarray, output: jnp.ndarray, kernel) -> jnp.ndarray:
    return module.triton_call(
      input,
      output,
      kernel=kernel,
      out_shape=jax.ShapeDtypeStruct(shape=input.shape, dtype=input.dtype),
      grid=1,
      input_output_aliases={1: 0},
    )

  def init_scalar() -> list:
    return [jnp.array(42.314)]

  def init_vec() -> list:
    return [jnp.arange(NGigs * 1024 * 1024 * 1024)]

  def init_vec_out() -> list:
    i = jnp.arange(NGigs * 1024 * 1024 * 1024)
    return [i, jnp.empty_like(i)]

  # fmt: off
  return {
    "startup(1)|new": (lambda x: startup(jt, x, copy_scalar_triton), init_scalar),
    "startup(1)|old": (lambda x: startup(jt_old, x, copy_scalar_triton), init_scalar),
    "startup(1) jcall|new": (jax.jit(lambda x: startup(jt, x, copy_scalar_triton)), init_scalar),
    "startup(1) jcall|old": (jax.jit(lambda x: startup(jt_old, x, copy_scalar_triton)), init_scalar),
    f"startup({NGigs}G) jcall|new": (jax.jit(lambda x: startup(jt, x, copy_scalar_triton)), init_vec),
    f"startup({NGigs}G) jcall|old": (jax.jit(lambda x: startup(jt_old, x, copy_scalar_triton)), init_vec),
    f"startup({NGigs}G) out jcall|new": (jax.jit(lambda x, y: startup_out(jt, x, y, copy_scalar_triton)), init_vec_out),
    f"startup({NGigs}G) out jcall|old": (jax.jit(lambda x, y: startup_out(jt_old, x, y, copy_scalar_triton)), init_vec_out),
    f"startup({NGigs}G) donate jcall|new": (jax.jit(lambda x, y: startup_out(jt, x, y, copy_scalar_triton), donate_argnums=(1,)), init_vec_out),
    f"startup({NGigs}G) donate jcall|old": (jax.jit(lambda x, y: startup_out(jt_old, x, y, copy_scalar_triton), donate_argnums=(1,)), init_vec_out),
  }
  # fmt: on


def run_benchmarks(
  enabled: list[str] | None = None,
  *,
  iters: int = 100,
  reps: int = 10,
  warmup: int = 3,
  batch_functions: bool = False,
  pvalue_stats_bootstrap: int = 1000,
):
  start = time.perf_counter_ns()

  if not enabled:
    enabled = qb.getRegisteredBenchmarkSetNames()

  console = LoggingConsole()

  bms = qb.getRegisteredBenchmarks(enabled)

  bm_names = tuple(bms.keys())
  all_bms = '", "'.join(bm_names)
  print(f'Going to run {len(bm_names)} benchmarks ({jax.local_device_count()} device(s) available): "{all_bms}"')
  if jax.local_device_count() > 1:
    console.warning(
      "More than 1 device is visible. For potentially better results consistency, restrict the number of devices using ROCR_VISIBLE_DEVICES or similar environment variable."
    )

  # we're interested in a wall-clock time of invoking kernels, including all python
  # related overhead, so time.perf_counter_ns() used there is appropriate
  _, results = qb.benchmark(
    bms.values(),
    iters=iters,
    reps=reps,
    warmup=warmup,
    randomize_iterations=True,
    batch_functions=batch_functions,
    wait_complete=jax.block_until_ready,
    show_progress_each=1,
    bm_names=bm_names,
    alt_delimiter="|",
    metrics={"mean": np.mean, "median": np.median, "min": np.min},
    console=console,
    pvalue_stats_bootstrap=pvalue_stats_bootstrap,
  )

  end = time.perf_counter_ns()
  console.print(f"Done in {makeReadable((end - start) * 1e-9, 1)}s")
  return results


_g_ProgramName = "jax-triton/jax-triton-old benchmarks runner"


def main():
  parser = argparse.ArgumentParser(description=_g_ProgramName)
  parser = qb.makeArgumentParser(parser)

  args = parser.parse_args()
  run_benchmarks(
    enabled=args.benchmark_sets or None,
    iters=args.iters,
    reps=args.reps,
    warmup=args.warmup,
    batch_functions=args.batch_functions,
    pvalue_stats_bootstrap=args.pvalue_stats_bootstrap,
  )


if __name__ == "__main__":
  main()
```