### PR TITLE
Pass triton's global scratch buffer size through to kernel launch

### DIFF
--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -228,6 +228,8 @@ class CompilationResult:
   shared_mem_bytes: int
   ttgir: str | None
   llir: str | None
+  global_scratch_size: int = 0
+  global_scratch_align: int = 1
 
 
 def compile_ttir_inplace(
@@ -295,6 +297,10 @@ def compile_ttir_to_ptx_inplace(
         f"TMEM size {metadata['tmem_size']} exceeds limit {_TMEM_MAX_SIZE}."
     )
   shared_mem_bytes = metadata["shared"]
+  # Per-CTA global scratch memory the compiled kernel expects as an implicit
+  # trailing argument (e.g. for on-device construction of TMA descriptors).
+  global_scratch_size = metadata.get("global_scratch_size", 0)
+  global_scratch_align = metadata.get("global_scratch_align", 1) or 1
   if cuda_options.debug:
     print(llir)
   ptx = cuda_backend.make_ptx(
@@ -314,6 +320,8 @@ def compile_ttir_to_ptx_inplace(
       shared_mem_bytes=shared_mem_bytes,
       ttgir=ttgir,
       llir=llir,
+      global_scratch_size=global_scratch_size,
+      global_scratch_align=global_scratch_align,
   )
 
 
@@ -613,6 +621,8 @@ class JTJITFunction:
         compilation_result.binary,
         ttir,
         compute_capability,
+        compilation_result.global_scratch_size,
+        compilation_result.global_scratch_align,
       )
 
       self.fn._jT_kernel_cache[cache_key] = kernel

--- a/tests/gluon_test.py
+++ b/tests/gluon_test.py
@@ -27,6 +27,7 @@ import triton
 
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
+from triton.experimental.gluon.language.nvidia import blackwell as gl_blackwell
 
 
 config.parse_flags_with_absl()
@@ -83,6 +84,33 @@ def memcpy_inplace_output_kernel(in_ptr, out_ptr, xnumel, XBLOCK: gl.constexpr):
   for i in range(start, end):
     value = gl.load(in_ptr + i)
     gl.store(out_ptr + i, value)
+
+
+@gluon.jit
+def tma_copy_kernel(in_ptr, out_ptr, M: gl.constexpr, N: gl.constexpr):
+  # Copies a single (M, N) tile from in_ptr to out_ptr entirely via TMA:
+  # an async load into shared memory, gated on an mbarrier, followed by an
+  # async store back out to global memory.
+  layout: gl.constexpr = gl.NVMMASharedLayout.get_default_for([M, N], gl.float32)
+
+  in_desc = gl_blackwell.tma.make_tensor_descriptor(
+    in_ptr, shape=[M, N], strides=[N, 1], block_shape=[M, N], layout=layout,
+  )
+  out_desc = gl_blackwell.tma.make_tensor_descriptor(
+    out_ptr, shape=[M, N], strides=[N, 1], block_shape=[M, N], layout=layout,
+  )
+
+  smem = gl.allocate_shared_memory(gl.float32, [M, N], layout)
+  bar = gl_blackwell.mbarrier.allocate_mbarrier()
+  gl_blackwell.mbarrier.init(bar, count=1)
+
+  gl_blackwell.mbarrier.expect(bar, bytes_per_cta=in_desc.nbytes_per_cta)
+  gl_blackwell.tma.async_copy_global_to_shared(in_desc, [0, 0], bar, smem)
+  gl_blackwell.mbarrier.wait(bar, phase=0)
+  gl_blackwell.mbarrier.invalidate(bar)
+
+  gl_blackwell.tma.async_copy_shared_to_global(out_desc, [0, 0], smem)
+  gl_blackwell.tma.store_wait(0)
 
 
 # autotuner example isn't ported as Triton's autotuner depends on torch internally
@@ -192,6 +220,39 @@ class GluonTest(parameterized.TestCase):
     np.testing.assert_(output.is_deleted())
     np.testing.assert_equal(output_ptr, result.unsafe_buffer_pointer())
     np.testing.assert_array_equal(result, input)
+
+  @parameterized.product(shape=[(32, 32), (8, 64), (16, 128)])
+  def test_tma_copy(self, shape):
+    """Round-trips an (M, N) tile through shared memory using TMA load/store.
+
+    TODO: Add Hopper tests as well, the current test is only for Blackwell.
+    Requires a Blackwell-or-newer GPU (TMA hardware) and on-device construction
+    of tensor descriptors, which in turn needs a jaxlib new enough to
+    allocate the scratch buffer Triton's compiler implicitly appends as a
+    kernel argument (see jaxlib/gpu/triton_kernels.cc, KernelCall::Launch).
+    """
+    if jax.devices()[0].platform != "gpu":
+      self.skipTest("TMA requires an NVIDIA GPU.")
+    compute_capability = jt.get_compute_capability(0)
+    if compute_capability < 100:
+      self.skipTest("TMA requires Blackwell (sm_100) or newer.")
+
+    M, N = shape
+    dtype = jnp.float32
+
+    def tma_copy(input):
+      return jt.triton_call(
+        input,
+        kernel=tma_copy_kernel,
+        out_shape=jax.ShapeDtypeStruct(shape=input.shape, dtype=input.dtype),
+        grid=1,
+        M=M,
+        N=N,
+      )
+
+    input = random.uniform(random.key(0), (M, N), dtype=dtype)
+    output = tma_copy(input)
+    np.testing.assert_array_equal(output, input)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
jaxlib currently passes a null pointer for Triton's global scratch buffer, which breaks any kernel that constructs a TMA tensor descriptor on-device — see jax-ml/jax#38912 for the actual fix on that side.

This threads `global_scratch_size`/`global_scratch_align` from Triton's own compile metadata through to the `TritonKernel` construction, and adds a Gluon test that does a TMA round-trip copy through shared memory to exercise the path. The new args default to 0/1 so this is a no-op until the jaxlib PR above lands — the new test won't actually pass until then.
