### PR TITLE
Refactor triton_call to use Triton binder and support kwargs/tuples

### DIFF
--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -22,17 +22,16 @@ import dataclasses
 import functools
 from functools import cached_property
 import inspect
+import itertools
 import os
 import pprint
 import tempfile
-import types
 from typing import Any, Protocol, Self, Union
 import zlib
 
 import jax
 from jax import tree_util
 from jax._src import core
-from jax._src import state
 from jax._src import util
 from jax._src.lib import gpu_triton as triton_kernel_call_lib
 import jax.extend as jex
@@ -46,10 +45,8 @@ import triton
 import triton._C.libtriton as _triton
 import triton.compiler.compiler as tc
 import triton.experimental.gluon._runtime as gl_runtime
-import triton.experimental.gluon.language as gl
-import triton.language as tl
 import triton.runtime.autotuner as autotuner
-
+import triton.runtime.jit as triton_runtime_jit
 
 try:
   import triton.backends.nvidia.compiler as cb
@@ -64,9 +61,23 @@ except ImportError:
 
 if "TRITON_CACHE_DIR" in os.environ:
   del os.environ["TRITON_CACHE_DIR"]
+
 _JAX_TRITON_DUMP_DIR = os.environ.get("JAX_TRITON_DUMP_DIR")
 map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip
+
+Grid = Union[int, tuple[int], tuple[int, int], tuple[int, int, int]]
+GridOrLambda = Union[Grid, Callable[[dict[str, Any]], Grid]]
+
+# A coordinate of an element in the kernel parameter coordinate space. The first int
+# indexes the kernel parameter by its declaration order in the signature; the following
+# ints (if any) index into nested tuples within the actual argument. This is therefore a
+# kernel-call attribute, since it depends on actual argument values, unlike kernel
+# parameters themselves.
+# Triton calls a coordinate a path, so we follow that convention.
+CanonicalKernelArgPath = tuple[int, ...]
+KernelArgPath = tuple[int | str, *tuple[int, ...]]
+InOutSpec = int | str | KernelArgPath | tuple[int | str | KernelArgPath, ...]
 
 # b/447434580: Exceeding this limit will cause Triton to emit a single trap
 # instruction, which will cause the GPU to hang indefinitely. See
@@ -93,9 +104,6 @@ _JAX_TO_TRITON_TYPE_MAP = {
     jnp.dtype("bool"): "i1",
 }
 
-Grid = Union[int, tuple[int], tuple[int, int], tuple[int, int, int]]
-GridOrLambda = Union[Grid, Callable[[dict[str, Any]], Grid]]
-
 
 def normalize_grid(grid: GridOrLambda, metaparams) -> tuple[int, int, int]:
   if callable(grid):
@@ -107,15 +115,30 @@ def normalize_grid(grid: GridOrLambda, metaparams) -> tuple[int, int, int]:
   return tuple(grid) + (1,) * (3 - len(grid))
 
 
-def avals_to_layouts(avals):
-  return [list(reversed(range(aval.ndim))) for aval in avals]
-
-
+# Type handling is slightly messy here. Triton uses exact dtypes for arrays, but for
+# scalars (whether constexpr or runtime) it accepts native Python objects only. The
+# actual type of a kernel parameter is determined solely from the parameter type
+# annotation. To feed the specialization engine correctly, we must typecast all scalars
+# to Python types. Caveats:
+# 1. We must not typecast constexprs, as they are a separate type that influences
+# specialization.
+# 2. Triton's runtime specialization for scalars unconditionally treats all floats as
+# fp32. It is unclear whether this is a bug — the relevant code does not even have a
+# string to describe fp64. Triton's kernel launcher likely does not support doubles,
+# but JAX's `create_scalar_parameter()` supports them perfectly well. However, Triton
+# still produces binaries that expect floats only, so there is no point in handling
+# this differently.
+#
+# Fortunately, both Triton and JAX use the same (likely LLVM/MLIR-based) type
+# identifiers, so the function below serves both goals: Triton's specialization and
+# JAX's launcher.
 def get_type_id(obj: Any) -> str:
-  if isinstance(obj, (jax.core.ShapedArray, state.AbstractRef)):
-    return f"*{_JAX_TO_TRITON_TYPE_MAP[obj.dtype]}"
-  if isinstance(obj, (tl.constexpr, gl.constexpr)):
-    obj = obj.value
+  """Returns a Triton/JAX type identifier for the given object. Intended for use with
+  runtime values only. Constexprs (strings are also constexprs in Triton) don't need
+  type info."""
+  if hasattr(obj, "dtype"):
+    return _JAX_TO_TRITON_TYPE_MAP[obj.dtype]
+
   if isinstance(obj, bool):  # True == isinstance(True, int) !!!
     return "B"
   if isinstance(obj, int):
@@ -130,14 +153,8 @@ def get_type_id(obj: Any) -> str:
     else:
       raise ValueError(f"integer overflow representing {obj}")
   if isinstance(obj, float):
-    return "fp64"
-  if isinstance(obj, np.float32):
-    return "fp32"
-  if isinstance(obj, str):
-    return "str"
-  raise NotImplementedError(
-      f"could not compute type name for {obj}: {type(obj)}"
-  )
+    return "fp32"  # Triton unconditionally treats all floats as fp32, see above
+  raise NotImplementedError(f"could not compute type name for {obj}: {type(obj)}")
 
 
 def to_python_type(arg: Any) -> Any:
@@ -154,6 +171,10 @@ def to_python_type(arg: Any) -> Any:
   # else return as-is and let it possibly, but not necessarily, fail (constexprs and
   # strings pass through, and the rest isn't expected here, so saving cycles on that)
   return arg
+
+
+def avals_to_layouts(avals):
+  return [list(reversed(range(aval.ndim))) for aval in avals]
 
 
 triton_kernel_call_p = jex.core.Primitive("triton_kernel_call")
@@ -182,10 +203,9 @@ def make_gpu_target_cuda(device, compute_capability):
 _IS_HIPBackend_PATCHED = False
 def _patch_hip_backend():
   """
-  This defuses a bomb planted into Triton's AMD-specific compilation path by
+  This fixes unconditional and totally unnecessary "import torch" in Triton's
+  AMD-specific compilation path added in
   https://github.com/triton-lang/triton/commit/37ff43c5efd6e1b84c00a599ba070a501181e832#diff-33c9a103282c05c9d9d213b94450ae7481b6db8c3c6d810f54f175b4735a3c72
-  In short: there's an unconditional and totally unnecessary "import torch" directive crashing
-  the code when torch isn't installed.
 
   Remove the patch once triton wheel package version is pinned to >= triton version with the fix.
   """
@@ -388,6 +408,12 @@ def make_backend(
   return backend, gpu_target, compute_capability
 
 
+_BACKEND_OPTIONS_FIELD_NAMES = {
+  "cuda": frozenset(cb.CUDAOptions.__dataclass_fields__.keys()),
+  "hip": frozenset(hb.HIPOptions.__dataclass_fields__.keys()),
+}
+
+
 # nb: the class name is purposely distinct from Triton's JITFunction to simplify writing
 # comments and docstrings, and make them unambiguous without additional context.
 class JTJITFunction:
@@ -460,128 +486,218 @@ class JTJITFunction:
   def signature(self) -> inspect.Signature:
     return self.fn.signature
 
+  def _get_cached_kernel(
+    self,
+    compute_capability: int,
+    specialization: list[tuple[str, Any]],
+    kwargs: dict[str, Any],
+  ) -> tuple[str, triton_kernel_call_lib.TritonKernel | None]:
+    if "_compute_capability" in kwargs:
+      raise ValueError("'_compute_capability' key is reserved in the options/kwargs!")
+    kwargs["_compute_capability"] = compute_capability
+
+    if not hasattr(self.fn, "_jT_kernel_cache_key"):
+      self.fn._jT_kernel_cache_key = {}
+
+    # `triton_runtime_jit.compute_cache_key()` walks through kernel dependencies and
+    # produces a hash with absolutely all kernel compilation dependencies accounted for.
+    key = triton_runtime_jit.compute_cache_key(
+      self.fn._jT_kernel_cache_key, specialization, kwargs
+    )
+    del kwargs["_compute_capability"]
+
+    if not hasattr(self.fn, "_jT_kernel_cache"):
+      self.fn._jT_kernel_cache = {}
+
+    return key, self.fn._jT_kernel_cache.get(key, None)
+
+  def _cache_kernel(
+    self,
+    key: str,
+    kernel: triton_kernel_call_lib.TritonKernel,
+    asm: dict | None = None,
+  ):
+    assert isinstance(self.fn._jT_kernel_cache, dict)
+    self.fn._jT_kernel_cache[key] = kernel
+    if asm is not None:
+      if not hasattr(self.fn, "_jT_asm"):
+        self.fn._jT_asm = {}
+      self.fn._jT_asm[key] = asm
+
+  @property
+  def asm(self) -> dict[str, dict] | None:
+    """Returns a dictionary of assembly files for the kernel, if they were saved during
+    compilation."""
+    return self.fn._jT_asm if hasattr(self.fn, "_jT_asm") else None
+
   @property
   def compiled_kernels_cache_size(self) -> int:
     return len(self.fn._jT_kernel_cache) if hasattr(self.fn, "_jT_kernel_cache") else 0
 
+  def _make_signature_constexprs(
+    self,
+    named_args: dict[str, Any],
+    sigvals: list[str],
+  ) -> tuple[dict[str, Any], dict[str, Any]]:
+    signature = dict(zip(self.arg_names, sigvals))
+
+    constexprs = triton_runtime_jit.find_paths_if(
+      sigvals, lambda _, val: val == "constexpr"
+    )
+    constexprs = {
+      path: triton_runtime_jit.get_iterable_path(list(named_args.values()), path)
+      for path in constexprs
+    }
+    return signature, constexprs
+
+  @staticmethod
+  def _make_attrs_nonconstexprs_sigvals(
+    backend, specialization: list[tuple[str, Any]], named_args: dict[str, Any]
+  ) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    # We must always build attributes, as they are needed to launch the kernel
+    attrvals = [x[1] for x in specialization]
+    attrs = triton_runtime_jit.find_paths_if(attrvals, lambda _, x: isinstance(x, str))
+    attrs = {
+      k: backend.parse_attr(triton_runtime_jit.get_iterable_path(attrvals, k))
+      for k in attrs
+    }
+    # attrs keys are tuples of integers representing a path into the (possibly nested)
+    # kernel argument list as seen by the Triton compiler (i.e. including all
+    # constexprs and whatnot — everything as declared in the signature)
+
+    sigvals = [x[0] for x in specialization]
+    non_constexprs = triton_runtime_jit.find_paths_if(
+      sigvals, lambda _, val: val != "constexpr"
+    )
+    non_constexprs = {
+      path: triton_runtime_jit.get_iterable_path(list(named_args.values()), path)
+      for path in non_constexprs
+    }
+    return attrs, non_constexprs, sigvals
+
+  def _get_binder(
+    self, backend
+  ) -> Callable[
+    [Any, ..., Any], tuple[dict[str, Any], list[tuple[str, Any]], dict[str, Any]]
+  ]:
+    if not hasattr(self.fn, "_jT_binder"):
+      self.fn._jT_binder = {}
+
+    # In the upstream, a binder is per-`torch._C._cuda_getDevice()`. Here the closest
+    # equivalent for this should be backend.hash() which is generally a GPU arch string.
+    backend_hash = backend.hash()
+    binder = self.fn._jT_binder.get(backend_hash, None)
+    if binder is None:
+      # create_function_from_signature() is a clever optimization in Triton that makes
+      # a so-called binder function for the kernel, which simultaneously:
+      # 1. assigns default values to all unspecified kernel arguments,
+      # 2. assembles a complete dict of parameter_name->value mapping for all arguments,
+      # 3. runs the correct specialization pipeline for all arguments, respecting all
+      #   user annotations,
+      # 4. finds key-value pairs in kwargs that don't match any kernel signature param.
+      self.fn._jT_binder[backend_hash] = binder = (
+        triton_runtime_jit.create_function_from_signature(
+          self.fn.signature, self.fn.params, backend
+        )
+      )
+    return binder
+
   def get_or_create_triton_kernel(
     self,
     make_gpu_target_func,
-    platform,
-    arg_dtypes,
-    scalar_args,
+    platform: str,
+    args: list[Any],
     *,
-    num_warps,
-    num_stages,
-    num_ctas,
-    compute_capability,
-    enable_fp_fusion,
-    metaparams,
-    dump: bool,
-  ) -> tuple[triton_kernel_call_lib.TritonKernel, Any]:
-    fn = self.fn
-    if num_warps is None:
-      num_warps = 4
-    if num_stages is None:
-      num_stages = 3
+    compute_capability: int | None,
+    kwargs: dict[str, Any],
+  ) -> tuple[triton_kernel_call_lib.TritonKernel, dict[str, Any], dict[str, Any]]:
+    num_warps = kwargs["num_warps"]
+    num_ctas = kwargs["num_ctas"]
+    assert all(
+      isinstance(v, int) for v in (num_warps, kwargs["num_stages"], num_ctas)
+    )  # internal sanity check
+
+    store_asm = False
+    if "_store_asm" in kwargs:
+      store_asm = kwargs["_store_asm"]
+      del kwargs["_store_asm"]  # this is JT internal, no need to leave it further
 
     backend, gpu_target, compute_capability = make_backend(
       make_gpu_target_func, compute_capability, num_ctas
     )
 
-    signature = {self.arg_names[i]: v for i, v in enumerate(arg_dtypes)}
-    # TODO(sharadmv,zhangqiaorjc): handle differently aligned pointers
-    # We assume that all arrays are aligned to 16 bytes, and Triton may use this
-    # assumption, unless array args are include in the `do_not_specialize` list.
-    alignments = [16] * len(arg_dtypes)
-    for i, _, _ in scalar_args:
-      alignments[i] = 0
-    specialize_impl = _triton.native_specialize_impl
-    is_const = False
-    do_specialize = True
-    specialization = [
-      specialize_impl(
-        backend,
-        types.SimpleNamespace(
-          data_ptr=lambda: alignment, dtype=arg_dtype.removeprefix("*")
-        ),
-        is_const,
-        do_specialize,
-        alignment > 0,
-      )
-      for arg_dtype, alignment in zip(arg_dtypes, alignments)
-    ]
-    attrs = {
-      (i,): backend.parse_attr(attr) for i, (_, attr) in enumerate(specialization)
-    }
-    constants = dict(metaparams)
-    constants.update({k: None for _, k, v in scalar_args if v is None})
-    constants.update({self.arg_names[i]: 1 for i, _, v in scalar_args if v == 1})
-    for constant in constants:
-      signature[constant] = "constexpr"
-
-    # Cache key should contain any parameter that can affect the compiler output.
-    cache_key = (
-      fn,
-      tuple(signature.items()),
-      tuple(specialization),
-      tuple(constants.items()),
-      num_warps,
-      num_stages,
-      num_ctas,
-      compute_capability,
-      enable_fp_fusion,
+    named_args, specialization, other_kwargs = self._get_binder(backend)(
+      *args, **kwargs
     )
-    if not hasattr(self.fn, "_jT_kernel_cache"):
-      self.fn._jT_kernel_cache = {}  # TODO(cjfj): Convert to LRU cache?
-    kernel = self.fn._jT_kernel_cache.get(cache_key)
+    # named_args is a complete dict of kernel param names -> actual values.
+    # other_kwargs is kwargs with keys matching kernel parameters removed.
+    # specialization is a list[tuple[str, Any]], one entry per kernel parameter, that
+    # captures two things about each argument at call time: data type reflection, and
+    # specialization value (an attribute that may trigger a separately compiled kernel
+    # variant). Specialization serves 3 goals: (1) it affects the kernel caching key,
+    # (2) discover additional vars to be turned into constexprs by the compiler,
+    # (3) is a source for the `attrs` spec.
+
+    attrs, non_constexprs, sigvals = self._make_attrs_nonconstexprs_sigvals(
+      backend, specialization, named_args
+    )
+
+    key, kernel = self._get_cached_kernel(
+      compute_capability, specialization, other_kwargs
+    )
 
     if kernel is None:
       # First, check that the kernel signature and the reconstructed signature have the
       # same number of parameters. A mismatch can occur due to differences in
       # `triton_call(input_output_aliases=)` handling between jax-triton versions.
-      if len(self.signature.parameters) != len(signature):
+      if len(self.params) != len(named_args):
         raise TypeError(
-          f"Number of parameters in the kernel '{fn}' signature "
-          f"({len(self.signature.parameters)}: {self.signature}) "
-          f"does not match reconstructed signature ({len(signature)}: {signature}). "
+          f"Number of parameters in the kernel '{self.fn}' signature "
+          f"({len(self.params)}: {self.signature}) "
+          f"does not match reconstructed signature ({len(named_args)}: {list(named_args.keys())}). "
           "If the kernel was working on an older version of jax-triton and its "
           "triton_call() launcher uses `input_output_aliases` argument, note that "
           "implicit output arguments are no longer required for aliased arguments."
         )
 
-      opts = {
-        "num_warps": num_warps,
-        "num_stages": num_stages,
-        "num_ctas": num_ctas,
-        "optimize_epilogue": False,
-        "debug": dump,
-        "enable_fp_fusion": enable_fp_fusion,
-      }
+      signature, constexprs = self._make_signature_constexprs(named_args, sigvals)
 
-      options = backend.parse_options(opts)
+      backend_fields = _BACKEND_OPTIONS_FIELD_NAMES[gpu_target.backend]
+      unrecognized = kwargs.keys() - named_args.keys() - backend_fields
+      if len(unrecognized) > 0:
+        raise ValueError(
+          f"Unknown backend options: '{ {k: kwargs[k] for k in unrecognized} }' "
+          f"were found in kwargs! Known options are: {backend_fields}."
+        )
 
-      kernel_hash = abs(hash(cache_key))
+      backend_options = backend.parse_options(kwargs)
+
       if _JAX_TRITON_DUMP_DIR:
+        kernel_hash = abs(hash(key))
         os.makedirs(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}")
         with open(f"{_JAX_TRITON_DUMP_DIR}/{kernel_hash}/config", "w") as f:
-          pprint.pprint(cache_key, stream=f)
-          pprint.pprint(options, stream=f)
+          pprint.pprint(key, stream=f)
+          pprint.pprint(backend_options, stream=f)
 
       context = _triton.ir.context()
       _triton.ir.load_dialects(context)
       backend.load_dialects(context)
-      codegen_fns = backend.get_codegen_implementation(options)
+      codegen_fns = backend.get_codegen_implementation(backend_options)
 
       real_ASTSource = gl_runtime.GluonASTSource if self.is_gluon else tc.ASTSource
       module = real_ASTSource(
-        fn, constexprs=constants, signature=signature, attrs=attrs
-      ).make_ir(gpu_target, options, codegen_fns, backend.get_module_map(), context)
+        self.fn, constexprs=constexprs, signature=signature, attrs=attrs
+      ).make_ir(
+        gpu_target, backend_options, codegen_fns, backend.get_module_map(), context
+      )
 
       ttir = str(module)
 
+      # triton_kernel_call_lib.TritonKernel() stores ttir internally, but does not
+      # expose access to it, so we store it manually elsewhere for testing purposes.
+
       compilation_result = compile_ttir_inplace(
-        module, backend, options, compute_capability, platform
+        module, backend, backend_options, compute_capability, platform
       )
 
       kernel_name = compilation_result.name
@@ -601,8 +717,7 @@ class JTJITFunction:
           "w",
         ) as f:
           f.write(
-            f"{kernel_name}: shared_mem_bytes:"
-            f" {compilation_result.shared_mem_bytes}\n"
+            f"{kernel_name}: shared_mem_bytes: {compilation_result.shared_mem_bytes}\n"
           )
 
       kernel = triton_kernel_call_lib.TritonKernel(
@@ -615,9 +730,10 @@ class JTJITFunction:
         compute_capability,
       )
 
-      self.fn._jT_kernel_cache[cache_key] = kernel
+      asm = dict(ttir=ttir) if store_asm else None
+      self._cache_kernel(key, kernel, asm)
 
-    return kernel, attrs
+    return kernel, attrs, non_constexprs
 
 
 def make_autotuner_configs(
@@ -680,87 +796,39 @@ def apply_heuristics(
   return updated_configs
 
 
-def triton_kernel_call_lowering(
-    make_gpu_target_func,
-    ctx,
-    *array_args,
-    fn,
-    scalar_args,
-    name,
-    out_shapes,
-    grid,
-    num_warps,
-    num_stages,
-    num_ctas,
-    compute_capability,
-    enable_fp_fusion,
-    input_output_aliases,
-    zeroed_outputs,
-    debug,
-    serialized_metadata,
-    metaparams: tuple[tuple[str, Any], ...],
-):
-  # Metaparams must be a tuple to support the hashing required for
-  # lowering via xla_primitive_callable().
-  assert isinstance(metaparams, tuple), "metaparams must be tuple[tuple[str, Any], ...]"
-  metaparams = dict(metaparams)  # will crash if tuple format is incompatible
-
-  kernel_call_name = name
-  args = list(ctx.avals_in)
-  arg_dtypes = list(map(get_type_id, ctx.avals_in))
-  for idx, dtype, v in scalar_args:
-    args.insert(idx, v)
-    arg_dtypes.insert(idx, dtype)
-  # Extract only the output avals not referenced in the input_output_aliases mapping.
-  assert isinstance(input_output_aliases, tuple), "input_output_aliases must be a tuple"
-  input_output_aliases = dict(input_output_aliases)
-  strictly_out_avals = [
-    aval
-    for i, aval in enumerate(ctx.avals_out)
-    if i not in input_output_aliases.values()
-  ]
-  args.extend(strictly_out_avals)
-  arg_dtypes.extend(map(get_type_id, strictly_out_avals))
-
-  named_args = dict(unsafe_zip(fn.arg_names, args))
-
-  if isinstance(fn, autotuner.Autotuner):
-    configs = make_autotuner_configs(fn, metaparams, named_args)
-    fn = fn.fn
-  else:
-    config = triton.Config(
-      {},
-      num_warps=num_warps,
-      num_stages=num_stages,
-      num_ctas=num_ctas,
-    )
-    configs = [config]
-
-  if isinstance(fn, autotuner.Heuristics):
-    configs = apply_heuristics(fn, configs, metaparams, named_args)
-    fn = fn.fn
-
-  if not isinstance(fn, (triton.JITFunction, gl_runtime.GluonJITFunction)):
-    raise ValueError(
-        "`kernel` must be a Triton `JITFunction`, `GluonJITFunction`, `Heuristics` or `Autotuner`."
-    )
-
-  output2input = {v: k for k, v in input_output_aliases.items()}
-  if len(output2input) != len(input_output_aliases):
-    raise ValueError("input_output_aliases must be a bijection")
-
-  outputs_offset = len(ctx.avals_in) + len(scalar_args)
-  config_params = []
+def make_kernel_params(
+  ctx,
+  outputs_offset: int,
+  kwargs: dict[str, Any],
+  grid,
+  zeroed_outputs,
+  configs: list[triton.Config],
+  operand_output_aliases: dict[int, int],
+) -> list[dict[str, Any]]:
+  """Make kernel call parameters for each config."""
+  kernel_params = []
   for config in configs:
-    config_metaparams = {**metaparams, **config.kwargs}
+    # propagating backend-related config params
+    config_metaparams = {
+      **kwargs,
+      **config.kwargs,
+      "num_warps": config.num_warps,
+      "num_stages": config.num_stages,
+      "num_ctas": config.num_ctas,
+      "maxnreg": config.maxnreg,
+    }
+    if config.maxnreg is None:
+      del config_metaparams["maxnreg"]
+
     config_grid = normalize_grid(grid, config_metaparams)
 
-    config_zeroed_outputs = zeroed_outputs
-    if callable(zeroed_outputs):
-      config_zeroed_outputs = config_zeroed_outputs(config_metaparams)
+    config_zeroed_outputs = (
+      zeroed_outputs(config_metaparams) if callable(zeroed_outputs) else zeroed_outputs
+    )
 
     # zeroed_params_with_sizes is a dict output_arg_idx -> aval_size_bytes
     # config_zeroed_outputs contains output ordinal indices
+    output2input = {v: k for k, v in operand_output_aliases.items()}
     zeroed_params_with_sizes = {
       output2input[i] if i in output2input else i + outputs_offset: aval_size_bytes(
         ctx.avals_out[i]
@@ -768,58 +836,212 @@ def triton_kernel_call_lowering(
       for i in sorted(config_zeroed_outputs)
     }
 
-    config_params.append(
-        dict(
-            metaparams=tuple(sorted(config_metaparams.items())),
-            num_warps=config.num_warps,
-            num_stages=config.num_stages,
-            num_ctas=config.num_ctas,
-            grid=config_grid,
-            zeroed_params_with_sizes=tuple(zeroed_params_with_sizes.items()),
-        )
+    kernel_params.append(
+      dict(
+        metaparams=config_metaparams,
+        grid=config_grid,
+        zeroed_params_with_sizes=zeroed_params_with_sizes,
+      )
     )
+  return kernel_params
+
+
+def convert_zeroed_outputs(
+  jtfu: JTJITFunction,
+  kwargs: dict[str, Any],
+  zeroed_outputs: Sequence[InOutSpec] | Callable[[dict[str, Any]], Sequence[InOutSpec]],
+) -> tuple[int, ...]:
+  idx2name = jtfu.arg_names
+  assert zeroed_outputs
+
+  def _unwrap_compound(arg: Any) -> tuple[int, ...]:
+    if not isinstance(arg, tuple):
+      raise ValueError(
+        f"Element of zeroed_outputs must reference an array or a tuple of arrays. Found {arg} of type {type(arg)}"
+      )
+    flat, _ = tree_util.tree_flatten(arg)
+    assert all(isinstance(elm, JTArray) for elm in flat), (
+      "All elements of a compound must be arrays"
+    )
+    return tuple(elm.index for elm in flat)
+
+  def _unwrap(elm) -> tuple[int, ...]:
+    """For a single element of zeroed_outputs returns raw indices of all output arrays
+    it corresponds to"""
+    is_int = isinstance(elm, int)
+    if isinstance(elm, (int, str)):
+      arg_name = idx2name[elm] if is_int else elm
+      arg = kwargs[arg_name]
+      # we could perhaps have a check for it being output argument too by modifying JTArray
+      if isinstance(arg, JTArray):
+        return (arg.index,)
+      return _unwrap_compound(arg)
+    elif isinstance(elm, (tuple, list)):
+      if not elm:
+        raise ValueError("Empty tuple or list is not a valid element of zeroed_outputs")
+      top_elm = elm[0]
+      if not isinstance(top_elm, (int, str)):
+        raise ValueError(
+          "First element of a tuple or list in zeroed_outputs must be an int or a str"
+        )
+      arg_name = idx2name[top_elm] if isinstance(top_elm, int) else top_elm
+      arg = (
+        kwargs[arg_name]
+        if len(elm) == 1
+        else triton_runtime_jit.get_iterable_path(kwargs[arg_name], elm[1:])
+      )
+      if isinstance(arg, JTArray):
+        return (arg.index,)
+      return _unwrap_compound(arg)
+    else:
+      raise ValueError(f"Invalid element of zeroed_outputs: {elm}")
+
+  if callable(zeroed_outputs):
+    orig_zeroed = zeroed_outputs
+    zeroed_outputs = lambda kw: tuple(
+      itertools.chain.from_iterable(map(_unwrap, orig_zeroed(kw)))
+    )
+  else:
+    zeroed_outputs = tuple(itertools.chain.from_iterable(map(_unwrap, zeroed_outputs)))
+
+  return zeroed_outputs
+
+
+def add_output_args(
+  jtfu: JTJITFunction,
+  ctx,
+  out_info: tuple[int, tree_util.PyTreeDef],
+  args: list[Any],
+  kwargs: dict[str, Any],
+) -> dict[str, Any]:
+  """Add output arguments to the argument list/dictionary."""
+  num_pure_outputs, pure_out_tree = out_info
+  assert num_pure_outputs <= len(ctx.avals_out)
+
+  outputs = tree_util.tree_unflatten(
+    pure_out_tree,
+    (JTArray.from_avals_by_idx(ctx.avals_out, i) for i in range(num_pure_outputs)),
+  )
+  # outputs is a dict mapping out-spec->possibly nested structure of 1 or many JTArrays
+
+  idx2name = jtfu.arg_names
+  for out_spec, arrays in outputs.items():
+    assert isinstance(out_spec, tuple)
+    top_idx = out_spec[0]
+    assert isinstance(top_idx, int)
+    arg_name = idx2name[top_idx]
+    if top_idx < len(args):
+      raise ValueError(f"Output argument idx {top_idx}=>{arg_name} mustn't be in args")
+    if len(out_spec) == 1:
+      if arg_name in kwargs:
+        raise ValueError(f"Output argument {arg_name} mustn't be in kwargs")
+      kwargs[arg_name] = arrays
+    else:
+      # So this is a path into a compound, and this is a bit tricky, as we could only
+      # expect tuples as compounds and tuples are immutable. We'd have to rebuild the
+      # whole nested tuple structure to modify just a single element. For similar
+      # purposes (see triton._utils.set_iterable_path()) Triton uses
+      # triton.language.core.tuple class which is a list under the hood.
+      raise ValueError(
+        f"Output argument spec for {arg_name} is a nested {out_spec} and we don't currently support that"
+      )
+  return kwargs
+
+
+def triton_kernel_call_lowering(
+  make_gpu_target_func,
+  ctx,
+  *abstract_args,
+  fn,
+  kernel_call_name,
+  out_shapes,
+  grid,
+  compute_capability,
+  operand_output_aliases,
+  zeroed_outputs,
+  serialized_metadata,
+  args_kwargs,
+  out_info,
+):
+  operand_output_aliases = dict[int, int](operand_output_aliases)
 
   jtfu = JTJITFunction(fn)
+
+  args, kwargs, nonabstracted = deserialize_args_kwargs(ctx, abstract_args, args_kwargs)
+
+  # extending with outputs
+  kwargs = add_output_args(jtfu, ctx, out_info, args, kwargs)
+  if zeroed_outputs:
+    zeroed_outputs = convert_zeroed_outputs(jtfu, kwargs, zeroed_outputs)
+
+  if not isinstance(fn, (triton.JITFunction, gl_runtime.GluonJITFunction)):
+    # Note: `fn.arg_names` below is not `JITFunction::arg_names`: Autotuner and
+    # Heuristics classes have their own field and it is NOT deprecated.
+    named_args = dict(unsafe_zip(fn.arg_names, args))
+    # named_args are needed only for Autotuner/Heuristics handling.
+    # Note that named_args is built from positional args only.
+    # This is consistent with how the upstream handles it in Autotuner/Heuristics.
+    # These are name-value pairs for positional arguments only, not `bound_args`
+    # constructed from the kernel's signature.
+
+  if isinstance(fn, autotuner.Autotuner):
+    # Autotuner must be unpacked before Heuristics to ensure we reach the actual
+    # kernel `fn`.
+    configs = make_autotuner_configs(fn, kwargs, named_args)
+    fn = fn.fn
+  else:
+    ttcfg_args = dict(
+      num_warps=kwargs["num_warps"],
+      num_stages=kwargs["num_stages"],
+      num_ctas=kwargs["num_ctas"],
+    )
+    if "maxnreg" in kwargs:
+      ttcfg_args["maxnreg"] = kwargs["maxnreg"]
+    configs = [triton.Config({}, **ttcfg_args)]
+
+  if isinstance(fn, autotuner.Heuristics):
+    configs = apply_heuristics(fn, configs, kwargs, named_args)
+    fn = fn.fn
+
+  kernel_params = make_kernel_params(
+    ctx,
+    len(abstract_args),
+    kwargs,
+    grid,
+    zeroed_outputs,
+    configs,
+    operand_output_aliases,
+  )
+
   kernel_calls = []
-  for params in config_params:
-    kernel, specialization_attr = jtfu.get_or_create_triton_kernel(
+  for params in kernel_params:
+    kernel, specialization_attr, non_constexprs = jtfu.get_or_create_triton_kernel(
       make_gpu_target_func,
       ctx.module_context.platforms[0],
-      arg_dtypes,
-      scalar_args,
-      num_warps=params["num_warps"],
-      num_stages=params["num_stages"],
-      num_ctas=params["num_ctas"],
+      args,
       compute_capability=compute_capability,
-      enable_fp_fusion=enable_fp_fusion,
-      metaparams=dict(params["metaparams"]),
-      dump=debug,
+      kwargs=params["metaparams"],
     )
 
-    kernel_params = []
-    zeroed_params_with_sizes = dict(params["zeroed_params_with_sizes"])
-    equal_to_1 = {i for i, _, v in scalar_args if v == 1}
-    for i, (arg, dtype) in enumerate(zip(args, arg_dtypes)):
-      if isinstance(arg, core.ShapedArray):
-        arg_attrs = specialization_attr[(i,)]
-        kernel_params.append(
-            triton_kernel_call_lib.create_array_parameter(
-                zeroed_params_with_sizes.get(i, 0),
-                16 if (["tt.divisibility", 16] in arg_attrs) else 0,
-            )
+    call_params = []
+    zeroed_params_with_sizes = params["zeroed_params_with_sizes"]
+    array_idx = 0
+
+    for path, arg in non_constexprs.items():
+      if isinstance(arg, JTArray):
+        arg_attrs = specialization_attr[path]
+        call_params.append(
+          triton_kernel_call_lib.create_array_parameter(
+            zeroed_params_with_sizes.get(array_idx, 0),
+            16 if (["tt.divisibility", 16] in arg_attrs) else 0,
+            # TODO shouldn't we take "tt.divisibility" attr value instead from arg_attrs
+            # if it's there?
+          )
         )
-      elif i not in equal_to_1:
-        # Convert TypedInt/TypedFloat subclasses to plain Python types,
-        # as nanobind's strict-mode integer caster rejects subclasses.
-        if isinstance(arg, bool):
-          arg = bool(arg)
-        elif isinstance(arg, int):
-          arg = int(arg)
-        elif isinstance(arg, float):
-          arg = float(arg)
-        kernel_params.append(
-            triton_kernel_call_lib.create_scalar_parameter(arg, dtype)
-        )
+        array_idx += 1
+      else:
+        dtype = get_type_id(arg)
+        call_params.append(triton_kernel_call_lib.create_scalar_parameter(arg, dtype))
 
     kernel_calls.append(
         triton_kernel_call_lib.TritonKernelCall(
@@ -827,18 +1049,17 @@ def triton_kernel_call_lowering(
             params["grid"][0],
             params["grid"][1],
             params["grid"][2],
-            kernel_params,
+            call_params,
         )
     )
 
   if len(kernel_calls) > 1:
-    named_scalar_args = {fn.arg_names[i]: v for i, _, v in scalar_args}
     input_output_aliases_with_sizes = tuple(
         (input_idx, output_idx, aval_size_bytes(ctx.avals_in[input_idx]))
-        for input_idx, output_idx in input_output_aliases.items()
+        for input_idx, output_idx in operand_output_aliases.items()
     )
     kernel_call = triton_kernel_call_lib.TritonAutotunedKernelCall(
-        f"{kernel_call_name} ({fn.fn.__name__}) {named_scalar_args}",
+        f"{kernel_call_name} ({fn.fn.__name__}) {nonabstracted}",
         [(call, str(config)) for call, config in zip(kernel_calls, configs)],
         input_output_aliases_with_sizes,
     )
@@ -847,22 +1068,27 @@ def triton_kernel_call_lowering(
 
   call_proto = kernel_call.to_proto(kernel_call_name, serialized_metadata)
 
+  # Note: `operand_output_aliases` uses raw positional indices into the operands seen by
+  # MLIR custom_call(). Scalars in JAX-Triton are embedded into
+  # `backend_config`/`call_proto` and are not passed as MLIR operands; therefore,
+  # indices in `operand_output_aliases` count only arrays among all inputs.
+
   # TODO(phawkins): remove forward_compat after 2026-05-04
   if jax.__version_info__ < (0, 10, 1) or ctx.is_forward_compat():
     rule = jax.ffi.ffi_lowering(
         "triton_kernel_call",
         api_version=2,
         backend_config=zlib.compress(call_proto),
-        operand_output_aliases=input_output_aliases,
+        operand_output_aliases=operand_output_aliases,
     )
-    return rule(ctx, *array_args)
+    return rule(ctx, *abstract_args)
   else:
     rule = jax.ffi.ffi_lowering(
         "triton_kernel_call_ffi",
         api_version=4,
-        operand_output_aliases=input_output_aliases,
+        operand_output_aliases=operand_output_aliases,
     )
-    return rule(ctx, *array_args, opaque=zlib.compress(call_proto))
+    return rule(ctx, *abstract_args, opaque=zlib.compress(call_proto))
 
 
 mlir.register_lowering(
@@ -905,14 +1131,338 @@ batching.primitive_batchers[triton_kernel_call_p] = (
 
 
 class ShapeDtype(Protocol):
+  @property
+  def shape(self) -> tuple[int, ...]: ...
 
   @property
-  def shape(self) -> tuple[int, ...]:
-    ...
+  def dtype(self) -> np.dtype: ...
 
-  @property
-  def dtype(self) -> np.dtype:
-    ...
+
+class JTArray:
+  _default_alignment = 16
+
+  @classmethod
+  def from_avals_by_idx(cls, avals: list, idx: int):
+    """Instantiate a JTArray from a list of avals and an index into the list."""
+    return cls(avals[idx], idx)
+
+  def __init__(self, aval, idx: int):
+    self.dtype = get_type_id(aval)
+    self.index = idx  # index into a corresponding avals array.
+    # TODO(sharadmv,zhangqiaorjc): handle differently aligned pointers
+    self.data_ptr = lambda: JTArray._default_alignment
+
+
+def serialize_args_kwargs(jtfu, args, kwargs):
+  """Prepares args and kwargs for passing through JAX's primitive system by separating
+  things that must be traced from things that must be passed as-is.
+
+  Returns a sequence of traced values, a mapping of array id -> flat array index to
+  construct the operand_output_aliases mapping, and a tuple of hashable reconstruction
+  info. Assumes the caller adheres to Triton's rules about argument types, so no
+  special checks for hashability are done for performance reasons.
+  """
+  assert isinstance(jtfu, JTJITFunction), "jtfu must be a JTJITFunction object"
+  leaves, treedef = tree_util.tree_flatten((args, kwargs))
+  is_array = tuple(isinstance(v, jax.Array) for v in leaves)
+  dyn_leaves = [v for v, b in zip(leaves, is_array) if b]
+  static_leaves = tuple(to_python_type(v) for v, b in zip(leaves, is_array) if not b)
+  array_id2idx = {id(v): i for i, v in enumerate(dyn_leaves)}
+  return dyn_leaves, array_id2idx, (treedef, is_array, static_leaves)
+
+
+def deserialize_args_kwargs(ctx, abstract_args, args_kwargs_meta):
+  """Reconstructs args and kwargs from the serialized form. Abstract arguments are
+  replaced by stubs."""
+  treedef, is_array, static_leaves = args_kwargs_meta
+  abs_iter = (
+    JTArray.from_avals_by_idx(ctx.avals_in, i) for i in range(len(abstract_args))
+  )
+  static_iter = iter(static_leaves)
+  leaves = [next(abs_iter) if b else next(static_iter) for b in is_array]
+  args, kwargs = tree_util.tree_unflatten(treedef, leaves)
+  return args, kwargs, static_leaves
+
+
+ArrayId = int
+OutShapeId = int
+
+
+def _in_spec_to_ShapeDtypeStruct(
+  elm: InOutSpec,
+  args: list[Any],
+  kwargs: dict[str, Any],
+  name2idx: dict[str, int],
+  idx2name: list[str],
+  aliases: dict[ArrayId, OutShapeId],  # mutable
+  shapes: list[jax.ShapeDtypeStruct],  # mutable
+):
+  """For an `in-spec` element `elm`, traverses `args`/`kwargs` to find all arrays
+  addressed by it and updates a list of ShapeDtypeStruct objects describing those arrays
+  and a dict mapping array identifiers to ShapeDtypeStruct identifiers.
+  """
+  # This code runs on each kernel launch, so thorough validation is expensive; we skip
+  # most checks and let invalid specs fail naturally. We might check some things later.
+  orig_name = None
+  if isinstance(elm, int):
+    path = (elm,)
+  elif isinstance(elm, str):
+    orig_name = elm
+    path = (name2idx[elm],)  # user is responsible for correct indexing
+  elif isinstance(elm, (tuple, list)):
+    param_idx = elm[0]  # first element is an index into signature parameter list
+    if isinstance(param_idx, str):
+      orig_name = param_idx
+      path = (name2idx[param_idx], *elm[1:])
+    else:
+      path = elm
+  else:
+    raise ValueError(f"Invalid in_spec element: {elm}")
+  # checking if the path refers to a terminal array, or to a compound
+  param_idx = path[0]
+  if param_idx < len(args):  # must be in args by construction
+    arg = triton_runtime_jit.get_iterable_path(args, path)
+  else:  # must be in kwargs by construction
+    arg = triton_runtime_jit.get_iterable_path(
+      kwargs[idx2name[param_idx] if orig_name is None else orig_name], path[1:]
+    )
+
+  def _unpack_arg(elm: Any, shapes:list[jax.ShapeDtypeStruct]):
+    if isinstance(elm, jax.Array):
+      shape = jax.ShapeDtypeStruct(elm.shape, elm.dtype)
+      aid = id(elm)
+      if aid in aliases:
+        raise ValueError(f"Array {elm} found under path {path} can't be aliased twice")
+      aliases[aid] = id(shape)
+      shapes.append(shape)
+    else:
+      if isinstance(elm, tuple):
+        new_shapes = []
+        for e in elm:
+          _unpack_arg(e, new_shapes)
+        if new_shapes:
+          shapes.append(tuple(new_shapes))
+      # else: just ignore any other arguments
+
+  if isinstance(arg, jax.Array):
+    _unpack_arg(arg, shapes)
+  elif not isinstance(arg, tuple):
+    raise ValueError(
+      f"Aliased element {arg} at path {path} is not a jax.Array or a tuple of them"
+    )
+  else:
+    for elm in arg:
+      _unpack_arg(elm, shapes)
+
+
+def make_aliased_shapes(
+  jtfu: JTJITFunction,
+  input_output_aliases: dict[int, int] | Sequence[InOutSpec],
+  pure_out_shapes: dict[CanonicalKernelArgPath, Sequence[jax.ShapeDtypeStruct]],
+  orig_aliased_shapes: Sequence[jax.ShapeDtypeStruct],
+  args: list[Any],
+  kwargs: dict[str, Any],
+) -> tuple[tuple[jax.ShapeDtypeStruct], dict[ArrayId, OutShapeId]]:
+  """Uses `input_output_aliases` to produce a tuple of aliased shapes to append to
+  `out_shapes` for the Primitive's .bind() call, and a dict mapping input array
+  identifiers to output array identifiers. After serialization, we'll be able to
+  create `operand_output_aliases` dictionary based on raw array indices using this
+  mapping."""
+  assert isinstance(jtfu, JTJITFunction), "jtfu must be a JTJITFunction object"
+  # building aliased_shapes from in_spec
+  is_dict = isinstance(input_output_aliases, dict)
+  in_spec = list(input_output_aliases.keys()) if is_dict else input_output_aliases
+  if isinstance(in_spec, (int, str)) or (
+    isinstance(in_spec, tuple) and in_spec and not isinstance(in_spec[0], (tuple, list))
+  ):
+    in_spec = [in_spec]
+
+  name2idx = jtfu.arg_name_to_index
+  idx2name = jtfu.arg_names
+  aliases = {}
+
+  def _make_aliased(elm: Any, shapes: list[jax.ShapeDtypeStruct]) -> None:
+    inner_shapes = []
+    if isinstance(elm, list) or (
+      isinstance(elm, tuple) and isinstance(elm[0], (tuple, list))
+    ):
+      tuple(_make_aliased(e, inner_shapes) for e in elm)
+      assert len(inner_shapes) == len(elm)
+      shapes.append(tuple(inner_shapes))
+    else:
+      _in_spec_to_ShapeDtypeStruct(
+        elm, args, kwargs, name2idx, idx2name, aliases, inner_shapes
+      )
+      inner_shapes = inner_shapes[0] if len(inner_shapes) == 1 else tuple(inner_shapes)
+      shapes.append(inner_shapes)
+
+  aliased_shapes = []
+  tuple(_make_aliased(e, aliased_shapes) for e in in_spec)
+
+  # TODO: perhaps remove the whole `if is_dict:` below to spare cycles?
+  # if it's a dict, validate that out_shapes match aliased_shapes
+  if is_dict:  # and kwargs["debug"]:
+    # getting a starting index of aliased shapes in the original out_shape for reading
+    # a dict values
+    aliased_idx = len(pure_out_shapes)
+    for oidx in input_output_aliases.values():
+      oidx -= aliased_idx
+      if oidx < 0 or oidx >= len(aliased_shapes):
+        raise ValueError(f"Output index {oidx} is out of range for aliased shapes")
+      if aliased_shapes[oidx] != orig_aliased_shapes[oidx]:
+        raise ValueError(
+          f"Output shape {aliased_shapes[oidx]} at index {oidx} doesn't match to the shape "
+          f"in `out_shape[{oidx + aliased_idx}]` {orig_aliased_shapes[oidx]}"
+        )
+  return tuple(aliased_shapes), aliases
+
+
+def _split_out_values(
+  out_values: Sequence,
+  out_names: None | InOutSpec,
+  input_output_aliases: dict[int, int] | Sequence[InOutSpec],
+) -> tuple[tuple, Sequence]:
+  """Splits `out_values` into a tuple of purely output values and a tuple of aliased
+  values."""
+  # If we know `out_names`, the first len(out_names) elements in `out_values`
+  # must describe pure outputs. Else if there's a dict form of `input_output_aliases`,
+  # then len(input_output_aliases) is the number of aliased buffers/shapes. Otherwise,
+  # there are no aliased elements.
+  if out_names is not None:
+    num_purely_output = len(out_names)
+    num_aliased = len(out_values) - num_purely_output
+    if num_aliased < 0 or (
+      isinstance(input_output_aliases, dict)
+      and num_aliased != len(input_output_aliases)
+    ):
+      raise ValueError(
+        "Content of `out_shape` doesn't match to `out_names` and `input_output_aliases` specification"
+      )
+  elif isinstance(input_output_aliases, dict):
+    num_aliased = len(input_output_aliases)
+    num_purely_output = len(out_values) - num_aliased
+    if num_purely_output < 0:
+      raise ValueError(
+        "There was specified more aliased buffers than there are output arguments"
+      )
+  else:
+    num_aliased = 0
+    num_purely_output = len(out_values)
+
+  if num_aliased > 0:
+    aliased_shapes = out_values[num_purely_output:]
+    out_values = out_values[:num_purely_output]
+  else:
+    aliased_shapes = []
+  return out_values, aliased_shapes
+
+
+def canonicalize_out_shape(
+  jtfu: JTJITFunction,
+  out_shape: ShapeDtype | Sequence[ShapeDtype] | dict[InOutSpec, Sequence[ShapeDtype]],
+  out_names: None | InOutSpec,
+  args: list[Any],  # positional args passed to the launcher
+  input_output_aliases: dict[int, int] | Sequence[InOutSpec],  # original aliases
+) -> tuple[
+  dict[CanonicalKernelArgPath, Sequence[jax.ShapeDtypeStruct]],
+  Sequence[jax.ShapeDtypeStruct],
+]:
+  """Converts different forms of out_shape and out_names to a single dict mapping from
+  output kernel argument paths to shapes/dtypes of the output arguments for output-only
+  arguments (which have corresponding parameters in the kernel's signature), and a
+  sequence of shapes/dtypes of aliased arguments (which reuse input parameters and
+  therefore have no separate output parameters in the kernel's signature).
+  """
+  assert isinstance(jtfu, JTJITFunction), "jtfu must be a JTJITFunction object"
+  if isinstance(out_names, (int, str)):
+    out_names = (out_names,)
+  # a basic validation that will be elided by the JIT compiler, so it's fine
+  if out_names is not None and not isinstance(out_names, (tuple, list)):
+    raise ValueError(
+      "out_names must be None, a string, an int, or a tuple/list of specific format"
+    )
+
+  if isinstance(out_shape, dict):
+    # The dictionary form doesn't have info on aliased buffers
+    if out_names is None:
+      out_names = tuple(out_shape.keys())
+      out_values = tuple(out_shape.values())  # must materialize
+    else:
+      # TODO: remove the check to speedup things/check only lengths, or add cache?
+      if frozenset(out_names) != out_shape.keys():
+        raise ValueError("out_names and out_shape must have the same keys")
+      out_values = tuple(out_shape[name] for name in out_names)  # reorder
+
+    aliased_shapes = []
+  else:
+    if isinstance(out_shape, list):
+      out_shape = tuple(out_shape)
+    out_values = out_shape if isinstance(out_shape, tuple) else (out_shape,)
+    # out_values here might contain shapes for aliased elements, we need to split them
+    out_values, aliased_shapes = _split_out_values(
+      out_values, out_names, input_output_aliases
+    )
+    # TODO we could perhaps even drop `aliased_shapes` entirely, as we reconstruct them
+    # from the signature
+    if out_names is None:
+      # building out_names from the assumption that `args` contain all input arguments
+      arg_names = jtfu.arg_names
+      # out_values may contain compounds, hence we must consider non-flattened shapes
+      out_names = tuple(arg_names[i + len(args)] for i in range(len(out_values)))
+    if len(out_names) != len(out_values):  # this checks only top level specs
+      raise ValueError("out_shape specification mismatches out_names")
+  del out_shape  # safer to hide from scope as it's no longer needed
+
+  def _to_ShapeDtypeStruct(a: Any) -> jax.ShapeDtypeStruct:
+    return jax.ShapeDtypeStruct(a.shape, a.dtype)
+
+  if aliased_shapes:
+    aliased_shapes = tree_util.tree_map(_to_ShapeDtypeStruct, aliased_shapes)
+  out_values = tree_util.tree_map(_to_ShapeDtypeStruct, out_values)
+
+  # now canonicalizing out_names using the out_values.
+  pure_out_shapes: dict[CanonicalKernelArgPath, Sequence[jax.ShapeDtypeStruct]] = {}
+  name2idx = jtfu.arg_name_to_index
+  for i, outn in enumerate(out_names):
+    ospec = _canonicalize_out_spec_element(outn, name2idx)
+    pure_out_shapes[ospec] = out_values[i]
+  # While the ordering of pure_out_shapes here reflects the ordering of out_names, it
+  # does not mean that ordering will be used for passing arguments to the kernel or
+  # producing outputs. Two things affect that:
+  # First, `tree_util.tree_flatten()` is used to serialize compound data structures
+  # including output argument info, and JAX assumes that flattening also sorts
+  # dictionary keys (otherwise it would break the entire Primitive call caching system).
+  # Keys here are `tuple[int, ...]` where ints are kernel signature parameter indices,
+  # so they will be sorted accordingly. Using `OrderedDict()` here could bypass this,
+  # but it would not help: later we inject output arguments into `kwargs` as Triton
+  # variables, which also nullifies any imposed ordering in favor of kernel signature
+  # order. During kernel launch, we also iterate over kernel arguments in signature
+  # order. Hence, effectively, there is only one ordering: the kernel signature's.
+
+  return pure_out_shapes, aliased_shapes
+
+
+def _canonicalize_out_spec_element(
+  elm: InOutSpec,
+  name2idx: dict[str, int],
+) -> CanonicalKernelArgPath:
+  if isinstance(elm, int):
+    path = (elm,)
+  elif isinstance(elm, str):
+    path = (name2idx[elm],)  # user is responsible for correct indexing
+  elif isinstance(elm, tuple):
+    prim_idx = elm[0]
+    if isinstance(prim_idx, str):
+      path = (name2idx[prim_idx], *elm[1:])
+    else:
+      if not isinstance(prim_idx, int):
+        raise ValueError(f"Invalid first element of this out-spec: {elm}")
+      path = elm
+  else:
+    raise ValueError(f"Invalid out-spec element: {elm}")
+  # No need to go deeper. A Triton variable will be created for whatever shape the
+  # corresponding element of out_shape has.
+  return path
 
 
 def triton_call(
@@ -923,8 +1473,9 @@ def triton_call(
         | triton.runtime.Heuristics
         | triton.runtime.Autotuner
     ),
-    out_shape: ShapeDtype | Sequence[ShapeDtype],
     grid: GridOrLambda,
+    out_shape: ShapeDtype | Sequence[ShapeDtype] | dict[str, ShapeDtype] = (),
+    out_names: None | str | tuple[str, ...] = None,
     name: str = "",
     num_warps: int | None = None,
     num_stages: int | None = None,
@@ -933,11 +1484,11 @@ def triton_call(
     enable_fp_fusion: bool = True,
     input_output_aliases: dict[int, int] | None = None,
     zeroed_outputs: (
-        Sequence[int] | Callable[[dict[str, Any]], Sequence[int]]
+        Sequence[InOutSpec] | Callable[[dict[str, Any]], Sequence[InOutSpec]]
     ) = (),
     debug: bool = False,
     serialized_metadata: bytes = b"",
-    **metaparams: Any,
+    **kwargs: Any,
 ) -> Any:
   """Calls a Triton kernel with `jax.Array` arguments.
 
@@ -974,13 +1525,12 @@ def triton_call(
   import jax_triton as jt
 
   def add(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
-    out_shape = jax.ShapeDtypeStruct(shape=x.shape, dtype=x.dtype)
     block_size = 8
     return jt.triton_call(
         x,
         y,
         kernel=add_kernel,
-        out_shape=out_shape,
+        out_shape=x,
         grid=(x.size // block_size,),
         block_size=block_size)
 
@@ -990,77 +1540,283 @@ def triton_call(
   print(jax.jit(add)(x_val, y_val))
   ```
 
+  Kernel output and aliasing specification introduce necessary complexity on top of
+  Triton to interoperate with JAX. To address this, a concept of "Kernel's signature
+  coordinate system" is used — it is a hashable way to address an individual array at
+  any position in the kernel's (*args, **kwargs), regardless of nesting depth. A
+  "coordinate" refers to either a single array or all arrays nested within the addressed
+  tuple. It can be:
+    - an int: indexes a kernel signature parameter.
+    - a string: parameter name in the kernel's signature.
+    - a tuple whose first element is a string (identifies a parameter name in the
+      kernel's signature) or an int (indexes a kernel signature parameter). All other
+      elements of the tuple must be ints indexing into the compound argument
+      corresponding to the parameter at index 0.
+      For example: a tuple `("Ptrs", 0, 1)` refers to the `Ptrs` parameter of the
+      kernel, and expects the corresponding argument to be a tuple whose 0th element is
+      another tuple, and whose 1st element is an array or a tuple of arrays/tuples.
+
   Args:
-    *args: Inputs for the Triton kernel.
-    kernel: A Triton kernel (e.g. a function decorated with `triton.jit`). All
-      static values should be annotated with `triton.language.constexpr` or
-      `triton.experimental.gluon.language.constexpr`.
-    out_shape: A `jax.ShapeDtypeStruct` (or something that has `.shape` and
-      `.dtype` attributes) or a sequence thereof that specify the output(s) of
-      the kernel. Pointers for each of the `jax.ShapeDtypeStruct`s in
-      `out_shape` will be passed into `kernel` following the input parameters.
+    *args: Positional inputs for the Triton kernel. In the kernel signature, purely
+      output parameters should go after the last input parameter to be passed as
+      a positional argument to `triton_call()`.
+
+    kernel: Triton (e.g. a function decorated with `triton.jit`) or a Gluon kernel.
+      All static values should be annotated with `triton.language.constexpr` or
+      `triton.experimental.gluon.language.constexpr`. All other Triton annotations are
+      also supported.
+
+    out_shape: Description of shapes and dtypes of output parameters of the kernel.
+      Can be one of the following:
+
+      (1) a single ShapeDtype-like object (something that has `.shape` and
+      `.dtype` attributes) describing a single output parameter of the kernel; or an
+      ordered, potentially nested, sequence of ShapeDtype-like objects corresponding to
+      one or more output parameters, where each root-level element of the sequence
+      describes one kernel output parameter in its signature (the nesting defines the
+      form of the individual argument; for example, `out_shape=((a,b),c)` defines two
+      output arguments: the first is a tuple of arrays with the shapes and dtypes of
+      arrays a and b, and the second is an array with the shape and dtype of array c).
+      Ordering of elements in the sequence must correspond to the ordering of the output
+      parameters in the kernel's signature.
+
+      (2) a dictionary mapping kernel output parameter names or indices to
+      one ShapeDtype-like object or an ordered, potentially nested, sequence of such
+      objects. The nested structure of dictionary values defines the structure of the
+      output argument. For example, `out_shape={"a": (x,y), "b": z}` defines that the
+      kernel has two output parameters: the parameter named "a" is a tuple of 2 arrays
+      borrowing their shapes and dtypes from arrays x and y, and "b" is a single
+      `z`-like array.
+      If `out_names` is specified, the `out_shape` must have the same keys. Ordering
+      of the kernel signature parameters takes precedence over the ordering of the
+      dictionary keys.
+      If `input_output_aliases` is needed and a dictionary form of `out_shape` is used,
+      `input_output_aliases` must use a non-dictionary form, enumerating input arrays
+      only.
+
+      Unlike Triton itself, JAX/XLA must manage memory buffers and organize data copying
+      between host and device memory for all array parameters, so `out_shape` provides
+      the necessary information.
+      Due to the JAX custom call API, there is currently a restriction on the ordering
+      of input/output parameters in the kernel signature: all purely output parameters
+      must reside after the last non-constexpr input parameter in the flattened kernel
+      signature parameter list. Interleaving input and output parameters in the
+      signature is not supported.
+
+      If `out_shape` uses a dictionary form, or if `out_names` is provided, there are
+      no other restrictions. In other cases, all input arguments that are not
+      specialized as constexprs must be passed strictly as positional `args`. `out_names`
+      are inferred by assuming output parameters follow the positional arguments passed
+      as `args` to `triton_call()`.
+
+      Note that regardless of which form of `out_shape` is used, arguments
+      corresponding to strictly output parameters must never be passed to
+      `triton_call()` as part of `args` or `kwargs` — they are added implicitly by the
+      launcher. If an argument is intended to be an input-output argument, set
+      `input_output_aliases` accordingly.
+
+    out_names: A sequence of output parameter names.
+      Another way to specify the kernel's output parameter names. Useful in conjunction
+      with the `@kernel` decorator.
+      If `out_shape` is a dictionary, its keys must be consistent with `out_names`.
+
     grid: An integer, tuple of up to 3 integers, or a function that returns a
       tuple of up to 3 integers. When `grid` is an integer, `kernel` is
-      invocated in `grid`-many parallel executions. When `grid` is a sequence of
+      invoked in `grid`-many parallel executions. When `grid` is a sequence of
       integers, `kernel` is launched in a `prod(grid)`-many parallel execution.
-      When `grid` is a function, it is passed `**metaparams` and should return a
-      tuple of up to 3 integers.
-    input_output_aliases: A dictionary mapping input argument indices to output
-      indices. Providing a mapping will alias the corresponding buffers.
-    zeroed_outputs: A sequence of indices, or a function returning a sequence of
-      indices, for outputs that should be zeroed before the kernel is launched.
-      Note that this also supports zeroing input-output (i.e. aliased through
-      `input_output_aliases`) arguments that should be treated as outputs in this
-      argument.
+      When `grid` is a function, it is passed `kwargs` and should return a tuple of up
+      to 3 integers.
+
+    input_output_aliases: Tells XLA that it shouldn't allocate fresh output buffers for
+      these arguments, but instead alias the input buffers (requiring the backend to
+      arrange not only `host->device` data copying before kernel launch, but
+      also `device->host` data copying after kernel execution). Can take two forms:
+
+      (1 — deprecated): A dictionary mapping an input array coordinate in the kernel's
+      signature coordinate space to the `out_shape` sequence coordinate space.
+      Important note: if the kernel also has purely output arguments, they must go first
+      in the `out_shape` sequence, and aliased buffers must go last in the sequence.
+      Interleaving output with in/out argument shapes in `out_shape` is not supported.
+      The user is responsible for adhering to this requirement.
+
+      (2 — recommended): An ordered, potentially nested, sequence of input array
+      coordinates in the kernel's signature coordinate space. When this form is used,
+      there should be no corresponding output arguments in `out_shape`. Shapes and
+      dtypes are inferred from referenced input arguments automatically (JAX/XLA does
+      not support typecasting of aliased buffers anyway, so `out_shape` entries for
+      aliased buffers are always redundant). It can specifically be:
+      - a single int, a string, or a tuple having an int or a string as its first
+        element: describes an input array in the kernel's signature coordinate space.
+      - a list: ordered, possibly nested, sequence of the above. The nested structure of
+        the sequence describes the structure of the corresponding output argument,
+        containing aliased buffers as returned by `triton_call()`. For example,
+        `input_output_aliases=["out_ptr",[(2,0), "out_ptr2"]]` describes three aliased
+        (input-output) buffers: the first is an input array passed to the `out_ptr`
+        kernel parameter, the second is an array at index 0 of a tuple passed to the
+        third positional parameter, and the third is an input array passed for
+        `out_ptr2`. These three buffers (assuming all are single arrays) are returned
+        from `triton_call()` as a tuple of two elements: [0] is a new array wrapping
+        the same buffer used for the `out_ptr` kernel parameter, and [1] is a tuple of
+        two new arrays wrapping the other two buffers. If some referenced input argument
+        is not an array but a possibly nested tuple of arrays, all its internal arrays
+        are considered aliased and are returned as a flat tuple of arrays.
+        Note that tuples can also be used instead of lists, but remember that if a
+        tuple's first element is not another iterable, it is always treated as a
+        coordinate descriptor, which may not be what you want. For example,
+        `input_output_aliases=(0,1)` is always treated as a reference to an array at
+        the second position of a tuple passed to the first kernel parameter, while
+        `input_output_aliases=[0,1]` references two arrays passed to the first and
+        second kernel parameters respectively. Hence, for clarity, it is recommended to
+        use tuples only when describing a single input array coordinate.
+      Note that if a kernel needs to start working with an initially zeroed read-write
+      buffer to be returned as an output (for example, for sparse updates), you should
+      designate a purely output argument for it with a proper `out_shape` specification
+      and list its coordinate in `zeroed_outputs`.
+
+      Attention: You as a user is responsible for ensuring that all arrays listed in
+      input_output_aliases are used strictly once anywhere in *args, **kwargs (i.e.
+      for each array A in (*args, **kwargs) from input_output_aliases, id(A) is not
+      equal to ANY other id(B) of an array B from (*args, **kwargs)). Failure to adhere
+      to that rule might lead to an undefined behavior.
+
+    zeroed_outputs: A sequence of kernel signature coordinates of output arguments, or
+      a function taking a dict of metaparameters and returning a sequence of such
+      coordinates, for outputs that should be zeroed before the kernel is launched.
+
+      BREAKING: This argument does NOT support zeroing input-output (i.e. aliased
+      through `input_output_aliases`) arguments anymore, since this breaks the semantics
+      of input-output parameters: you cannot pass information from the host to the
+      kernel through the buffer, effectively turning an input-output argument into a
+      purely output argument. Note the slight terminological ambiguity here:
+      input-output arguments are named from the backend's perspective, whose job is to
+      manage memory buffers and arrange data copying between host and device memory for
+      all array parameters. A kernel can always read from what is called a purely output
+      argument, so if you need the kernel to start from a zeroed buffer, declare it as a
+      purely output argument in `out_shape` and list its coordinate in `zeroed_outputs`.
+
+      Note that a callable form of `zeroed_outputs` is allowed to modify the
+      metaparameters dict passed to it if and only if the modification does not affect
+      kernel compilation (for example, by not changing parameters that affect kernel
+      specialization), and the modification is propagated to the kernel call. If the
+      modification does affect kernel compilation, the behavior is undefined.
+
     num_warps: The number of warps used to execute the Triton kernel.
     num_stages: The number of stages emitted by the Triton compiler.
     num_ctas: The size of thread blocks per cluster to be used on GPUs with
       compute capabilities >= 9.0. It must be less or equal to 8.
-    debug: Prints out intermediate IRs if True for debugging purposes.
+    enable_fp_fusion: Whether to enable floating-point operands fusion for the kernel.
+    debug: Prints out intermediate IRs if True for debugging purposes. Also passed as a
+      backend options argument.
     serialized_metadata: Arbitrary metadata that will be added into the
       serialized kernel call.
-    metaparams: A dictionary of arguments that will be provided to a `grid`
-      (if it is a function) and to the Triton kernel as `constexpr` arguments.
+
+    kwargs: Additional keyword arguments (num_warps, num_stages, num_ctas, debug, and
+      enable_fp_fusion are added automatically) that are provided to:
+      - a `grid` (if it is a function),
+      - the backend options constructor (only recognized arguments are forwarded),
+      - the Triton kernel as `constexpr` arguments (constexprs must always be scalars)
+        or regular runtime arguments.
 
   Returns:
-    Outputs from the Triton kernel.
+    Outputs from the Triton kernel. First go all purely output arguments, then all
+    input-output arguments.
   """
-  out_shape = tree_util.tree_map(
-      lambda a: jax.ShapeDtypeStruct(a.shape, a.dtype), out_shape
-  )
-  flat_args, _ = tree_util.tree_flatten(args)
-  # TODO(sharadmv): check in_tree is flat (no Pytrees allowed in triton_call)
-  flat_out_shapes, out_tree = tree_util.tree_flatten(out_shape)
+  # TODO(Arech): improve error reporting and check for assumption violations. We make
+  # many assumptions about user behavior. Most, if not all, of these assumptions can be
+  # verified. We skip this for performance or other reasons, which hurts the user
+  # experience. Extensive validation is possible in at least two cases: (1) some kernel
+  # launch parameters don't vary much across calls because they reflect fixed kernel
+  # properties; their processing could be cached. The uncached first run could do full
+  # validation and all subsequent runs would be fast. (2) the `debug` parameter is
+  # designed precisely for this.
 
-  array_args = []
-  scalar_args = []
-  for i, arg in enumerate(flat_args):
-    if isinstance(arg, (bool, int, float)):
-      scalar_args.append((i, get_type_id(arg), arg))
-    elif isinstance(arg, np.float32):
-      scalar_args.append((i, get_type_id(arg), float(arg)))
-    else:
-      array_args.append(arg)
+  # Python guarantees these keys don't exist yet. The original Triton has a single
+  # namespace for both constexprs and backend options; we do the same to unify
+  # processing. Defaults are set early because we use these values early.
+  kwargs["num_warps"] = num_warps if num_warps is not None else 4
+  kwargs["num_stages"] = num_stages if num_stages is not None else 3
+  kwargs["num_ctas"] = num_ctas
+  kwargs["enable_fp_fusion"] = enable_fp_fusion
+  kwargs["debug"] = debug
 
   if input_output_aliases is None:
-    input_output_aliases = {}
+    input_output_aliases = []
+
+  jtfu = JTJITFunction(kernel)
+  pure_out_shapes, aliased_shapes = canonicalize_out_shape(
+    jtfu, out_shape, out_names, args, input_output_aliases
+  )
+  # The structure of `pure_out_shapes` will let us reconstruct the output variables for
+  # Triton using ctx.avals_out instead of arrays; the dict keys will let us place them
+  # correctly into args/kwargs and properly structure the returned outputs.
+
+  if input_output_aliases or input_output_aliases == 0:
+    aliased_shapes, aliases = make_aliased_shapes(
+      jtfu, input_output_aliases, pure_out_shapes, aliased_shapes, args, kwargs
+    )
+  else:  # quick shortcut
+    aliases = {}
+    if aliased_shapes:
+      raise ValueError("out_shape isn't coherent with input_output_aliases!")
+
+  # The structure of `aliased_shapes` helps return aliased arrays in the correct form;
+  # flattened values are the shapes passed to .bind(). `aliases` helps generate the
+  # properly array-only indexed `operand_output_aliases` needed for the FFI interface.
+  # We match aliased (from XLA's point of view) arrays using Python's id() function.
+  # From the point of view of constructing `operand_output_aliases`, it's a benign
+  # situation when the same input-only array is used several times as a kernel parameter
+  # (pure inputs have no role in `operand_output_aliases` and when their id()'s collapse
+  # to a single value, it's still ignored), however, we require a user to never use
+  # an `input_output_aliases`-ed array twice or more as a kernel parameter, since this
+  # is already a UB from XLA's and compiler's point of view (when two arguments refer
+  # to the same memory location, in general case, write to which argument takes
+  # precedence?).
+  abs_args_kwargs, array_id2idx, args_kwargs_meta = serialize_args_kwargs(
+    jtfu, args, kwargs
+  )
+
+  pure_out_shapes_flat, pure_out_tree = tree_util.tree_flatten(pure_out_shapes)
+  num_pure_outputs = len(pure_out_shapes_flat)
+
+  aliased_shapes_flat, aliased_tree = tree_util.tree_flatten(aliased_shapes)
+  aliased_shape_id2idx = {  # shape id -> raw output array idx
+    id(s): i + num_pure_outputs for i, s in enumerate(aliased_shapes_flat)
+  }
+  operand_output_aliases = {
+    array_id2idx[arr_id]: aliased_shape_id2idx[shp_id]
+    for arr_id, shp_id in aliases.items()
+  }
+
+  if num_pure_outputs + aliased_tree.num_leaves == 0:
+    raise ValueError(
+      "No outputs specified for the kernel, DCE will eliminate the call entirely"
+    )
 
   out_flat = triton_kernel_call_p.bind(
-      *array_args,
+      *abs_args_kwargs,
       fn=kernel,
-      scalar_args=tuple(scalar_args),
-      name=name,
-      out_shapes=tuple(flat_out_shapes),
+      kernel_call_name=name,
+      # out_shapes must be a flat sequence of shapes of ALL arrays to be returned:
+      # purely output + input-output (aliased) arrays.
+      out_shapes=(*pure_out_shapes_flat, *aliased_shapes_flat),
       grid=grid,
-      num_warps=num_warps,
-      num_stages=num_stages,
-      num_ctas=num_ctas,
       compute_capability=compute_capability,
-      enable_fp_fusion=enable_fp_fusion,
-      input_output_aliases=tuple(input_output_aliases.items()),
+      operand_output_aliases=tuple(operand_output_aliases.items()),
       zeroed_outputs=zeroed_outputs,
-      debug=debug,
       serialized_metadata=serialized_metadata,
-      metaparams=tuple(metaparams.items()),
+      args_kwargs=args_kwargs_meta,
+      out_info=(num_pure_outputs, pure_out_tree),
   )
-  return tree_util.tree_unflatten(out_tree, out_flat)
+
+  pure_outs = (
+    tree_util.tree_unflatten(pure_out_tree, out_flat[:num_pure_outputs])
+    if num_pure_outputs > 0
+    else {}
+  )
+  aliased_outs = (
+    tree_util.tree_unflatten(aliased_tree, out_flat[num_pure_outputs:])
+    if aliased_tree.num_leaves > 0
+    else ()
+  )
+  ret = tuple(pure_outs.values()) + aliased_outs
+  return ret[0] if len(ret) == 1 else ret

--- a/tests/aliasing_test.py
+++ b/tests/aliasing_test.py
@@ -1,0 +1,438 @@
+# Copyright 2026 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Additional tests for input_output_aliases= parameter of triton_call().
+"""
+
+import os
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+from jax import config, random
+import jax.numpy as jnp
+import jax_triton as jt
+import jax_triton.triton_lib as jttl
+import numpy as np
+import triton
+import triton.language as tl
+
+config.parse_flags_with_absl()
+
+
+@triton.jit
+def inc_inplace_kernel(x_in_out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+  pid = tl.program_id(axis=0)
+  block_start = pid * BLOCK_SIZE
+  offsets = block_start + tl.arange(0, BLOCK_SIZE)
+  mask = offsets < n_elements
+  x = tl.load(x_in_out_ptr + offsets, mask=mask)
+  output = x + 1
+  tl.store(x_in_out_ptr + offsets, output, mask=mask)
+
+
+class TritonCallAliasingTest(parameterized.TestCase):
+  @parameterized.parameters(False, True)
+  def test_simple(self, with_donation):
+    size = 8
+    x = random.normal(random.key(0), [size])
+    expected = x + 1
+
+    launcher = lambda x: jt.triton_call(
+      x,
+      size,
+      kernel=inc_inplace_kernel,
+      out_shape=x,
+      grid=(8,),
+      BLOCK_SIZE=1,
+      input_output_aliases={0: 0},
+    )
+
+    if with_donation:
+      launcher = jax.jit(launcher, donate_argnums=(0,))
+      x_ptr = x.unsafe_buffer_pointer()
+
+    out = launcher(x)
+
+    if with_donation:
+      np.testing.assert_(x.is_deleted())
+      np.testing.assert_equal(x_ptr, out.unsafe_buffer_pointer())
+
+    np.testing.assert_allclose(out, expected)
+
+  @parameterized.product(with_donation=[False, True], first_is_inout=[False, True])
+  def test_2outputs(self, with_donation, first_is_inout):
+    # this tests aliasing correctness in case of 4 buffer parameters two of which
+    # (0 and 2, or 1 and 3) are in-out params. When first_is_inout=True, buffers 0 and 2
+    # are incremented in place using values from buffers 1 and 3, and otherwise buffers
+    # 1 and 3 are incremented in place with values from buffers 0 and 2.
+
+    @triton.jit
+    def weird_kernel(
+      ptr0,
+      ptr1,
+      ptr2,
+      ptr3,
+      n_elements,
+      BLOCK_SIZE: tl.constexpr,
+      FIRST_INOUT: tl.constexpr,
+    ):
+      """
+      For FIRST_INOUT=True  computes *ptr0[] += *ptr1[], *ptr2[] += *ptr3[],
+      for FIRST_INOUT=False computes *ptr1[] += *ptr0[], *ptr3[] += *ptr2[]
+      """
+      pid = tl.program_id(axis=0)
+      block_start = pid * BLOCK_SIZE
+      offsets = block_start + tl.arange(0, BLOCK_SIZE)
+      mask = offsets < n_elements
+      if FIRST_INOUT:
+        io0_ptr = ptr0
+        io1_ptr = ptr2
+        i0_ptr = ptr1
+        i1_ptr = ptr3
+      else:
+        io0_ptr = ptr1
+        io1_ptr = ptr3
+        i0_ptr = ptr0
+        i1_ptr = ptr2
+
+      x0 = tl.load(io0_ptr + offsets, mask=mask)
+      y0 = tl.load(i0_ptr + offsets, mask=mask)
+      x1 = tl.load(io1_ptr + offsets, mask=mask)
+      y1 = tl.load(i1_ptr + offsets, mask=mask)
+      output0 = x0 + y0
+      output1 = x1 + y1
+      tl.store(io0_ptr + offsets, output0, mask=mask)
+      tl.store(io1_ptr + offsets, output1, mask=mask)
+
+    size = 8
+    keys = random.split(random.key(0), 4)
+    args = [random.normal(key, [size]) for key in keys]
+    expect0 = args[0] + args[1]
+    expect1 = args[2] + args[3]
+
+    inout_aliases = {0: 0, 2: 1} if first_is_inout else {1: 0, 3: 1}
+    inout_indices = tuple(inout_aliases.keys())
+    in_indices = (1, 3) if first_is_inout else (0, 2)
+
+    launcher = lambda *a: jt.triton_call(
+      *a,
+      size,
+      kernel=weird_kernel,
+      out_shape=tuple(a[io] for io in inout_indices),
+      input_output_aliases=inout_aliases,
+      grid=(8,),
+      BLOCK_SIZE=1,
+      FIRST_INOUT=first_is_inout,
+    )
+    if with_donation:
+      launcher = jax.jit(launcher, donate_argnums=inout_indices)
+      io_ptrs = tuple(args[io].unsafe_buffer_pointer() for io in inout_indices)
+
+    outs = launcher(*args)
+
+    if with_donation:
+      for io in inout_indices:
+        np.testing.assert_(args[io].is_deleted())
+      for i in in_indices:
+        np.testing.assert_(not args[i].is_deleted())
+      np.testing.assert_array_equal(
+        io_ptrs, tuple(o.unsafe_buffer_pointer() for o in outs)
+      )
+
+    np.testing.assert_allclose(outs[0], expect0)
+    np.testing.assert_allclose(outs[1], expect1)
+
+  @parameterized.parameters(0, "x_in_out_ptr")
+  def test_raw_values(self, input_output_aliases):
+    """test raw values in input_output_aliases (without a container wrapping)."""
+    size = 8
+    x = random.normal(random.key(0), [size])
+    out = jt.triton_call(
+      x,
+      size,
+      kernel=inc_inplace_kernel,
+      grid=(8,),
+      BLOCK_SIZE=1,
+      input_output_aliases=input_output_aliases,
+    )
+    np.testing.assert_array_equal(out, x + 1)
+
+  @parameterized.parameters([("Ptrs", 1)], [(0, 1)], (("Ptrs", 1),), ((0, 1),))
+  def test_tuple_coordinate_into_compound(self, alias_spec):
+    """Tuple coordinate drilling into a specific element of a compound param.
+    Tests both ("name", idx) and (int, idx) forms."""
+
+    @triton.jit
+    def _k(Ptrs, val_ptr, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      v = tl.load(val_ptr + offs)
+      x = tl.load(Ptrs[1] + offs)
+      tl.store(Ptrs[1] + offs, x + v)
+
+    a = jnp.array([10.0], dtype=jnp.float32)
+    b = jnp.array([20.0], dtype=jnp.float32)
+    val = jnp.array([5.0], dtype=jnp.float32)
+    out = jt.triton_call(
+      (a, b), val, 1, input_output_aliases=[alias_spec], kernel=_k, grid=(1,)
+    )
+    np.testing.assert_array_equal(out, jnp.array([25.0]))
+
+  def test_nested_list_structured_output(self):
+    """input_output_aliases=[0, [1, 2]] returns (flat, (nested, nested)) and
+    related tests"""
+
+    @triton.jit
+    def _k(ptr0, ptr1, ptr2, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      tl.store(ptr0 + offs, tl.load(ptr0 + offs) + 1)
+      tl.store(ptr1 + offs, tl.load(ptr1 + offs) + 2)
+      tl.store(ptr2 + offs, tl.load(ptr2 + offs) + 3)
+
+    a = jnp.array([10.0], dtype=jnp.float32)
+    b = jnp.array([20.0], dtype=jnp.float32)
+    c = jnp.array([30.0], dtype=jnp.float32)
+
+    result = jt.triton_call(
+      a, b, c, BLOCK=1, input_output_aliases=[0, [1, 2]], kernel=_k, grid=1
+    )
+    self.assertIsInstance(result, tuple)
+    self.assertEqual(len(result), 2)
+    np.testing.assert_array_equal(result[0], jnp.array([11.0]))
+    self.assertIsInstance(result[1], tuple)
+    self.assertEqual(len(result[1]), 2)
+    np.testing.assert_array_equal(result[1][0], jnp.array([22.0]))
+    np.testing.assert_array_equal(result[1][1], jnp.array([33.0]))
+
+    result = jt.triton_call(
+      a, b, c, BLOCK=1, input_output_aliases=[2, [0, 1]], kernel=_k, grid=1
+    )
+    self.assertIsInstance(result, tuple)
+    self.assertEqual(len(result), 2)
+    np.testing.assert_array_equal(result[0], jnp.array([33.0]))
+    self.assertIsInstance(result[1], tuple)
+    self.assertEqual(len(result[1]), 2)
+    np.testing.assert_array_equal(result[1][0], jnp.array([11.0]))
+    np.testing.assert_array_equal(result[1][1], jnp.array([22.0]))
+    assert jttl.JTJITFunction(_k).compiled_kernels_cache_size == 1
+
+    result = jt.triton_call(
+      a, b, c, BLOCK=1, input_output_aliases=[[1, 0], 2], kernel=_k, grid=1
+    )
+    self.assertIsInstance(result, tuple)
+    self.assertEqual(len(result), 2)
+    np.testing.assert_array_equal(result[1], jnp.array([33.0]))
+    self.assertIsInstance(result[0], tuple)
+    self.assertEqual(len(result[0]), 2)
+    np.testing.assert_array_equal(result[0][0], jnp.array([22.0]))
+    np.testing.assert_array_equal(result[0][1], jnp.array([11.0]))
+    assert jttl.JTJITFunction(_k).compiled_kernels_cache_size == 1
+
+  @parameterized.parameters(
+    "inout_ptr",
+    ["inout_ptr"],
+    ("inout_ptr",),
+    (("inout_ptr",),),
+    [("inout_ptr",)],
+    1,
+    (1,),
+    [1],
+    [(1,)],
+    ((1,),),
+  )
+  def test_mixed_pure_and_aliased_outputs(self, input_output_aliases):
+    """Pure output + aliased output in a single call.
+    Exercises the return assembly: tuple(pure_outs.values()) + aliased_outs."""
+
+    @triton.jit
+    def _k(in_ptr, inout_ptr, out_ptr, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      x = tl.load(in_ptr + offs)
+      y = tl.load(inout_ptr + offs)
+      tl.store(out_ptr + offs, x * 2)
+      tl.store(inout_ptr + offs, y + x)
+
+    x = jnp.array([5.0], dtype=jnp.float32)
+    y = jnp.array([10.0], dtype=jnp.float32)
+    pure_out, aliased_out = jt.triton_call(
+      x,
+      y,
+      BLOCK=1,
+      out_shape=x,
+      input_output_aliases=input_output_aliases,
+      kernel=_k,
+      grid=(1,),
+    )
+    np.testing.assert_array_equal(pure_out, x * 2)
+    np.testing.assert_array_equal(aliased_out, y + x)
+
+  @parameterized.parameters(
+    "inout_ptr",
+    ["inout_ptr"],
+    ("inout_ptr",),
+    (("inout_ptr",),),
+    [("inout_ptr",)],
+    1,
+    (1,),
+    [1],
+    [(1,)],
+    ((1,),),
+  )
+  def test_mixed_multiple_pure_and_aliased_outputs(self, input_output_aliases):
+    """2 pure outputs + 1 aliased output, verifying ordering."""
+
+    @triton.jit
+    def _k(in_ptr, inout_ptr, out1_ptr, out2_ptr, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      x = tl.load(in_ptr + offs)
+      y = tl.load(inout_ptr + offs)
+      tl.store(out1_ptr + offs, x * 2)
+      tl.store(out2_ptr + offs, x * 3)
+      tl.store(inout_ptr + offs, y + x)
+
+    x = jnp.array([5.0], dtype=jnp.float32)
+    y = jnp.array([10.0], dtype=jnp.float32)
+    out1, out2, aliased_out = jt.triton_call(
+      x,
+      y,
+      BLOCK=1,
+      out_shape=(x, x),
+      input_output_aliases=input_output_aliases,
+      kernel=_k,
+      grid=(1,),
+    )
+    np.testing.assert_array_equal(out1, x * 2)
+    np.testing.assert_array_equal(out2, x * 3)
+    np.testing.assert_array_equal(aliased_out, y + x)
+
+  @parameterized.product(
+    out_shape_key=["out_ptr", 2, ("out_ptr",), (2,)],
+    input_output_aliases=[
+      "inout_ptr",
+      ["inout_ptr"],
+      ("inout_ptr",),
+      (("inout_ptr",),),
+      [("inout_ptr",)],
+      1,
+      (1,),
+      [1],
+      [(1,)],
+      ((1,),),
+    ],
+  )
+  def test_with_dict_out_shape(self, out_shape_key, input_output_aliases):
+    """Dict out_shape combined with sequence-form input_output_aliases.
+    The dict provides pure output shapes; aliased shapes are inferred from inputs."""
+
+    @triton.jit
+    def _k(in_ptr, inout_ptr, out_ptr, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      x = tl.load(in_ptr + offs)
+      y = tl.load(inout_ptr + offs)
+      tl.store(out_ptr + offs, x * 2)
+      tl.store(inout_ptr + offs, y + x)
+
+    x = jnp.array([5.0], dtype=jnp.float32)
+    y = jnp.array([10.0], dtype=jnp.float32)
+    pure_out, aliased_out = jt.triton_call(
+      x,
+      y,
+      BLOCK=1,
+      out_shape={out_shape_key: x},
+      input_output_aliases=input_output_aliases,
+      kernel=_k,
+      grid=(1,),
+    )
+    np.testing.assert_array_equal(pure_out, x * 2)
+    np.testing.assert_array_equal(aliased_out, y + x)
+
+  @parameterized.parameters(
+    "inout_ptr",
+    ("inout_ptr",),
+    (("inout_ptr",),),
+    1,
+    (1,),
+    ((1,),),
+  )
+  def test_dict_form_with_pure_and_aliased_out_shape(self, aliasing_key):
+    """Deprecated dict-form aliases where out_shape carries both pure and
+    aliased shapes, split by out_names count."""
+
+    @triton.jit
+    def _k(in_ptr, inout_ptr, out_ptr, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      x = tl.load(in_ptr + offs)
+      y = tl.load(inout_ptr + offs)
+      tl.store(out_ptr + offs, x * 2)
+      tl.store(inout_ptr + offs, y + x)
+
+    x = jnp.array([5.0], dtype=jnp.float32)
+    y = jnp.array([10.0], dtype=jnp.float32)
+    pure_out, aliased_out = jt.triton_call(
+      x,
+      y,
+      out_shape=(x, y),  # the first is pure output, the second is aliased
+      BLOCK=1,
+      input_output_aliases={aliasing_key: 1},
+      kernel=_k,
+      grid=1,
+    )
+    np.testing.assert_array_equal(pure_out, x * 2)
+    np.testing.assert_array_equal(aliased_out, y + x)
+
+  def test_compound_with_mixed_dtypes(self):
+    """String aliasing a compound param whose arrays have different dtypes.
+    Verifies functools.reduce(_unpack_arg, ...) creates correct per-dtype shapes."""
+
+    @triton.jit
+    def _k(Ptrs, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      x = tl.load(Ptrs[0] + offs)
+      y = tl.load(Ptrs[1] + offs)
+      tl.store(Ptrs[0] + offs, x + 1)
+      tl.store(Ptrs[1] + offs, y + 10)
+
+    f = jnp.array([5.0], dtype=jnp.float32)
+    i = jnp.array([100], dtype=jnp.int32)
+    out = jt.triton_call((f, i), 1, input_output_aliases="Ptrs", kernel=_k, grid=(1,))
+    self.assertIsInstance(out, tuple)
+    self.assertEqual(len(out), 2)
+    np.testing.assert_array_equal(out[0], jnp.array([6.0], dtype=jnp.float32))
+    self.assertEqual(out[0].dtype, jnp.float32)
+    np.testing.assert_array_equal(out[1], jnp.array([110], dtype=jnp.int32))
+    self.assertEqual(out[1].dtype, jnp.int32)
+
+  def test_nested_aliasing(self):
+    @triton.jit
+    def _k_nested(Ptrs, BLOCK: tl.constexpr):
+      offs = tl.arange(0, BLOCK)
+      tl.store(Ptrs[0] + offs, tl.load(Ptrs[0] + offs) + 1)
+      tl.store(Ptrs[1][0] + offs, tl.load(Ptrs[1][0] + offs) + 2)
+      tl.store(Ptrs[1][1] + offs, tl.load(Ptrs[1][1] + offs) + 3)
+
+    a = jnp.array([1.0], dtype=jnp.float32)
+    b = jnp.array([2.0], dtype=jnp.float32)
+    c = jnp.array([3.0], dtype=jnp.float32)
+    out = jt.triton_call((a, (b, c)), 1, input_output_aliases="Ptrs", kernel=_k_nested, grid=(1,))
+    assert isinstance(out, tuple) and len(out) == 2
+    np.testing.assert_array_equal(out[0], jnp.array([2.0], dtype=jnp.float32))
+    assert isinstance(out[1], tuple) and len(out[1]) == 2
+    np.testing.assert_array_equal(out[1][0], jnp.array([4.0], dtype=jnp.float32))
+    np.testing.assert_array_equal(out[1][1], jnp.array([6.0], dtype=jnp.float32))
+
+
+if __name__ == "__main__":
+  os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+  absltest.main()

--- a/tests/outshape_test.py
+++ b/tests/outshape_test.py
@@ -1,0 +1,367 @@
+# Copyright 2026 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Additional tests for out_shape= parameter of triton_call().
+"""
+
+import os
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from jax import config
+import jax.numpy as jnp
+import jax_triton as jt
+import jax_triton.triton_lib as jttl
+import numpy as np
+import triton
+import triton.language as tl
+
+config.parse_flags_with_absl()
+
+
+class TritonCallOutShapeTest(parameterized.TestCase):
+  def test_single_output(self):
+    """All forms of out_shape for a single output parameter."""
+
+    @triton.jit
+    def copy_k(in_ptr, n_elements, out_ptr, BLOCK_SIZE: tl.constexpr):
+      pid = tl.program_id(axis=0)
+      offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+      mask = offs < n_elements
+      tl.store(out_ptr + offs, tl.load(in_ptr + offs, mask=mask), mask=mask)
+
+    def assert_expected(out):
+      np.testing.assert_array_equal(out, x)
+      assert jttl.JTJITFunction(copy_k).compiled_kernels_cache_size == 1
+
+    x = jnp.arange(16, dtype=jnp.float32)
+
+    for out_shape in [{"out_ptr": x}, {2: x}, x, [x], (x,)]:
+      for out_names in [["out_ptr"], ("out_ptr",), "out_ptr", 2, [2], (2,), None]:
+        if (
+          isinstance(out_shape, dict)
+          and out_names is not None
+          and frozenset(out_shape.keys())
+          != frozenset(
+            out_names if isinstance(out_names, (tuple, list)) else (out_names,)
+          )
+        ):
+          out_names = None
+        out = jt.triton_call(
+          x,
+          x.size,
+          BLOCK_SIZE=8,
+          out_shape=out_shape,
+          out_names=out_names,
+          kernel=copy_k,
+          grid=(2,),
+        )
+        assert_expected(out)
+
+  def test_multiple_outputs(self):
+    """All forms of out_shape for multiple output parameters."""
+
+    @triton.jit
+    def twin_k(in_ptr, n, out1_ptr, out2_ptr, BLOCK_SIZE: tl.constexpr):
+      pid = tl.program_id(axis=0)
+      offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+      mask = offs < n
+      x = tl.load(in_ptr + offs, mask=mask)
+      tl.store(out1_ptr + offs, x, mask=mask)
+      tl.store(out2_ptr + offs, x + 1, mask=mask)
+
+    def assert_expected(o1, o2):
+      np.testing.assert_array_equal(o1, x)
+      np.testing.assert_array_equal(o2, x + 1)
+      assert jttl.JTJITFunction(twin_k).compiled_kernels_cache_size == 1
+
+    x = jnp.arange(8, dtype=jnp.float32)
+
+    for out_shape in [
+      {"out1_ptr": x, "out2_ptr": x},
+      {"out2_ptr": x, "out1_ptr": x},
+      {2: x, "out2_ptr": x},
+      {3: x, "out1_ptr": x},
+      {"out1_ptr": x, 3: x},
+      {"out2_ptr": x, 2: x},
+      {2: x, 3: x},
+      {3: x, 2: x},
+      (x, x),
+      [x, x],
+    ]:
+      for out_names in [
+        None,
+        ("out1_ptr", "out2_ptr"),
+        ("out2_ptr", "out1_ptr"),
+        [2, 3],
+        [3, 2],
+        [2, "out2_ptr"],
+        [3, "out1_ptr"],
+        (2, 3),
+        (3, 2),
+        ("out1_ptr", 3),
+        (2, "out2_ptr"),
+      ]:
+        if (
+          isinstance(out_shape, dict)
+          and out_names is not None
+          and frozenset(out_shape.keys())
+          != frozenset(
+            out_names if isinstance(out_names, (tuple, list)) else (out_names,)
+          )
+        ):
+          out_names = None
+        o1, o2 = jt.triton_call(
+          x,
+          x.size,
+          BLOCK_SIZE=8,
+          out_shape=out_shape,
+          out_names=out_names,
+          kernel=twin_k,
+          grid=(1,),
+        )
+        assert_expected(o1, o2)
+
+  def test_different_shapes(self):
+    """Multiple outputs with different shapes via sequence form."""
+
+    @triton.jit
+    def split_k(in_ptr, out1_ptr, out2_ptr, BLOCK_SIZE: tl.constexpr):
+      pid = tl.program_id(axis=0)
+      offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+      mask8 = offs < 8
+      mask7 = offs < 7
+      tl.store(out1_ptr + offs, tl.load(in_ptr + offs, mask=mask8), mask=mask8)
+      tl.store(out2_ptr + offs, tl.load(in_ptr + 8 + offs, mask=mask7), mask=mask7)
+
+    x = jnp.arange(15, dtype=jnp.float32)
+    o1, o2 = jt.triton_call(
+      x, BLOCK_SIZE=8, out_shape=[x[:8], x[8:]], kernel=split_k, grid=(1,)
+    )
+    np.testing.assert_array_equal(o1, x[:8])
+    np.testing.assert_array_equal(o2, x[8:])
+
+  def test_different_dtypes(self):
+    """Multiple outputs with different dtypes."""
+
+    @triton.jit
+    def cast_k(in_ptr, out_f32_ptr, out_i32_ptr):
+      x = tl.load(in_ptr)
+      tl.store(out_f32_ptr, x)
+      tl.store(out_i32_ptr, x.to(tl.int32))
+
+    x = jnp.array([42.25], dtype=jnp.float32)
+    o_f, o_i = jt.triton_call(
+      x, out_shape=[x, x.astype(jnp.int32)], kernel=cast_k, grid=(1,)
+    )
+    np.testing.assert_array_equal(o_f, x)
+    self.assertEqual(o_f.dtype, jnp.float32)
+    np.testing.assert_array_equal(o_i, jnp.array([42], dtype=jnp.int32))
+    self.assertEqual(o_i.dtype, jnp.int32)
+
+  def test_dict_ordering(self):
+    """Dict out_shape + explicit out_names: ordering doesn't matter and is always
+    governed by the kernel signature."""
+
+    @triton.jit
+    def twin_k(in_ptr, out_a_ptr, out_b_ptr):
+      x = tl.load(in_ptr)
+      tl.store(out_a_ptr, x.to(tl.int32))
+      tl.store(out_b_ptr, x + 10)
+
+    x = jnp.array([5.25], dtype=jnp.float32)
+
+    def assert_expected(o1, o2):
+      np.testing.assert_array_equal(o1, x.astype(jnp.int32))
+      self.assertEqual(o1.dtype, jnp.int32)
+      np.testing.assert_array_equal(o2, x + 10)
+      self.assertEqual(o2.dtype, jnp.float32)
+      assert jttl.JTJITFunction(twin_k).compiled_kernels_cache_size == 1
+
+    for out_shape in [
+      {"out_b_ptr": x, "out_a_ptr": x.astype(jnp.int32)},
+      {"out_a_ptr": x.astype(jnp.int32), "out_b_ptr": x},
+    ]:
+      for out_names in [
+        ("out_b_ptr", "out_a_ptr"),
+        ("out_a_ptr", "out_b_ptr"),
+        None,
+      ]:
+        o1, o2 = jt.triton_call(
+          x, out_shape=out_shape, out_names=out_names, kernel=twin_k, grid=(1,)
+        )
+        assert_expected(o1, o2)
+
+  def test_compound_first(self):
+    """out_shape=((a,(b,c)),d) — first output param is a compound tuple of arrays."""
+
+    @triton.jit
+    def compound_k(in_ptr, Ptrs, single_out):
+      x = tl.load(in_ptr)
+      tl.static_assert(len(Ptrs) == 2, "Ptrs must be a tuple of 2 elements")
+      tl.store(Ptrs[0], x)
+      tl.static_assert(len(Ptrs[1]) == 2, "Ptrs[1] must be a tuple of 2 arrays")
+      tl.store(Ptrs[1][0], x.to(tl.int32) + 1)
+      tl.store(Ptrs[1][1], x.to(tl.int16) + 2)
+      tl.store(single_out, x * 2)
+
+    x = jnp.array([5.25])
+    z = jnp.zeros((1,), dtype=jnp.float32)
+
+    compound_out, scalar_out = jt.triton_call(
+      x,
+      out_shape=((z, (z.astype(jnp.int32), z.astype(jnp.int16))), z),
+      kernel=compound_k,
+      grid=(1,),
+    )
+    self.assertIsInstance(compound_out, tuple)
+    self.assertEqual(len(compound_out), 2)
+    np.testing.assert_array_equal(compound_out[0], x)
+    self.assertEqual(compound_out[0].dtype, jnp.float32)
+
+    self.assertIsInstance(compound_out[1], tuple)
+    self.assertEqual(len(compound_out[1]), 2)
+    np.testing.assert_array_equal(compound_out[1][0], (x + 1).astype(jnp.int32))
+    self.assertEqual(compound_out[1][0].dtype, jnp.int32)
+    np.testing.assert_array_equal(compound_out[1][1], (x + 2).astype(jnp.int16))
+    self.assertEqual(compound_out[1][1].dtype, jnp.int16)
+
+    np.testing.assert_array_equal(scalar_out, x * 2)
+    self.assertEqual(scalar_out.dtype, jnp.float32)
+
+  def test_compound_second(self):
+    """out_shape=(a, (b,(c,d),e)) — second output param is a compound tuple of arrays."""
+
+    @triton.jit
+    def compound_k(in_ptr, single_out, Ptrs):
+      x = tl.load(in_ptr)
+      tl.store(single_out, x * 2)
+      tl.static_assert(len(Ptrs) == 3, "Ptrs must be a tuple of 3 elements")
+      tl.static_assert(len(Ptrs[1]) == 2, "Ptrs[1] must be a tuple of 2 arrays")
+      tl.store(Ptrs[0], x)
+      tl.store(Ptrs[1][0], x.to(tl.int32) + 1)
+      tl.store(Ptrs[1][1], x.to(tl.int16) + 2)
+      tl.store(Ptrs[2], x.to(tl.int8) + 3)
+
+    x = jnp.array([5.25])
+    z = jnp.zeros((1,), dtype=jnp.float32)
+    scalar_out, compound_out = jt.triton_call(
+      x,
+      out_shape=(
+        z,
+        (z, (z.astype(jnp.int32), z.astype(jnp.int16)), z.astype(jnp.int8)),
+      ),
+      kernel=compound_k,
+      grid=(1,),
+    )
+    np.testing.assert_array_equal(scalar_out, x * 2)
+    self.assertEqual(scalar_out.dtype, jnp.float32)
+
+    self.assertIsInstance(compound_out, tuple)
+    self.assertEqual(len(compound_out), 3)
+    self.assertIsInstance(compound_out[1], tuple)
+    self.assertEqual(len(compound_out[1]), 2)
+
+    np.testing.assert_array_equal(compound_out[0], x)
+    self.assertEqual(compound_out[0].dtype, jnp.float32)
+
+    np.testing.assert_array_equal(compound_out[1][0], (x + 1).astype(jnp.int32))
+    self.assertEqual(compound_out[1][0].dtype, jnp.int32)
+    np.testing.assert_array_equal(compound_out[1][1], (x + 2).astype(jnp.int16))
+    self.assertEqual(compound_out[1][1].dtype, jnp.int16)
+
+    np.testing.assert_array_equal(compound_out[2], (x + 3).astype(jnp.int8))
+    self.assertEqual(compound_out[2].dtype, jnp.int8)
+
+  def test_dict_compound(self):
+    """Dict form: out_shape={"Ptrs": ((a,b),c), "single_out": d} — compound dict value."""
+
+    @triton.jit
+    def compound_k(in_ptr, Ptrs, single_out):
+      x = tl.load(in_ptr)
+      tl.static_assert(len(Ptrs) == 2, "Ptrs must be a tuple of 2 elements")
+      tl.static_assert(len(Ptrs[0]) == 2, "Ptrs[0] must be a tuple of 2 arrays")
+      tl.store(Ptrs[0][0], x)
+      tl.store(Ptrs[0][1], x.to(tl.int32) + 1)
+      tl.store(Ptrs[1], x.to(tl.int16) + 2)
+      tl.store(single_out, x * 2)
+
+    x = jnp.array([5.25])
+    z = jnp.zeros((1,), dtype=jnp.float32)
+
+    def assert_expected(compound_out, scalar_out):
+      self.assertIsInstance(compound_out, tuple)
+      self.assertEqual(len(compound_out), 2)
+      self.assertIsInstance(compound_out[0], tuple)
+      self.assertEqual(len(compound_out[0]), 2)
+
+      np.testing.assert_array_equal(compound_out[0][0], x)
+      self.assertEqual(compound_out[0][0].dtype, jnp.float32)
+      np.testing.assert_array_equal(compound_out[0][1], (x + 1).astype(jnp.int32))
+      self.assertEqual(compound_out[0][1].dtype, jnp.int32)
+
+      np.testing.assert_array_equal(compound_out[1], (x + 2).astype(jnp.int16))
+      self.assertEqual(compound_out[1].dtype, jnp.int16)
+
+      np.testing.assert_array_equal(scalar_out, x * 2)
+      self.assertEqual(scalar_out.dtype, jnp.float32)
+
+      assert jttl.JTJITFunction(compound_k).compiled_kernels_cache_size == 1
+
+    compound_out, scalar_out = jt.triton_call(
+      x,
+      out_shape={
+        "Ptrs": ((z, z.astype(jnp.int32)), z.astype(jnp.int16)),
+        "single_out": z,
+      },
+      kernel=compound_k,
+      grid=(1,),
+    )
+    assert_expected(compound_out, scalar_out)
+
+    # Reversed dict key ordering — result must be identical (kernel signature order wins)
+    compound_out2, scalar_out2 = jt.triton_call(
+      x,
+      out_shape={
+        "single_out": z,
+        "Ptrs": ((z, z.astype(jnp.int32)), z.astype(jnp.int16)),
+      },
+      kernel=compound_k,
+      grid=(1,),
+    )
+    assert_expected(compound_out2, scalar_out2)
+
+  def test_integer_interleaved(self):
+    """Integer out_names for output params interleaved with a kwarg-only scalar input."""
+
+    @triton.jit
+    def interleaved_k(in_ptr, out1_ptr, scale, out2_ptr):
+      x = tl.load(in_ptr)
+      tl.store(out1_ptr, x)
+      tl.store(out2_ptr, x * scale)
+
+    x = jnp.array([5.25])
+    z = jnp.zeros((1,), dtype=jnp.float32)
+
+    o1, o2 = jt.triton_call(
+      x, out_shape=[z, z], out_names=(1, 3), scale=3.0, kernel=interleaved_k, grid=(1,)
+    )
+    np.testing.assert_array_equal(o1, x)
+    np.testing.assert_array_equal(o2, x * 3)
+
+
+if __name__ == "__main__":
+  os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+  absltest.main()

--- a/tests/triton_call_test.py
+++ b/tests/triton_call_test.py
@@ -12,20 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+"""
+Main tests for triton_call()
+"""
+
 from unittest import mock
 
-from absl.testing import absltest
 from absl.testing import parameterized
+from copy import deepcopy
 import jax
-from jax import config
-from jax import random
+from jax import config, random, tree_util
 import jax.numpy as jnp
 import jax_triton as jt
 import jax_triton.triton_lib as jttl
 import numpy as np
 import triton
 import triton.language as tl
+import types
 
 config.parse_flags_with_absl()
 
@@ -36,6 +39,115 @@ def setUpModule():
 
 def tearDownModule():
   config.update("jax_enable_x64", False)
+
+
+class ArgsKwargsTest(parameterized.TestCase):
+  def test_serialize_deserialize(self):
+    """Test that serialize_args_kwargs() and deserialize_args_kwargs() are inverses of
+    each other, with correct handling of argument ordering."""
+    args = [
+      1,
+      3.14,
+      jnp.array([1, 2, 3], dtype=jnp.int8),
+      (3, 4),
+      "string",
+      (jnp.array([5, 6], dtype=jnp.int16),),
+      (9, jnp.array([7, 8], dtype=jnp.int32), jnp.array([70, 80], dtype=jnp.float32)),
+      (10, (jnp.array([7, 8], dtype=jnp.int64), 11)),
+    ]
+    kwargs = {  # keys aren't in the order of declaration in the signature
+      "b": 3.14,
+      "g": (
+        9,
+        jnp.array([7, 8], dtype=jnp.uint32),
+        jnp.array([70, 80], dtype=jnp.float16),
+      ),
+      "h": (10, (jnp.array([7, 8], dtype=jnp.uint64), 11)),
+      "a": 1,
+      "e": "string",
+      "c": jnp.array([1, 2, 3], dtype=jnp.uint8),
+      "d": (3, 4),
+      "f": (jnp.array([5, 6], dtype=jnp.uint16),),
+    }
+
+    # kwargs are expected to be sorted
+    @triton.jit
+    def kernel(int_, fl, a1, t1, st, t2, t3, t4, *, a, b, c, d, e, f, g, h):
+      pass
+
+    class FakeAvals:
+      def __init__(self):
+        # Extracting only arrays from the args sequence in kernel signature order.
+        # This ensures that during serialization/deserialization, arrays are in
+        # signature order, so no reshuffling is needed to call the kernel.
+        self.flat = [
+          v
+          for v in tree_util.tree_flatten((
+            args,
+            {k: kwargs[k] for k in sorted(kwargs.keys())},  # restore signature order
+          ))[0]
+          if isinstance(v, jax.Array)
+        ]
+
+        # check the core test assumption that types in args are unique and get_type_id()
+        # is a bijection.
+        unique_types = frozenset(jttl.get_type_id(v) for v in self.flat)
+        assert len(unique_types) == len(self.flat), (
+          "Duplicate types in the args sequence"
+        )
+
+      def __getitem__(self, i):
+        return self.flat[i]
+
+      def __len__(self):
+        return len(self.flat)
+
+    def _make_expected_array_id2idx(args, kwargs):
+      array_id2idx = {}
+      for coll in [args, kwargs]:
+        flat, _ = tree_util.tree_flatten(coll)
+        arrays = [v for v in flat if isinstance(v, jax.Array)]
+        l = len(array_id2idx)
+        array_id2idx.update({id(v): idx + l for idx, v in enumerate(arrays)})
+      return array_id2idx
+
+    kwargs_copy = deepcopy(kwargs)
+    expected_array_id2idx = _make_expected_array_id2idx(args, kwargs_copy)
+
+    abs_args_kwargs, array_id2idx, args_kwargs_meta = jttl.serialize_args_kwargs(
+      jttl.JTJITFunction(kernel),
+      args,
+      kwargs_copy,
+      # kwargs could be modified, hence must copy
+    )
+
+    assert array_id2idx == expected_array_id2idx
+
+    ctx = types.SimpleNamespace(avals_in=FakeAvals())
+    dargs, dkwargs, _ = jttl.deserialize_args_kwargs(
+      ctx, [*abs_args_kwargs], args_kwargs_meta
+    )
+
+    def assert_correct(a, b):
+      if isinstance(a, jax.Array):
+        assert jttl.get_type_id(a) == b.dtype
+        # can't test actual values here, they were abstracted away
+      elif isinstance(a, tuple):
+        assert isinstance(b, tuple)
+        assert len(a) == len(b)
+        for ai, bi in zip(a, b):
+          assert_correct(ai, bi)
+      else:
+        assert isinstance(a, type(b))
+        assert a == b
+
+    assert len(args) == len(dargs)
+    for ai in range(len(args)):
+      assert_correct(args[ai], dargs[ai])
+
+    assert len(kwargs) == len(dkwargs)
+    for k in kwargs.keys():
+      assert_correct(kwargs[k], dkwargs[k])
 
 
 @triton.jit
@@ -51,7 +163,9 @@ def add_kernel(x_ptr, y_ptr, n_elements, output_ptr, BLOCK_SIZE: tl.constexpr):
 
 
 @triton.jit
-def add_inplace_kernel(x_ptr, y_ptr, n_elements, BLOCK_SIZE: tl.constexpr, INPLACE_Y: tl.constexpr):
+def add_inplace_kernel(
+  x_ptr, y_ptr, n_elements, BLOCK_SIZE: tl.constexpr, INPLACE_Y: tl.constexpr
+):
   pid = tl.program_id(axis=0)
   block_start = pid * BLOCK_SIZE
   offsets = block_start + tl.arange(0, BLOCK_SIZE)
@@ -75,46 +189,35 @@ def add(x, y, *, kernel=add_kernel, **kwargs):
 
   default_grid = lambda meta: triton.cdiv(x.size, meta["BLOCK_SIZE"])
   return jt.triton_call(
-      x,
-      y,
-      x.size,
-      kernel=kernel,
-      out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype),
-      grid=kwargs.pop("grid", default_grid),
-      **kwargs,
+    x,
+    y,
+    x.size,
+    kernel=kernel,
+    out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype),
+    grid=kwargs.pop("grid", default_grid),
+    **kwargs,
   )
 
 
 @triton.jit
-def inc_inplace_kernel(x_in_out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
-  pid = tl.program_id(axis=0)
-  block_start = pid * BLOCK_SIZE
-  offsets = block_start + tl.arange(0, BLOCK_SIZE)
-  mask = offsets < n_elements
-  x = tl.load(x_in_out_ptr + offsets, mask=mask)
-  output = x + 1
-  tl.store(x_in_out_ptr + offsets, output, mask=mask)
-
-
-@triton.jit
 def matmul_kernel(
-    a_ptr,
-    b_ptr,
-    M,
-    N,
-    K,
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
-    stride_cm,
-    stride_cn,
-    c_ptr,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-    K_EXACTLY_DIVISIBLE_BY_BLOCK: tl.constexpr,
+  a_ptr,
+  b_ptr,
+  M,
+  N,
+  K,
+  stride_am,
+  stride_ak,
+  stride_bk,
+  stride_bn,
+  stride_cm,
+  stride_cn,
+  c_ptr,
+  BLOCK_SIZE_M: tl.constexpr,
+  BLOCK_SIZE_N: tl.constexpr,
+  BLOCK_SIZE_K: tl.constexpr,
+  GROUP_SIZE_M: tl.constexpr,
+  K_EXACTLY_DIVISIBLE_BY_BLOCK: tl.constexpr,
 ):
   pid = tl.program_id(axis=0)
   num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
@@ -161,22 +264,22 @@ def matmul(x, y, *, kernel=matmul_kernel, **kwargs):
     return cdiv(m, meta["BLOCK_SIZE_M"]) * cdiv(n, meta["BLOCK_SIZE_N"])
 
   return jt.triton_call(
-      x,
-      y,
-      m,
-      n,
-      k,
-      k,  # stride_am
-      1,  # stride_ak
-      n,  # stride_bk
-      1,  # stride_bn
-      n,  # stride_cm
-      1,  # stride_cn
-      kernel=kernel,
-      out_shape=jax.ShapeDtypeStruct((m, n), dtype=x.dtype),
-      grid=grid,
-      GROUP_SIZE_M=8,
-      **kwargs,
+    x,
+    y,
+    m,
+    n,
+    k,
+    k,  # stride_am
+    1,  # stride_ak
+    n,  # stride_bk
+    1,  # stride_bn
+    n,  # stride_cm
+    1,  # stride_cn
+    kernel=kernel,
+    out_shape=jax.ShapeDtypeStruct((m, n), dtype=x.dtype),
+    grid=grid,
+    GROUP_SIZE_M=8,
+    **kwargs,
   )
 
 
@@ -194,12 +297,14 @@ def create_random_inputs(shape1, shape2=None, *, dtype="float32"):
   return x, y
 
 
-class TritonKernelCallTest(parameterized.TestCase):
+GLOBAL_DEFAULT_ARG = 1
 
+
+class TritonKernelCallTest(parameterized.TestCase):
   @parameterized.product(
-      size=[1, 5, 100, 1024],
-      dtype=["int32", "float32", "float16", "int64", "float64"],
-      block_size=[1, 32, 256],
+    size=[1, 5, 100, 1024],
+    dtype=["int32", "float32", "float16", "int64", "float64"],
+    block_size=[1, 32, 256],
   )
   def test_add(self, size, dtype, block_size):
     x, y = create_random_inputs([size], dtype=dtype)
@@ -208,43 +313,43 @@ class TritonKernelCallTest(parameterized.TestCase):
     np.testing.assert_allclose(out, expected)
 
   @parameterized.product(
-      m=[512, 1024],
-      k=[512],
-      n=[512],
-      dtype=["float32", "float16"],
-      block_size_m=[64, 128],
-      block_size_n=[128, 256],
-      block_size_k=[32],
+    m=[512, 1024],
+    k=[512],
+    n=[512],
+    dtype=["float32", "float16"],
+    block_size_m=[64, 128],
+    block_size_n=[128, 256],
+    block_size_k=[32],
   )
   def test_matmul(
-      self,
-      m,
-      n,
-      k,
-      dtype,
-      block_size_m,
-      block_size_n,
-      block_size_k,
+    self,
+    m,
+    n,
+    k,
+    dtype,
+    block_size_m,
+    block_size_n,
+    block_size_k,
   ):
     if jt.get_compute_capability(0) < 70:
       self.skipTest("Matmul only works on GPUs with capability >= sm70")
 
     x, y = create_random_inputs([m, k], [k, n], dtype=dtype)
     out = matmul(
-        x,
-        y,
-        BLOCK_SIZE_M=block_size_m,
-        BLOCK_SIZE_N=block_size_n,
-        BLOCK_SIZE_K=block_size_k,
-        K_EXACTLY_DIVISIBLE_BY_BLOCK=k % block_size_k == 0,
+      x,
+      y,
+      BLOCK_SIZE_M=block_size_m,
+      BLOCK_SIZE_N=block_size_n,
+      BLOCK_SIZE_K=block_size_k,
+      K_EXACTLY_DIVISIBLE_BY_BLOCK=k % block_size_k == 0,
     )
     expected = jnp.matmul(x, y)
     np.testing.assert_allclose(out, expected, atol=0.05, rtol=0.05)
 
   @parameterized.product(
-      size=[1, 5, 100, 1024],
-      dtype=["int32", "float32", "float16", "int64", "float64"],
-      block_size=[1, 32, 256],
+    size=[1, 5, 100, 1024],
+    dtype=["int32", "float32", "float16", "int64", "float64"],
+    block_size=[1, 32, 256],
   )
   def test_pmap(self, size, dtype, block_size):
     n_devices = jax.local_device_count()
@@ -281,17 +386,135 @@ class TritonKernelCallTest(parameterized.TestCase):
     def add_scalar_kernel(x_ptr, y, output_ptr):
       tl.store(output_ptr, tl.load(x_ptr) + y)
 
-    def add_scalar(x, y):
+    x = jnp.array([1.0])
+    np.testing.assert_allclose(
+      jt.triton_call(x, scalar, out_shape=x, kernel=add_scalar_kernel, grid=1),
+      x + scalar,
+    )
+
+  @parameterized.product(
+    mul=[None, 1, 1.0, 3.14],
+    ofs=[None, 1, 1.0, 2.71],
+    numel=[1, 5, 257],
+    block_size=[1, 32],
+  )
+  def test_scalar_ordering_1None(self, mul, ofs, numel, block_size):
+    """Test that the order of passing scalars doesn't matter, and that special values
+    of 1 and None for runtime arguments are handled correctly.
+    Since most kernels in tests follow the `inputs first, then scalars` scheme, this
+    test only checks the reverse order."""
+
+    @triton.jit
+    def affine_kernel(mul, ofs, in_ptr, in_numel, out_ptr, BLOCK_SIZE: tl.constexpr):
+      pid = tl.program_id(0)
+      start = pid * BLOCK_SIZE
+      end = min(start + BLOCK_SIZE, in_numel)
+      for i in range(start, end):
+        x = tl.load(in_ptr + i)
+        if mul is not None:
+          x *= mul
+        if ofs is not None:
+          x += ofs
+        tl.store(out_ptr + i, x)
+
+    def affine(mul, ofs, x, BLOCK_SIZE):
       return jt.triton_call(
-          x,
-          y,
-          kernel=add_scalar_kernel,
-          out_shape=jax.ShapeDtypeStruct((), x.dtype),
-          grid=1,
+        mul,
+        ofs,
+        x,
+        x.size,
+        kernel=affine_kernel,
+        out_shape=x,
+        grid=(triton.cdiv(x.size, BLOCK_SIZE),),
+        BLOCK_SIZE=BLOCK_SIZE,
       )
 
+    x = jnp.arange(numel, dtype=jnp.float32)
+    y = affine(mul, ofs, x, block_size)
+    expected = x
+    if mul is not None:
+      expected *= mul
+    if ofs is not None:
+      expected += ofs
+    np.testing.assert_allclose(y, expected, rtol=2e-07)
+
+  def test_function_arguments(self):
+    # mostly taken from Triton with necessary changes and a test without tl.constexpr
+    @triton.jit
+    def func1():
+      return 1
+
+    @triton.jit
+    def func2():
+      return 2
+
+    @triton.jit
+    def func3(x):
+      return x
+
+    @triton.jit
+    def func4(x, y):
+      return x + y
+
+    @triton.jit  # callables are explicitly constexpr
+    def kernel(fn_args, Y, fn: tl.constexpr):
+      tl.store(Y, fn(*fn_args))
+
+    @triton.jit  # callables aren't annotated (made constexpr automatically)
+    def kernel2(fn_args, Y, fn):
+      tl.store(Y, fn(*fn_args))
+
+    def launch_kernel(fn, fn_args, kernel=kernel):
+      return jt.triton_call(
+        fn_args,
+        fn=fn,
+        kernel=kernel,
+        out_shape=jax.ShapeDtypeStruct((), jnp.int32),
+        grid=1,
+      )
+
+    rets = [None] * 5
+    k1 = jttl.JTJITFunction(kernel)
+    self.assertEqual(k1.compiled_kernels_cache_size, 0)
+    rets[0] = launch_kernel(func1, tuple())
+    rets[1] = launch_kernel(func2, tuple())
+    rets[2] = launch_kernel(func3, (3,))
+    rets[3] = launch_kernel(func4, (3, 4))
+    rets[4] = launch_kernel(func1, tuple())
+    self.assertEqual(k1.compiled_kernels_cache_size, 4)
+    np.testing.assert_array_equal(rets, [1, 2, 3, 7, 1])
+
+    rets = [None] * 5
+    k2 = jttl.JTJITFunction(kernel2)
+    self.assertEqual(k2.compiled_kernels_cache_size, 0)
+    rets[0] = launch_kernel(func1, tuple(), kernel=kernel2)
+    rets[1] = launch_kernel(func2, tuple(), kernel=kernel2)
+    rets[2] = launch_kernel(func3, (3,), kernel=kernel2)
+    rets[3] = launch_kernel(func4, (3, 4), kernel=kernel2)
+    rets[4] = launch_kernel(func1, tuple(), kernel=kernel2)
+    self.assertEqual(k2.compiled_kernels_cache_size, 4)
+    np.testing.assert_array_equal(rets, [1, 2, 3, 7, 1])
+
+  def test_explicit_constexpr_argument(self):
+    @triton.jit
+    def add_scalar_kernel(x_ptr, y, output_ptr):
+      tl.store(output_ptr, tl.load(x_ptr) + y)
+
+    jt_cache_size = lambda: jttl.JTJITFunction(add_scalar_kernel).compiled_kernels_cache_size
+    self.assertEqual(jt_cache_size(), 0)
+
     x = jnp.array([1.0])
-    np.testing.assert_allclose(add_scalar(x, scalar), x + scalar)
+    call = lambda y: jt.triton_call(x, y, kernel=add_scalar_kernel, out_shape=x, grid=1)
+
+    np.testing.assert_allclose(call(4.0), x + 4)
+    self.assertEqual(jt_cache_size(), 1)
+    np.testing.assert_allclose(call(4.0), x + 4)
+    self.assertEqual(jt_cache_size(), 1)
+
+    np.testing.assert_allclose(call(tl.constexpr(4.0)), x + 4)
+    self.assertEqual(jt_cache_size(), 2)
+    np.testing.assert_allclose(call(tl.constexpr(4.0)), x + 4)
+    self.assertEqual(jt_cache_size(), 2)
 
   def test_explicit_compute_capability(self):
     scalar = np.float32(8)
@@ -300,159 +523,69 @@ class TritonKernelCallTest(parameterized.TestCase):
     def add_scalar_kernel(x_ptr, y, output_ptr):
       tl.store(output_ptr, tl.load(x_ptr) + y)
 
-    def add_scalar(x, y):
-      return jt.triton_call(
-          x,
-          y,
-          kernel=add_scalar_kernel,
-          compute_capability=jt.get_compute_capability(0),
-          out_shape=jax.ShapeDtypeStruct((), x.dtype),
-          grid=1,
-      )
-
     x = jnp.array([1.0])
-    np.testing.assert_allclose(add_scalar(x, scalar), x + scalar)
-
-  @parameterized.parameters(False, True)
-  def test_input_output_aliasing_simple(self, with_donation):
-    size = 8
-    x = random.normal(random.PRNGKey(0), [size])
-    expected = x + 1
-
-    launcher = lambda x: jt.triton_call(
-      x,
-      size,
-      kernel=inc_inplace_kernel,
-      out_shape=x,
-      grid=(8,),
-      BLOCK_SIZE=1,
-      input_output_aliases={0: 0},
+    np.testing.assert_allclose(
+      jt.triton_call(
+        x,
+        scalar,
+        kernel=add_scalar_kernel,
+        out_shape=x,
+        grid=1,
+        compute_capability=jt.get_compute_capability(0),
+      ),
+      x + scalar,
     )
 
-    if with_donation:
-      launcher = jax.jit(launcher, donate_argnums=(0,))
-      x_ptr = x.unsafe_buffer_pointer()
-
-    out = launcher(x)
-
-    if with_donation:
-      np.testing.assert_(x.is_deleted())
-      np.testing.assert_equal(x_ptr, out.unsafe_buffer_pointer())
-
-    np.testing.assert_allclose(out, expected)
-
-  @parameterized.product(with_donation=[False, True], first_is_inout=[False, True])
-  def test_input_output_aliasing_2outputs(self, with_donation, first_is_inout):
-    # this tests aliasing correctness in case of 4 buffer parameters two of which
-    # (0 and 2, or 1 and 3) are in-out params. When first_is_inout=True, buffers 0 and 2
-    # are incremented in place using values from buffers 1 and 3, and otherwise buffers
-    # 1 and 3 are incremented in place with values from buffers 0 and 2.
+  def test_single_namespace_for_constexprs_and_backend_options(self):
+    """Checks that metaparams of triton_call() are passed to the kernel and to backend
+    options. Validates that non-hashable backend options work too."""
 
     @triton.jit
-    def weird_kernel(
-      ptr0,
-      ptr1,
-      ptr2,
-      ptr3,
-      n_elements,
-      BLOCK_SIZE: tl.constexpr,
-      FIRST_INOUT: tl.constexpr,
-    ):
-      """For FIRST_INOUT=True  computes *ptr0[] += *ptr1[], *ptr2[] += *ptr3[],
-      for FIRST_INOUT=False computes *ptr1[] += *ptr0[], *ptr3[] += *ptr2[]"""
-      pid = tl.program_id(axis=0)
-      block_start = pid * BLOCK_SIZE
-      offsets = block_start + tl.arange(0, BLOCK_SIZE)
-      mask = offsets < n_elements
-      if FIRST_INOUT:
-        io0_ptr = ptr0
-        io1_ptr = ptr2
-        i0_ptr = ptr1
-        i1_ptr = ptr3
-      else:
-        io0_ptr = ptr1
-        io1_ptr = ptr3
-        i0_ptr = ptr0
-        i1_ptr = ptr2
+    def kernel(in_ptr, out_ptr, num_warps: tl.constexpr):
+      tl.store(out_ptr, tl.load(in_ptr) * num_warps)
 
-      x0 = tl.load(io0_ptr + offsets, mask=mask)
-      y0 = tl.load(i0_ptr + offsets, mask=mask)
-      x1 = tl.load(io1_ptr + offsets, mask=mask)
-      y1 = tl.load(i1_ptr + offsets, mask=mask)
-      output0 = x0 + y0
-      output1 = x1 + y1
-      tl.store(io0_ptr + offsets, output0, mask=mask)
-      tl.store(io1_ptr + offsets, output1, mask=mask)
+    extern_libs = {"some wild lib": "/path/not/exists/trust_me"}
 
-    size = 8
-    keys = random.split(random.key(0), 4)
-    args = [random.normal(key, [size]) for key in keys]
-    expect0 = args[0] + args[1]
-    expect1 = args[2] + args[3]
-
-    inout_aliases = {0: 0, 2: 1} if first_is_inout else {1: 0, 3: 1}
-    inout_indices = tuple(inout_aliases.keys())
-    in_indices = (1, 3) if first_is_inout else (0, 2)
-
-    launcher = lambda *a: jt.triton_call(
-      *a,
-      size,
-      kernel=weird_kernel,
-      out_shape=tuple(a[io] for io in inout_indices),
-      input_output_aliases=inout_aliases,
-      grid=(8,),
-      BLOCK_SIZE=1,
-      FIRST_INOUT=first_is_inout,
-    )
-    if with_donation:
-      launcher = jax.jit(launcher, donate_argnums=inout_indices)
-      io_ptrs = tuple(args[io].unsafe_buffer_pointer() for io in inout_indices)
-
-    outs = launcher(*args)
-
-    if with_donation:
-      for io in inout_indices:
-        np.testing.assert_(args[io].is_deleted())
-      for i in in_indices:
-        np.testing.assert_(not args[i].is_deleted())
-      np.testing.assert_array_equal(
-        io_ptrs, tuple(o.unsafe_buffer_pointer() for o in outs)
+    def call_kernel(x, mul):
+      return jt.triton_call(
+        x,
+        kernel=kernel,
+        out_shape=x,
+        grid=1,
+        num_warps=mul,
+        extern_libs=extern_libs,
       )
 
-    np.testing.assert_allclose(outs[0], expect0)
-    np.testing.assert_allclose(outs[1], expect1)
+    import triton.backends.nvidia.compiler as cb
+    import triton.backends.amd.compiler as hb
 
-  @parameterized.parameters(False, True)
-  def test_zeroed_outputs(self, use_function):
-    x, y = create_random_inputs([1000000])
-    # We alias `y` with the output, so are performing the add in-place.
-    # If we zero the output before the kernel, the result is `x + 0`.
-    out = add(
-        x,
-        y,
-        input_output_aliases={1: 0},
-        kernel=add_inplace_kernel,
-        INPLACE_Y=True,
-        zeroed_outputs=(lambda _: (0,)) if use_function else (0,),
-    )
-    np.testing.assert_allclose(out, x)
+    # now we need the platform ID, and I didn't find a better way than this ugliness
+    backends = jax.extend.backend.backends()
+    default = jax.extend.backend.get_backend()
+    name = next((n for n, c in backends.items() if c is default))
+    # getting relevant backend options object for hooking its initialization method
+    OptionsObj = {"cuda": cb.CUDAOptions, "rocm": hb.HIPOptions}[name]
 
-  def test_multiple_outputs(self):
-    @triton.jit
-    def copy_twice_kernel(a_ptr, x_ptr, y_ptr):
-      a = tl.load(a_ptr)
-      tl.store(x_ptr, a)
-      tl.store(y_ptr, a)
+    orig_opts_init = OptionsObj.__post_init__
 
-    a = jnp.array([42])
-    x, y = jt.triton_call(
-        a,
-        kernel=copy_twice_kernel,
-        out_shape=[a, a],
-        grid=(1,),
-    )
-    np.testing.assert_array_equal(a, x)
-    np.testing.assert_array_equal(a, y)
+    my_num_warps = 1
+
+    def my_opts_init(self):
+      assert self.num_warps == my_num_warps
+      assert self.extern_libs == extern_libs
+      # cleaning it up to prevent unexpected effects of error handling
+      object.__setattr__(self, "extern_libs", None)
+      orig_opts_init(self)
+
+    x = jnp.array([2.5])
+
+    with mock.patch.object(OptionsObj, "__post_init__", new=my_opts_init):
+      my_num_warps = 1
+      np.testing.assert_allclose(call_kernel(x, my_num_warps), x * my_num_warps)
+      my_num_warps = 2
+      np.testing.assert_allclose(call_kernel(x, my_num_warps), x * my_num_warps)
+      my_num_warps = 4
+      np.testing.assert_allclose(call_kernel(x, my_num_warps), x * my_num_warps)
 
   def test_kernel_cache_equivalent_kernels(self):
     # Create unique JITFunction to avoid conflicts with other tests.
@@ -495,14 +628,12 @@ class TritonKernelCallTest(parameterized.TestCase):
       pid = tl.program_id(axis=0)
       tl.store(output_ptr + pid, tl.load(x_ptr + pid) + tl.load(y_ptr + pid))
 
-    def silly_add(n):
-      x, y = create_random_inputs([n])
-      return jt.triton_call(
+    def silly_add(n, dtype="float32"):
+      x, y = create_random_inputs([n], dtype=dtype)
+      return (
+        jt.triton_call(x, y, out_shape=x, kernel=silly_add_kernel, grid=x.size),
         x,
         y,
-        kernel=silly_add_kernel,
-        out_shape=x,
-        grid=x.size,
       )
 
     jt_kernel = jttl.JTJITFunction(silly_add_kernel)
@@ -522,25 +653,33 @@ class TritonKernelCallTest(parameterized.TestCase):
       "get_or_create_triton_kernel",
       new=my_get_or_create_triton_kernel,
     ):
-      _ = silly_add(42)
+      ret, x, y = silly_add(42)
+      np.testing.assert_array_equal(ret, x + y)
       self.assertEqual(call_count[0], 1)
       self.assertEqual(jt_cache_size(), 1)
 
-      _ = silly_add(42)
+      ret, x, y = silly_add(42)
+      np.testing.assert_array_equal(ret, x + y)
       self.assertEqual(call_count[0], 1)  # Second call hits the Primitive cache.
-      self.assertEqual(jt_cache_size(), 1)
+      self.assertEqual(jt_cache_size(), 1)  # and the lowering doesn't even run
 
-      _ = silly_add(43)
-      # Third call differs in grid size and misses the Primitive cache, but hits
-      # the internal kernel cache.
+      ret, x, y = silly_add(43)
+      np.testing.assert_array_equal(ret, x + y)
+      # Third call differs in grid size and misses the Primitive's cache, but hits
+      # the internal kernel cache
       self.assertEqual(call_count[0], 2)
       self.assertEqual(jt_cache_size(), 1)
 
+      ret, x, y = silly_add(42, "int32")
+      np.testing.assert_array_equal(ret, x + y)
+      self.assertEqual(call_count[0], 3)  # Misses both caches due to a different dtype
+      self.assertEqual(jt_cache_size(), 2)
+
   def test_autotune(self):
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
-        triton.Config({"BLOCK_SIZE": 64}, num_warps=1),
-        triton.Config({"BLOCK_SIZE": 64}, num_warps=2),
+      triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 64}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 64}, num_warps=2),
     ]
     kernel = triton.autotune(autotune_configs, key=("n_elements",))(add_kernel)
 
@@ -551,8 +690,8 @@ class TritonKernelCallTest(parameterized.TestCase):
 
   def test_regression_issue_128(self):
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE": 1024}, num_warps=1),
-        triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 1024}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
     ]
     kernel = triton.autotune(autotune_configs, key=("n_elements",))(add_kernel)
 
@@ -567,7 +706,7 @@ class TritonKernelCallTest(parameterized.TestCase):
 
   def test_autotune_pre_hook_error(self):
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE": 32}, num_warps=1, pre_hook=lambda _: None),
+      triton.Config({"BLOCK_SIZE": 32}, num_warps=1, pre_hook=lambda _: None),
     ]
     kernel = triton.autotune(autotune_configs, key=("n_elements",))(add_kernel)
 
@@ -588,12 +727,12 @@ class TritonKernelCallTest(parameterized.TestCase):
     def do_matmul(m, n, k):
       x, y = create_random_inputs([m, k], [k, n])
       return matmul(
-          x,
-          y,
-          kernel=kernel,
-          BLOCK_SIZE_M=32,
-          BLOCK_SIZE_N=32,
-          BLOCK_SIZE_K=32,
+        x,
+        y,
+        kernel=kernel,
+        BLOCK_SIZE_M=32,
+        BLOCK_SIZE_N=32,
+        BLOCK_SIZE_K=32,
       )
 
     _ = do_matmul(m=128, n=128, k=128)
@@ -609,21 +748,21 @@ class TritonKernelCallTest(parameterized.TestCase):
 
     heuristics = {"K_EXACTLY_DIVISIBLE_BY_BLOCK": heuristic_fn}
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE_K": 32}, num_warps=1),
-        triton.Config({"BLOCK_SIZE_K": 64}, num_warps=1),
+      triton.Config({"BLOCK_SIZE_K": 32}, num_warps=1),
+      triton.Config({"BLOCK_SIZE_K": 64}, num_warps=1),
     ]
     kernel = triton.autotune(autotune_configs, key=("M", "N", "K"))(
-        triton.heuristics(heuristics)(matmul_kernel)
+      triton.heuristics(heuristics)(matmul_kernel)
     )
 
     def do_matmul(m, n, k):
       x, y = create_random_inputs([m, k], [k, n])
       return matmul(
-          x,
-          y,
-          kernel=kernel,
-          BLOCK_SIZE_M=32,
-          BLOCK_SIZE_N=32,
+        x,
+        y,
+        kernel=kernel,
+        BLOCK_SIZE_M=32,
+        BLOCK_SIZE_N=32,
       )
 
     _ = do_matmul(m=128, n=128, k=128)
@@ -637,17 +776,17 @@ class TritonKernelCallTest(parameterized.TestCase):
     heuristics = {"K_EXACTLY_DIVISIBLE_BY_BLOCK": heuristic_fn}
     autotune_config = triton.Config({"BLOCK_SIZE_K": 32}, num_warps=1)
     kernel = triton.autotune([autotune_config], key=("M", "N", "K"))(
-        triton.heuristics(heuristics)(matmul_kernel)
+      triton.heuristics(heuristics)(matmul_kernel)
     )
 
     def do_matmul(m, n, k):
       x, y = create_random_inputs([m, k], [k, n])
       return matmul(
-          x,
-          y,
-          kernel=kernel,
-          BLOCK_SIZE_M=32,
-          BLOCK_SIZE_N=32,
+        x,
+        y,
+        kernel=kernel,
+        BLOCK_SIZE_M=32,
+        BLOCK_SIZE_N=32,
       )
 
     _ = do_matmul(m=128, n=128, k=128)
@@ -655,8 +794,8 @@ class TritonKernelCallTest(parameterized.TestCase):
 
   def test_autotune_with_input_output_aliasing(self):
     autotune_configs = [
-        triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
-        triton.Config({"BLOCK_SIZE": 64}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 32}, num_warps=1),
+      triton.Config({"BLOCK_SIZE": 64}, num_warps=1),
     ]
     kernel = triton.autotune(autotune_configs, key=("n_elements",))(add_inplace_kernel)
 
@@ -668,22 +807,17 @@ class TritonKernelCallTest(parameterized.TestCase):
   def test_autodiff_exception(self):
     x, y = create_random_inputs([10, 100], dtype="float32")
     with self.assertRaisesRegex(
-        NotImplementedError,
-        r"jax_triton.triton_call does not support automatic differentiation.*"
-        r"jax\.custom_jvp or jax\.custom_vjp.*",
+      NotImplementedError,
+      r"jax_triton.triton_call does not support automatic differentiation.*"
+      r"jax\.custom_jvp or jax\.custom_vjp.*",
     ):
       jax.grad(lambda x, y: jnp.sum(add(x, y, BLOCK_SIZE=32)))(x, y)
 
   def test_batching_exception(self):
     x, y = create_random_inputs([10, 100], dtype="float32")
     with self.assertRaisesRegex(
-        NotImplementedError,
-        r"jax_triton.triton_call does not support batching.*"
-        r"jax\.custom_batching\.custom_vmap.*",
+      NotImplementedError,
+      r"jax_triton.triton_call does not support batching.*"
+      r"jax\.custom_batching\.custom_vmap.*",
     ):
       jax.vmap(lambda x, y: add(x, y, BLOCK_SIZE=32))(x, y)
-
-
-if __name__ == "__main__":
-  os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
-  absltest.main()

--- a/tests/tuple_test.py
+++ b/tests/tuple_test.py
@@ -1,0 +1,295 @@
+# Copyright 2026 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Additional tests for tuple passing and returning.
+"""
+
+import os
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+from jax import config, random
+import jax.numpy as jnp
+import jax_triton as jt
+import numpy as np
+import triton
+import triton.language as tl
+from typing import NamedTuple
+
+config.parse_flags_with_absl()
+
+
+def jax_strides(x):
+  assert isinstance(x, jax.Array) and x.ndim == 2
+  return (x.shape[1], 1)
+
+
+# many tests here are inspired by the original Triton's test suite
+
+
+class TupleTest(parameterized.TestCase):
+  @parameterized.parameters(1, 2, 3, 4)
+  # the original test also tested size=0, however, this leads to an invocation of the
+  # kernel with no outputs, which triggers JAX's DCE. DCE could be disabled for a
+  # kernel call if needed, but the utility of that isn't exactly clear, so until
+  # clarified, size=0 is excluded.
+  def test_index(self, size):
+    @triton.jit
+    def _tuple_increment(values):
+      return tl.tuple([v + 1 for v in values])
+
+    @triton.jit
+    def _tuple_index_func(Ptrs, values):
+      for i in tl.static_range(len(values)):
+        tl.store(Ptrs[i], values[i])
+
+    @triton.jit
+    def _tuple_index(_0, _1: tl.constexpr, values, _2, _3: tl.constexpr, _4, Ptrs):
+      values = _tuple_increment(values)
+      _tuple_index_func(Ptrs, values)
+
+    vals = tuple(i + 1 for i in range(size))
+    rets = tuple(jnp.zeros((1,), dtype=jnp.float32) for _ in vals)
+    rets = jt.triton_call(
+      0, 0, vals, 0, 0, 0, out_shape=[rets], kernel=_tuple_index, grid=(1,)
+    )
+    assert vals == tuple(x - 1 for x in rets)
+
+  def test_assign(self):
+    @triton.jit
+    def _tuple_assign(XPtrs, YPtrs, values):
+      # assign from tuple
+      X0, X1 = XPtrs
+      x0, x1, _ = values
+      tl.store(X0, x0)
+      tl.store(X1, x1)
+      # assign to tuple
+      Y0, Y1, Y2 = YPtrs
+      Y = Y0, Y1, Y2
+      y = x0, 10, x1
+      tl.store(Y[0], y[0])
+      tl.store(Y[1], y[1])
+      tl.store(Y[2], y[2])
+
+    vals = (2.0, 3.0, None)
+    x = tuple(jnp.zeros((1,), dtype=jnp.float32) for _ in range(2))
+    y = tuple(jnp.zeros((1,), dtype=jnp.float32) for _ in range(3))
+    x, y = jt.triton_call(
+      x,
+      y,
+      vals,
+      input_output_aliases=["XPtrs", "YPtrs"],
+      kernel=_tuple_assign,
+      grid=(1,),
+    )
+    assert x[0] == vals[0]
+    assert x[1] == vals[1]
+    assert y[0] == vals[0]
+    assert y[1] == 10
+    assert y[2] == vals[1]
+
+  def test_assign_return(self):
+    @triton.jit
+    def _tuple_ret(a, b):
+      return a + b, a - b, a * b
+
+    @triton.jit
+    def with_fn(X, Y, A, B, C):
+      x = tl.load(X)
+      y = tl.load(Y)
+      a, b, c = _tuple_ret(x, y)
+      tl.store(A, a)
+      tl.store(B, b)
+      tl.store(C, c)
+
+    @triton.jit
+    def without_fn(X, Y, A, B, C):
+      x = tl.load(X)
+      y = tl.load(Y)
+      a, b, c = x + y, x - y, x * y
+      tl.store(A, a)
+      tl.store(B, b)
+      tl.store(C, c)
+
+    x = jnp.array([1.3], dtype=jnp.float32)
+    y = jnp.array([1.9], dtype=jnp.float32)
+    for kernel in [with_fn, without_fn]:
+      a_tri, b_tri, c_tri = jt.triton_call(
+        x, y, num_warps=1, out_shape=(x, x, x), kernel=kernel, grid=(1,)
+      )
+      a_ref, b_ref, c_ref = x + y, x - y, x * y
+      assert a_tri == a_ref
+      assert b_tri == b_ref
+      assert c_tri == c_ref
+
+  def test_serialize(self):
+    @triton.jit
+    def _tuple_fn0(Ptr, cst2: tl.constexpr, tuple1):
+      tl.static_assert(tuple1[1] is None)
+      tl.store(Ptr + 5, cst2)
+      tl.store(Ptr + 6, tuple1[0])
+      tl.store(Ptr + 7, tl.load(tuple1[2][0]))
+      tl.store(Ptr + 8, tuple1[2][1][0])
+      tl.store(Ptr + 9, tl.load(tuple1[2][1][2]))
+
+    @triton.jit
+    def _tuple_serialize(N1, tuple1, cst1: tl.constexpr, val1, tuple2, Ptr):
+      tl.static_assert(N1 is None)
+      tl.static_assert(tuple1[1][1] is None)
+      tl.static_assert(tuple1[1][3] == 4)
+      tl.store(Ptr + 0, tl.load(tuple1[0]))
+      tl.store(Ptr + 1, tuple1[1][0])
+      tl.store(Ptr + 2, tl.load(tuple1[1][2]))
+      tl.store(Ptr + 3, cst1 + val1)
+      tl.store(Ptr + 4, tl.load(tuple2[0]))
+      _tuple_fn0(Ptr, 15, (-1, None, tuple1))
+
+    x0 = jnp.array([8], dtype=jnp.int32)
+    x1 = jnp.array([12], dtype=jnp.int32)
+    y0 = jnp.array([10], dtype=jnp.int32)
+
+    z = jt.triton_call(
+      None,
+      (x0, (1, None, x1, tl.constexpr(4))),
+      20,
+      1,
+      (y0,),
+      out_shape=jnp.empty((10,), dtype=jnp.int32),
+      kernel=_tuple_serialize,
+      grid=(1,),
+    )
+    ref = jnp.array([8, 1, 12, 21, 10, 15, -1, 8, 1, 12], dtype=jnp.int32)
+    np.testing.assert_array_equal(z, ref)
+
+  def test_namedtuple(self):
+    class Function(NamedTuple):
+      fn: tl.constexpr
+      captured: tuple
+
+    class Tensor(NamedTuple):
+      ptr: any
+      shape: tuple
+      stride: tuple
+
+    @triton.jit
+    def _namedtuple_create_func0(shape, ptr, stride):
+      return Tensor(shape=shape, ptr=ptr, stride=stride)
+
+    @triton.jit
+    def _namedtuple_create_func1(shape, ptr, stride):
+      tensor = Tensor(shape=shape, ptr=ptr, stride=stride)
+      return tensor
+
+    @triton.jit
+    def _namedtuple_mask_func(Tensor, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+      offs_m = tl.arange(0, BLOCK_M)
+      offs_n = tl.arange(0, BLOCK_N)
+      mask = (offs_m[:, None] < Tensor.shape[0]) & (offs_n[None, :] < Tensor.shape[1])
+      return mask
+
+    @triton.jit
+    def _namedtuple_kernel(
+      closure, _X, Y, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr
+    ):
+      offs_m = tl.arange(0, BLOCK_M)
+      offs_n = tl.arange(0, BLOCK_N)
+      X = _namedtuple_create_func0(_X.shape, _X.ptr, _X.stride)
+      Y = _namedtuple_create_func1(Y.shape, Y.ptr, Y.stride)
+      Xs = X.ptr + offs_m[:, None] * X.stride[0] + offs_n[None, :] * X.stride[1]
+      Ys = Y.ptr + offs_m[:, None] * Y.stride[0] + offs_n[None, :] * Y.stride[1]
+      x = tl.load(Xs, mask=_namedtuple_mask_func(X, BLOCK_M, BLOCK_N), other=0)
+      y = closure.fn(x, *closure.captured)
+      tl.store(Ys, y, mask=_namedtuple_mask_func(Y, BLOCK_M, BLOCK_N))
+
+    x = random.normal(random.key(0), (32, 32), dtype=jnp.float32)
+    y = jnp.empty((16, 16), dtype=jnp.float32)
+    a = jnp.array([5.2], dtype=jnp.float32)
+
+    @triton.jit
+    def mul(x, a):
+      return x * tl.load(a)
+
+    function = Function(mul, (a,))
+    tx = Tensor(x, x.shape, jax_strides(x))
+    ty = Tensor(y, y.shape, jax_strides(y))
+    y = jt.triton_call(
+      function,
+      tx,
+      ty,
+      64,
+      64,
+      input_output_aliases="Y",
+      kernel=_namedtuple_kernel,
+      grid=(1,),
+    )
+    # while aliased argument `ty` is a tuple, it has only a single internal array, so
+    # it gets unwrapped from the tuple.
+    np.testing.assert_allclose(y, x[:16, :16] * a)
+
+  def test_passing_nested_tuple_with_constexpr(self):
+    @triton.jit
+    def _nested_tuple_kernel(x, out_ptr):
+      # This creates a new scope, which will force a copy of liveins. It's
+      # important for this to happen as it forces IR flattening/unflattening,
+      # which relies on the types being correct for the roundtrip to succeed.
+      for _ in range(1):
+        tl.static_assert(x[1][0] == 2)
+        tl.static_assert(len(x[2]) == 0)  # to tests JT specific empty tuple passing
+
+    jt.triton_call(  # out_shape is needed to prevent DCE
+      ((1,), (tl.constexpr(2),), tuple()),
+      out_shape=jnp.zeros(1),
+      kernel=_nested_tuple_kernel,
+      grid=(1,),
+    )
+
+  def test_passing_tuple_to_make_tensor_descriptor(self):
+    @triton.jit
+    def m_to_the_n(X_base, shape, strides, m_n, BLOCK_DIM: tl.constexpr):
+      tl.static_assert(isinstance(strides[1].type, tl.constexpr_type))
+      X = tl.make_tensor_descriptor(
+        X_base,
+        shape=shape,
+        strides=strides,
+        block_shape=[BLOCK_DIM, BLOCK_DIM],
+      )
+      # Make sure tl.make_tensor_descriptor didn't modify strides (i.e. didn't unwrap the constexpr)
+      tl.static_assert(isinstance(strides[1].type, tl.constexpr_type))
+      data = X.load([0, 0])
+      # Include a for loop to ensure strides[1] is lifted into a constexpr
+      # (otherwise cloning the local scope will fail).
+      for i in tl.range(0, m_n[1]):
+        data = m_n[0] * data
+      X.store([0, 0], data)
+
+    x = jnp.arange(0, 16).reshape(4, 4)
+    expected_x = 8 * x.copy()
+    x = jt.triton_call(
+      x,
+      x.shape,
+      jax_strides(x),
+      (2, 3),
+      x.shape[0],
+      input_output_aliases="X_base",
+      kernel=m_to_the_n,
+      grid=(1,),
+    )
+    np.testing.assert_array_equal(x, expected_x)
+
+
+if __name__ == "__main__":
+  os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+  absltest.main()


### PR DESCRIPTION
Rewrite triton_call() lowering on top of Triton's own argument binder
(triton.runtime.jit.create_function_from_signature) and native
specialization, removing the hand-rolled specialization/alignment/scalar
plumbing in JTJITFunction.get_or_create_triton_kernel and the
flat-args-only path in triton_call().

Generalize the public API:

* Kernel signature "coordinate paths" (int, str, or tuple-with-leading
  int/str) are introduced as a uniform way to address arrays at any
  position within (*args, **kwargs), including arrays nested inside
  tuple-typed kernel parameters.
* triton_call() now accepts arbitrary **kwargs, forwards them either to
  the kernel as constexpr/runtime arguments or to the backend options
  parser (unknown keys for the active backend raise), and serializes the
  full (args, kwargs) pytree through the primitive via
  serialize_args_kwargs/deserialize_args_kwargs. A new JTArray stub
  represents abstract arrays during lowering.
* out_shape gains a dict form (mapping parameter name/index ->
  ShapeDtype, possibly nested) and an out_names parameter, in addition
  to the existing single/sequence forms. Output buffers are injected
  into kwargs by the launcher rather than appended to the positional
  argument list, and the docstring documents the constraint that purely
  output parameters must follow the last non-constexpr input parameter.
* input_output_aliases gains a sequence form that references input
  coordinates directly and infers shapes/dtypes from them; the previous
  dict form remains supported but is marked deprecated. operand/output
  aliasing is now computed from array identities after serialization
  (operand_output_aliases primitive parameter replaces the old
  input_output_aliases).
* zeroed_outputs now takes coordinate specs (int/str/tuple, or a
  callable returning them) and resolves them through the kernel
  arguments. BREAKING: it no longer accepts indices of input-output
  (aliased) buffers; such buffers must be expressed as purely output
  arguments to be zeroed.
* Kernel cache key construction is delegated to
  triton.runtime.jit.compute_cache_key, augmented with
  compute_capability. Compiled TTIR can optionally be retained per
  cache entry via a new _store_asm kwarg / JTJITFunction.asm property
  for test inspection.

Type handling in get_type_id is simplified: it dispatches on
hasattr(obj, "dtype") for arrays and returns Python-level type ids
("fp32", "i32", ...) for scalars, matching what Triton's binder and
JAX's create_scalar_parameter expect (with a note that Triton's runtime
specialization treats all floats as fp32).

Add tests covering the new behavior:

* tests/outshape_test.py - all forms of out_shape (single, sequence,
  nested, dict) and out_names.
* tests/aliasing_test.py - additional input_output_aliases scenarios
  including the new sequence form and donation interactions.
* tests/tuple_test.py - passing tuple-typed parameters and returning
  nested outputs.

tests/triton_call_test.py and tests/triton_test.py are updated to the
new API (notably the changed zeroed_outputs semantics and the
out_shape/aliasing forms).