### PR TITLE
Add TMA support: TensorDescriptor API, scratch metadata, and v2 handl…

### DIFF
--- a/examples/tma_copy.py
+++ b/examples/tma_copy.py
@@ -1,0 +1,118 @@
+# Copyright 2026 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal jax-triton example using a host-side TMA TensorDescriptor.
+
+Run with:
+
+  python examples/tma_copy.py
+
+This requires CUDA TMA support, which is available on NVIDIA GPUs with compute
+capability >= 90.
+"""
+
+import jax
+import jax.numpy as jnp
+import jax_triton as jt
+import numpy as np
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def tma_copy_kernel(
+    x_desc,
+    output_ptr,
+    N_COLS: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+  pid_m = tl.program_id(0)
+  pid_n = tl.program_id(1)
+
+  start_m = pid_m * BLOCK_M
+  start_n = pid_n * BLOCK_N
+
+  tile = x_desc.load([start_m, start_n])
+
+  rows = start_m + tl.arange(0, BLOCK_M)
+  cols = start_n + tl.arange(0, BLOCK_N)
+  output_offsets = rows[:, None] * N_COLS + cols[None, :]
+  tl.store(output_ptr + output_offsets, tile)
+
+
+def require_tma_capable_gpu() -> None:
+  try:
+    compute_capability = jt.get_compute_capability(0)
+  except Exception as exc:
+    raise RuntimeError(
+        "This example requires jaxlib with CUDA GPU support."
+    ) from exc
+
+  if compute_capability < 90:
+    raise RuntimeError(
+        "This example requires a CUDA GPU with compute capability >= 90; "
+        f"device 0 has {compute_capability}."
+    )
+
+
+def tma_copy(x: jax.Array) -> jax.Array:
+  if x.ndim != 2:
+    raise ValueError(f"expected a rank-2 input, got shape {x.shape}")
+
+  block_m = 16
+  block_n = 16
+  m, n = x.shape
+  if m % block_m != 0 or n % block_n != 0:
+    raise ValueError(
+        f"shape {x.shape} must be divisible by {(block_m, block_n)}"
+    )
+
+  x_desc = jt.TensorDescriptor(
+      base=x,
+      shape=(m, n),
+      strides=(n, 1),
+      block_shape=(block_m, block_n),
+  )
+  out_shape = jax.ShapeDtypeStruct(shape=x.shape, dtype=x.dtype)
+  grid = (m // block_m, n // block_n)
+  return jt.triton_call(
+      x_desc,
+      kernel=tma_copy_kernel,
+      out_shape=out_shape,
+      grid=grid,
+      num_warps=4,
+      num_stages=3,
+      N_COLS=n,
+      BLOCK_M=block_m,
+      BLOCK_N=block_n,
+  )
+
+
+def main() -> None:
+  require_tma_capable_gpu()
+
+  x = jnp.arange(64 * 64, dtype=jnp.float32).reshape(64, 64)
+
+  eager_out = tma_copy(x).block_until_ready()
+  np.testing.assert_allclose(eager_out, x)
+  print("eager TMA copy OK")
+
+  jit_out = jax.jit(tma_copy)(x).block_until_ready()
+  np.testing.assert_allclose(jit_out, x)
+  print("jit TMA copy OK")
+
+
+if __name__ == "__main__":
+  main()

--- a/jax_triton/__init__.py
+++ b/jax_triton/__init__.py
@@ -17,6 +17,7 @@
 __all__ = [
     "utils",
     "triton_call",
+    "TensorDescriptor",
     "cdiv",
     "next_power_of_2",
     "strides_from_shape",
@@ -26,6 +27,7 @@ __all__ = [
 
 from jax._src.lib import gpu_triton
 from jax_triton import utils
+from jax_triton.triton_lib import TensorDescriptor
 from jax_triton.triton_lib import triton_call
 from jax.experimental.pallas import cdiv
 from jax.experimental.pallas import next_power_of_2

--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -97,6 +97,79 @@ Grid = Union[int, tuple[int], tuple[int, int], tuple[int, int, int]]
 GridOrLambda = Union[Grid, Callable[[dict[str, Any]], Grid]]
 
 
+@dataclasses.dataclass(frozen=True)
+class TensorDescriptor:
+  """JAX-native tensor descriptor for host-side TMA.
+
+  Mirrors the public fields of Triton's ``TensorDescriptor`` but uses JAX
+  dtypes and avoids the torch-specific validation in Triton's implementation.
+  """
+
+  base: Any  # jax.Array or tracer
+  shape: tuple[int, ...]
+  strides: tuple[int, ...]
+  block_shape: tuple[int, ...]
+  padding: str = "zero"
+  round_f32_to_tf32: bool = False
+
+  def __post_init__(self):
+    rank = len(self.shape)
+    if rank < 1 or rank > 5:
+      raise ValueError(f"TensorDescriptor rank must be in [1, 5], got {rank}")
+    if len(self.strides) != rank:
+      raise ValueError(
+          f"strides length ({len(self.strides)}) != shape length ({rank})"
+      )
+    if len(self.block_shape) != rank:
+      raise ValueError(
+          f"block_shape length ({len(self.block_shape)}) != shape length ({rank})"
+      )
+    if self.strides[-1] != 1:
+      raise ValueError(
+          f"Minormost stride must be 1, got {self.strides[-1]}"
+      )
+    if self.padding not in ("zero", "nan"):
+      raise ValueError(f"padding must be 'zero' or 'nan', got {self.padding!r}")
+
+  @property
+  def rank(self) -> int:
+    return len(self.shape)
+
+  @property
+  def dtype(self):
+    """Return the numpy dtype of the base array."""
+    return np.dtype(self.base.dtype)
+
+
+@dataclasses.dataclass(frozen=True)
+class _TensorDescriptorMetadata:
+  """Hashable descriptor metadata carried as a primitive static parameter."""
+
+  dtype: np.dtype
+  shape: tuple[int, ...]
+  strides: tuple[int, ...]
+  block_shape: tuple[int, ...]
+  padding: str
+  round_f32_to_tf32: bool
+
+  @classmethod
+  def from_descriptor(
+      cls, desc: TensorDescriptor
+  ) -> "_TensorDescriptorMetadata":
+    return cls(
+        dtype=desc.dtype,
+        shape=tuple(int(s) for s in desc.shape),
+        strides=tuple(int(s) for s in desc.strides),
+        block_shape=tuple(int(b) for b in desc.block_shape),
+        padding=desc.padding,
+        round_f32_to_tf32=desc.round_f32_to_tf32,
+    )
+
+  @property
+  def rank(self) -> int:
+    return len(self.shape)
+
+
 def normalize_grid(grid: GridOrLambda, metaparams) -> tuple[int, int, int]:
   if callable(grid):
     grid = grid(metaparams)
@@ -154,6 +227,17 @@ def to_python_type(arg: Any) -> Any:
   # else return as-is and let it possibly, but not necessarily, fail (constexprs and
   # strings pass through, and the rest isn't expected here, so saving cycles on that)
   return arg
+
+
+def _tensordesc_signature_string(desc: _TensorDescriptorMetadata) -> str:
+  """Generate a Triton-compatible ``tensordesc<dtype[block_shape]>`` string."""
+  dtype_str = _JAX_TO_TRITON_TYPE_MAP[desc.dtype]
+  block_str = ",".join(str(b) for b in desc.block_shape)
+  return f"tensordesc<{dtype_str}[{block_str}]>"
+
+
+def _is_tensordesc_signature(dtype: str) -> bool:
+  return dtype.startswith("tensordesc<")
 
 
 triton_kernel_call_p = jex.core.Primitive("triton_kernel_call")
@@ -228,6 +312,9 @@ class CompilationResult:
   shared_mem_bytes: int
   ttgir: str | None
   llir: str | None
+  global_scratch_size: int = 0
+  global_scratch_align: int = 0
+  tensordesc_meta: list[dict] | None = None
 
 
 def compile_ttir_inplace(
@@ -306,14 +393,20 @@ def compile_ttir_to_ptx_inplace(
   if cuda_options.debug:
     print(ptx)
   name = metadata["name"]
-  ttgir = str(ttgir) if _JAX_TRITON_DUMP_DIR else None
-  llir = str(llir) if _JAX_TRITON_DUMP_DIR else None
+  global_scratch_size = metadata.get("global_scratch_size", 0) or 0
+  global_scratch_align = metadata.get("global_scratch_align", 0) or 0
+  tensordesc_meta = metadata.get("tensordesc_meta", None)
+  ttgir_str = str(ttgir) if _JAX_TRITON_DUMP_DIR else None
+  llir_str = str(llir) if _JAX_TRITON_DUMP_DIR else None
   return CompilationResult(
       binary=ptx,
       name=name,
       shared_mem_bytes=shared_mem_bytes,
-      ttgir=ttgir,
-      llir=llir,
+      ttgir=ttgir_str,
+      llir=llir_str,
+      global_scratch_size=global_scratch_size,
+      global_scratch_align=global_scratch_align,
+      tensordesc_meta=tensordesc_meta,
   )
 
 
@@ -478,7 +571,7 @@ class JTJITFunction:
     enable_fp_fusion,
     metaparams,
     dump: bool,
-  ) -> tuple[triton_kernel_call_lib.TritonKernel, Any]:
+  ) -> tuple[triton_kernel_call_lib.TritonKernel, Any, int, list[dict] | None]:
     fn = self.fn
     if num_warps is None:
       num_warps = 4
@@ -500,7 +593,9 @@ class JTJITFunction:
     is_const = False
     do_specialize = True
     specialization = [
-      specialize_impl(
+      (arg_dtype, "")
+      if _is_tensordesc_signature(arg_dtype)
+      else specialize_impl(
         backend,
         types.SimpleNamespace(
           data_ptr=lambda: alignment, dtype=arg_dtype.removeprefix("*")
@@ -613,11 +708,23 @@ class JTJITFunction:
         compilation_result.binary,
         ttir,
         compute_capability,
+        global_scratch_size=compilation_result.global_scratch_size,
+        global_scratch_align=compilation_result.global_scratch_align,
       )
 
-      self.fn._jT_kernel_cache[cache_key] = kernel
+      self.fn._jT_kernel_cache[cache_key] = (
+        kernel,
+        compilation_result.global_scratch_size,
+        compilation_result.tensordesc_meta,
+      )
 
-    return kernel, attrs
+    cached = self.fn._jT_kernel_cache[cache_key]
+    if isinstance(cached, tuple):
+      kernel, scratch_size, tensordesc_meta = cached
+    else:
+      kernel, scratch_size, tensordesc_meta = cached, 0, None
+
+    return kernel, attrs, scratch_size, tensordesc_meta
 
 
 def make_autotuner_configs(
@@ -686,6 +793,7 @@ def triton_kernel_call_lowering(
     *array_args,
     fn,
     scalar_args,
+    descriptor_args=(),
     name,
     out_shapes,
     grid,
@@ -705,12 +813,19 @@ def triton_kernel_call_lowering(
   assert isinstance(metaparams, tuple), "metaparams must be tuple[tuple[str, Any], ...]"
   metaparams = dict(metaparams)  # will crash if tuple format is incompatible
 
+  descriptor_args_dict = dict(descriptor_args)
+  has_tma = bool(descriptor_args_dict)
+
   kernel_call_name = name
   args = list(ctx.avals_in)
   arg_dtypes = list(map(get_type_id, ctx.avals_in))
   for idx, dtype, v in scalar_args:
     args.insert(idx, v)
     arg_dtypes.insert(idx, dtype)
+
+  # Override dtype strings for descriptor positions with tensordesc<...> format.
+  for orig_idx, desc in descriptor_args_dict.items():
+    arg_dtypes[orig_idx] = _tensordesc_signature_string(desc)
   # Extract only the output avals not referenced in the input_output_aliases mapping.
   assert isinstance(input_output_aliases, tuple), "input_output_aliases must be a tuple"
   input_output_aliases = dict(input_output_aliases)
@@ -782,25 +897,61 @@ def triton_kernel_call_lowering(
   jtfu = JTJITFunction(fn)
   kernel_calls = []
   for params in config_params:
-    kernel, specialization_attr = jtfu.get_or_create_triton_kernel(
-      make_gpu_target_func,
-      ctx.module_context.platforms[0],
-      arg_dtypes,
-      scalar_args,
-      num_warps=params["num_warps"],
-      num_stages=params["num_stages"],
-      num_ctas=params["num_ctas"],
-      compute_capability=compute_capability,
-      enable_fp_fusion=enable_fp_fusion,
-      metaparams=dict(params["metaparams"]),
-      dump=debug,
+    kernel, specialization_attr, scratch_size, tensordesc_meta = (
+      jtfu.get_or_create_triton_kernel(
+        make_gpu_target_func,
+        ctx.module_context.platforms[0],
+        arg_dtypes,
+        scalar_args,
+        num_warps=params["num_warps"],
+        num_stages=params["num_stages"],
+        num_ctas=params["num_ctas"],
+        compute_capability=compute_capability,
+        enable_fp_fusion=enable_fp_fusion,
+        metaparams=dict(params["metaparams"]),
+        dump=debug,
+      )
     )
+
+    if scratch_size > 0:
+      has_tma = True
 
     kernel_params = []
     zeroed_params_with_sizes = dict(params["zeroed_params_with_sizes"])
     equal_to_1 = {i for i, _, v in scalar_args if v == 1}
+    desc_meta_iter = iter(tensordesc_meta) if tensordesc_meta else iter([])
     for i, (arg, dtype) in enumerate(zip(args, arg_dtypes)):
-      if isinstance(arg, core.ShapedArray):
+      if i in descriptor_args_dict:
+        desc = descriptor_args_dict[i]
+        meta = next(desc_meta_iter, {})
+        dtype_str = _JAX_TO_TRITON_TYPE_MAP[desc.dtype]
+        kernel_params.append(
+            triton_kernel_call_lib.create_tensor_descriptor_parameter(
+                desc.rank,
+                dtype_str,
+                list(desc.shape),
+                list(desc.strides),
+                list(desc.block_shape),
+                desc.padding == "nan",
+                desc.round_f32_to_tf32,
+                int(meta.get("swizzle", 0)),
+                int(meta.get("elem_size", 0)),
+                int(meta.get("elem_type", 0)),
+                [int(b) for b in meta.get("block_size", [])],
+                bool(meta.get("fp4_padded", False)),
+            )
+        )
+        # Triton's ABI: descriptor payload + rank shape scalars (i32) +
+        # rank stride scalars (i64).
+        for s in desc.shape:
+          kernel_params.append(
+              triton_kernel_call_lib.create_scalar_parameter(int(s), "i32")
+          )
+        for s in desc.strides:
+          kernel_params.append(
+              triton_kernel_call_lib.create_scalar_parameter(int(s), "i64")
+          )
+      elif isinstance(arg, core.ShapedArray):
         arg_attrs = specialization_attr[(i,)]
         kernel_params.append(
             triton_kernel_call_lib.create_array_parameter(
@@ -809,8 +960,6 @@ def triton_kernel_call_lowering(
             )
         )
       elif i not in equal_to_1:
-        # Convert TypedInt/TypedFloat subclasses to plain Python types,
-        # as nanobind's strict-mode integer caster rejects subclasses.
         if isinstance(arg, bool):
           arg = bool(arg)
         elif isinstance(arg, int):
@@ -849,6 +998,11 @@ def triton_kernel_call_lowering(
 
   # TODO(phawkins): remove forward_compat after 2026-05-04
   if jax.__version_info__ < (0, 10, 1) or ctx.is_forward_compat():
+    if has_tma:
+      raise NotImplementedError(
+          "TMA kernels are not supported in forward-compat mode or with "
+          "JAX < 0.10.1. Update JAX/jaxlib to use TMA features."
+      )
     rule = jax.ffi.ffi_lowering(
         "triton_kernel_call",
         api_version=2,
@@ -856,6 +1010,13 @@ def triton_kernel_call_lowering(
         operand_output_aliases=input_output_aliases,
     )
     return rule(ctx, *array_args)
+  elif has_tma:
+    rule = jax.ffi.ffi_lowering(
+        "triton_kernel_call_ffi_v2",
+        api_version=4,
+        operand_output_aliases=input_output_aliases,
+    )
+    return rule(ctx, *array_args, opaque=zlib.compress(call_proto))
   else:
     rule = jax.ffi.ffi_lowering(
         "triton_kernel_call_ffi",
@@ -1034,8 +1195,12 @@ def triton_call(
 
   array_args = []
   scalar_args = []
+  descriptor_args = {}  # original flat index -> _TensorDescriptorMetadata
   for i, arg in enumerate(flat_args):
-    if isinstance(arg, (bool, int, float)):
+    if isinstance(arg, TensorDescriptor):
+      descriptor_args[i] = _TensorDescriptorMetadata.from_descriptor(arg)
+      array_args.append(arg.base)
+    elif isinstance(arg, (bool, int, float)):
       scalar_args.append((i, get_type_id(arg), arg))
     elif isinstance(arg, np.float32):
       scalar_args.append((i, get_type_id(arg), float(arg)))
@@ -1049,6 +1214,7 @@ def triton_call(
       *array_args,
       fn=kernel,
       scalar_args=tuple(scalar_args),
+      descriptor_args=tuple(sorted(descriptor_args.items())),
       name=name,
       out_shapes=tuple(flat_out_shapes),
       grid=grid,


### PR DESCRIPTION
…er selection

- Add jax_triton.TensorDescriptor dataclass for host-side TMA with JAX-aware validation (rank, stride, block_shape constraints) and no torch dependency.
- Extend CompilationResult to capture global_scratch_size/align and tensordesc_meta from Triton compilation metadata.
- Pass scratch fields to TritonKernel constructor so the jaxlib runtime can allocate device-side scratch via ScratchAllocator.
- Detect TensorDescriptor args in triton_call, classify them as array operands (base pointer) plus descriptor metadata.
- In lowering, emit tensordesc<...> signature strings, build TensorDescriptor parameters with NV TMA metadata, and append Triton-ABI-compatible shape (i32) and stride (i64) scalar params.
- Select triton_kernel_call_ffi_v2 handler for TMA-using kernels; reject TMA in forward-compat mode with a clear error.
- Export TensorDescriptor from jax_triton package.